### PR TITLE
Add agentskills-skilllint plugin with skilllint CLI guide skill

### DIFF
--- a/.claude/plan/agentskills-skilllint/SUMMARY.md
+++ b/.claude/plan/agentskills-skilllint/SUMMARY.md
@@ -1,0 +1,32 @@
+# Plugin Complete: agentskills-skilllint
+Date: 2026-03-13
+
+## Status: Marketplace-Ready
+
+## Files Created
+
+```
+plugins/agentskills-skilllint/
+├── .claude-plugin/
+│   └── plugin.json
+├── skills/
+│   └── skilllint/
+│       ├── SKILL.md
+│       └── references/
+│           └── rule-catalog.md
+├── mission.json
+└── README.md
+```
+
+## Validation Results
+- Layer 1 (skilllint): EXIT 0, 2/2 PASSED, 0 errors
+- Layer 2 (claude plugin validate): EXIT 0, Validation passed
+- Layer 3 (SK006/SK007): None present
+- Layer 4 (cross-references): rule-catalog.md link resolves
+
+## Key Decisions
+- No `context: fork` — skill runs inline with Bash tool calls
+- No `allowed-tools` — inherits parent tools
+- `argument-hint: "[rule-id | path]"` — $ARGUMENTS branches behaviour
+- `skilllint rule <id>` does NOT exist as a CLI subcommand; skill uses `--verbose` + inline catalog
+- references/rule-catalog.md provides progressive disclosure for 40+ rules

--- a/.claude/plan/agentskills-skilllint/design-PLAN.md
+++ b/.claude/plan/agentskills-skilllint/design-PLAN.md
@@ -1,0 +1,39 @@
+# Design Plan: agentskills-skilllint
+Date: 2026-03-13
+
+## Plugin Goal
+A single-skill Claude Code plugin (`agentskills:skilllint`) that guides AI agents
+through using the `skilllint` CLI to validate, fix, and understand linting
+violations in Claude Code plugins, skills, agents, and commands.
+
+## Architecture Decisions
+- **No `context: fork`** — skill runs inline, needs conversation history and Bash calls
+- **No `allowed-tools`** — inherits parent tools (Bash needed to run CLI commands)
+- **No `disable-model-invocation`** — both user (/skilllint) and model can invoke
+- **`argument-hint: "[rule-id | path]"`** — skill branches on $ARGUMENTS
+- **`references/rule-catalog.md`** — progressive disclosure for 25+ rules (avoids SK006)
+- **`skilllint rule <id>` does NOT exist** — use `--verbose` + inline catalog instead
+- **Dynamic context injection** — only for version availability check at activation
+
+## Files to Create
+
+<task id="1" name="Create plugin.json">
+  <file>plugins/agentskills-skilllint/.claude-plugin/plugin.json</file>
+  <description>Plugin manifest with name, version, description, author, keywords</description>
+  <verify>test -f plugins/agentskills-skilllint/.claude-plugin/plugin.json && python3 -c "import json; json.load(open('plugins/agentskills-skilllint/.claude-plugin/plugin.json'))"</verify>
+  <done>File exists with valid JSON containing name="agentskills-skilllint"</done>
+</task>
+
+<task id="2" name="Create SKILL.md">
+  <file>plugins/agentskills-skilllint/skills/skilllint/SKILL.md</file>
+  <description>Main skill file with argument routing, install guide, workflow, version checking</description>
+  <verify>test -f plugins/agentskills-skilllint/skills/skilllint/SKILL.md</verify>
+  <done>SKILL.md exists with valid YAML frontmatter (name, description, argument-hint) and workflow content</done>
+</task>
+
+<task id="3" name="Create rule catalog">
+  <file>plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md</file>
+  <description>Full rule catalog: FM, SK, AS, LK, PD, PL, PR, HK, NR, SL, TC series with severity and auto-fix flags</description>
+  <verify>test -f plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md</verify>
+  <done>File exists with all rule series documented</done>
+</task>

--- a/.claude/plan/agentskills-skilllint/discuss-CONTEXT.md
+++ b/.claude/plan/agentskills-skilllint/discuss-CONTEXT.md
@@ -1,0 +1,30 @@
+# Plugin Discussion: agentskills-skilllint
+Date: 2026-03-13
+
+## Scope Decisions
+- Skill takes arguments: YES — rule IDs or paths can be passed as arguments
+- Primary purpose: Guide Claude agents through using the skilllint CLI to lint Claude Code plugins/skills/agents
+- Secondary purposes: Explain how to fix specific rule violations, check for new versions, install the tool
+
+## UX Preferences
+- Invocation: user-invoked (slash command `/skilllint`) AND model-invoked (when linting topics come up)
+- Verbosity: balanced — show commands, explain what they do, give examples
+- Argument support: YES — `skilllint <rule-id>` should explain a specific rule; no args = full guide
+
+## Technical Choices
+- Component: 1 skill with argument support (no agents or hooks needed)
+- Installation section covers: uv, pipx, pip
+- Version checking: cover `uv tool upgrade skilllint`, `pipx upgrade skilllint`, `pip install --upgrade skilllint`
+- The `skilllint rule <rule-id>` pattern: document how to look up rule explanations in the CLI
+- Fix workflow: scan → identify rule IDs → `skilllint rule <id>` for explanation → `skilllint --fix` for auto-fixable issues
+- Rule categories to cover: FM-series (frontmatter), SK-series (skill structure/tokens), AS-series (agentskills standard)
+- Progressive disclosure: inline rule reference in the skill; separate references/ file for full rule catalog
+- Plugin structure: single skill, no agents, no hooks
+- Plugin location: plugins/agentskills-skilllint/
+
+## User Requirements (from invocation)
+- Skill takes arguments
+- Guide through skilllint CLI usage
+- Show how to address linting issues using `skilllint rule <rule id>`
+- Show how to check for new versions
+- Show usage with uv, pipx, pip

--- a/.claude/plan/agentskills-skilllint/research-1-existing.md
+++ b/.claude/plan/agentskills-skilllint/research-1-existing.md
@@ -133,7 +133,7 @@ This is the exact gap the `agentskills-skilllint` plugin is intended to fill per
 
 2. **No existing rule catalog** -- The plan calls for a `references/` file with the full rule catalog. This content needs to be authored (or generated from `skilllint rule --list` output).
 
-3. **No argument-driven skill examples in project** -- The `mmap-processor` skill does not use arguments. The planned skill needs `argument-hint` frontmatter and `` substitution for rule ID lookups. Vendor plugins (e.g., `plugin-dev` skills) provide reference patterns for this.
+3. **No argument-driven skill examples in project** -- The `mmap-processor` skill does not use arguments. The planned skill needs `argument-hint` frontmatter and `$ARGUMENTS` substitution for rule ID lookups. Vendor plugins (e.g., `plugin-dev` skills) provide reference patterns for this.
 
 ### What Already Exists and Can Be Leveraged
 

--- a/.claude/plan/agentskills-skilllint/research-1-existing.md
+++ b/.claude/plan/agentskills-skilllint/research-1-existing.md
@@ -1,0 +1,155 @@
+# Research: Existing Plugin/Skill Structures in agentskills-linter
+
+Date: 2026-03-13
+
+## 1. Plugin/Skill Directories That Exist in the Repo
+
+### Project-Level Skills (`.claude/skills/`)
+
+One skill exists:
+
+- **`.claude/skills/mmap-processor/SKILL.md`** -- Enforces memory-mapped file I/O for large file processing in Python. Standard skill format with frontmatter (`name`, `description`) and markdown body. No references/ subdirectory. Approximately 50 lines.
+
+### Project-Level Agents (`.claude/agents/`)
+
+13 agents exist, all at the project root `.claude/agents/` level:
+
+- `schema-drift-auditor.md` -- Reads `.drift-pending.json`, cross-references vendor doc changes against schema `x-audited.source` fields. This is the closest thing to a "linting/validation" agent in the repo. Uses frontmatter fields: `name`, `description`, `tools`, `color`.
+- 12 `gsd-*` agents -- Part of the "Get Shit Done" workflow system (planner, executor, verifier, debugger, etc.)
+
+### Project-Level Commands (`.claude/commands/`)
+
+- `commands/gsd/` -- 30+ GSD workflow commands (add-phase, execute-phase, verify-work, etc.)
+- No skilllint-related commands exist.
+
+### Vendor Plugins (`.claude/vendor/claude_code/plugins/`)
+
+13 vendor plugins exist as reference examples. These are NOT project plugins but local clones of official Anthropic plugin examples. Key patterns observed:
+
+| Plugin | Components | Pattern |
+|--------|-----------|---------|
+| `code-review` | commands/ only | Minimal plugin.json (name, description, version, author) |
+| `hookify` | commands/ + skills/ + agents/ + hooks/ + core/ | Full-featured plugin with Python hook handlers |
+| `plugin-dev` | commands/ + skills/ (7 skills) + agents/ | Multi-skill plugin for plugin development |
+| `feature-dev` | commands/ + agents/ (3 agents) | Agent-heavy plugin |
+| `commit-commands` | commands/ only | Simple command-only plugin |
+| `claude-opus-4-5-migration` | skills/ with references/ | Skill with reference documents |
+| `explanatory-output-style` | hooks/ only | Hook-only plugin |
+
+### Vendor Skills from Other Platforms (`.claude/vendor/`)
+
+The repo contains vendor documentation clones for multiple platforms (gemini_cli, codex, kilocode, kimi, opencode) used for schema auditing. These contain their own skills but are reference material, not project capabilities.
+
+### External Installed Plugins (`/root/.claude/plugins/cache/`)
+
+Two plugin sets are installed at the user level:
+
+- `jamie-bitflight-skills/plugin-creator/8.5.1/` -- The plugin-creator plugin (provides skills like `claude-skills-overview-2026`, `claude-plugins-reference-2026`, `hooks-guide`, etc.)
+- `jamie-bitflight-skills/python3-development/4.0.2/` -- Python development skills (python3-development, ty, hatchling, pre-commit, etc.)
+
+No skilllint-specific plugin exists in any installed plugin cache.
+
+## 2. Existing Skills About skilllint, Linting, or Validation
+
+**None found.** Specifically:
+
+- No skill in `.claude/skills/` mentions skilllint, linting, or validation
+- No command in `.claude/commands/` relates to skilllint
+- No installed plugin in `/root/.claude/plugins/cache/` references skilllint or agentskills-linter
+- The `schema-drift-auditor` agent is related (it audits schema drift from vendor docs) but does not use `skilllint` -- it is a manual cross-referencing agent
+
+The only validation-adjacent capability is `schema-drift-auditor.md`, which detects whether vendor documentation changes affect schema field definitions. This is complementary to but distinct from what a skilllint guide skill would do.
+
+## 3. Patterns Used in Existing Plugins/Skills
+
+### Frontmatter Pattern (from `mmap-processor` and `schema-drift-auditor`)
+
+Project-level skills use minimal frontmatter:
+```yaml
+---
+name: <kebab-case-name>
+description: <single-line description with trigger keywords>
+---
+```
+
+Agents add `tools` and `color` fields.
+
+### Vendor Plugin Structure Pattern
+
+The standard layout observed across all vendor plugins:
+```
+plugin-name/
+  .claude-plugin/
+    plugin.json          # name, version, description, author
+  commands/              # Markdown command files
+  skills/
+    skill-name/
+      SKILL.md           # Frontmatter + instructions
+      references/        # Supporting docs (loaded on demand)
+  agents/                # Subagent definitions
+  hooks/                 # Hook config + handlers
+  scripts/               # Executable utilities
+```
+
+### plugin.json Pattern
+
+Minimal required fields observed in all vendor plugins:
+```json
+{
+  "name": "plugin-name",
+  "version": "1.0.0",
+  "description": "Brief description",
+  "author": { "name": "...", "email": "..." }
+}
+```
+
+No vendor plugin uses custom path overrides (no `"skills": "./custom/"` etc.) -- they all rely on default directory conventions.
+
+### Reference Document Pattern
+
+Skills with supporting material use a `references/` subdirectory:
+- `claude-opus-4-5-migration/skills/.../references/effort.md` and `prompt-snippets.md`
+- `plugin-dev/skills/agent-development/references/` (3 files)
+- `plugin-dev/skills/command-development/references/` (7 files)
+
+References are linked from SKILL.md and loaded on demand by Claude.
+
+## 4. Gaps to Fill
+
+### Primary Gap: No skilllint Guide Skill
+
+There is no skill anywhere in the project that:
+- Teaches Claude how to use the `skilllint` CLI
+- Explains rule IDs (FM-series, SK-series, AS-series)
+- Shows the scan-identify-fix workflow
+- Documents installation via uv/pipx/pip
+- Covers version checking and upgrades
+
+This is the exact gap the `agentskills-skilllint` plugin is intended to fill per `discuss-CONTEXT.md`.
+
+### Secondary Gaps
+
+1. **No plugin structure at `plugins/` in repo root** -- The plan in `discuss-CONTEXT.md` specifies `plugins/agentskills-skilllint/` as the target location. This directory does not exist yet and needs to be created from scratch.
+
+2. **No existing rule catalog** -- The plan calls for a `references/` file with the full rule catalog. This content needs to be authored (or generated from `skilllint rule --list` output).
+
+3. **No argument-driven skill examples in project** -- The `mmap-processor` skill does not use arguments. The planned skill needs `argument-hint` frontmatter and `` substitution for rule ID lookups. Vendor plugins (e.g., `plugin-dev` skills) provide reference patterns for this.
+
+### What Already Exists and Can Be Leveraged
+
+- The `discuss-CONTEXT.md` plan file provides clear scope decisions
+- The vendor plugin examples in `.claude/vendor/claude_code/plugins/` provide structural templates
+- The `claude-skills-overview-2026` and `claude-plugins-reference-2026` skills (installed plugins) provide authoritative schema references for validation
+- The `skilllint` package itself lives at `packages/skilllint/` and can be queried for rule definitions
+
+## Summary
+
+| Category | Status |
+|----------|--------|
+| Plugin directory (`plugins/agentskills-skilllint/`) | Does not exist -- needs creation |
+| SKILL.md | Does not exist -- needs creation |
+| plugin.json | Does not exist -- needs creation |
+| Rule catalog reference | Does not exist -- needs creation |
+| Structural templates | Available via vendor plugins |
+| Schema references | Available via installed plugin-creator skills |
+| Scope/requirements | Documented in `discuss-CONTEXT.md` |

--- a/.claude/plan/agentskills-skilllint/research-2-features.md
+++ b/.claude/plan/agentskills-skilllint/research-2-features.md
@@ -1,0 +1,236 @@
+# Research: Claude Code Skill Features for skilllint Guide
+
+Date: 2026-03-13
+
+## Summary
+
+This document analyzes which Claude Code skill features are appropriate for a "skilllint guide" skill, based on the authoritative skill specification (claude-skills-overview-2026), the existing project context (discuss-CONTEXT.md), and the actual skilllint CLI capabilities.
+
+---
+
+## Question 1: Should this use `context: fork` or inline instructions?
+
+**Recommendation: Do NOT use `context: fork`. Use inline (main context) instructions.**
+
+### Rationale
+
+- `context: fork` runs the skill in an isolated subagent that does NOT have access to the user's conversation history. The skilllint guide needs conversation context -- when a user says "I got an FM004 error," the skill needs to see what they were working on and what plugin path is relevant.
+- The skill is primarily a knowledge/reference resource with some CLI execution. It does not perform a complex isolated task that benefits from a fresh context.
+- Per the specification: "Use `context: fork` only when the skill includes explicit instructions and a clear task." A guide/reference skill provides guidelines and context-sensitive help, not a single discrete task.
+- The existing `mmap-processor` skill in this project also uses inline context (no `context: fork`), which is the right pattern for instructional/knowledge skills.
+
+### When fork WOULD be appropriate
+
+If the skill needed to perform a full automated linting pass (scan a directory, collect results, produce a report), a forked `general-purpose` agent would make sense. But the discuss-CONTEXT.md makes clear this is a guide, not an automated scanner.
+
+---
+
+## Question 2: Should `disable-model-invocation` be set?
+
+**Recommendation: Do NOT set `disable-model-invocation: true`. Leave it at the default (false).**
+
+### Rationale
+
+- Per discuss-CONTEXT.md: "Invocation: user-invoked (slash command `/skilllint`) AND model-invoked (when linting topics come up)."
+- The skill should activate automatically when Claude encounters linting errors, when a user asks about skilllint rules, or when plugin validation is being discussed. This is the core value -- Claude should know about this tool without the user needing to explicitly invoke it.
+- `disable-model-invocation: true` would remove the skill description from Claude's context entirely (per the specification table), meaning Claude would never know this tool exists unless the user types `/skilllint`.
+- This skill has no side effects (it guides usage, it does not deploy or modify infrastructure), so there is no safety reason to restrict auto-invocation.
+
+### Impact on context budget
+
+With `disable-model-invocation: false`, the skill's description (up to 1024 chars) is always loaded into the `<available_skills>` block (2% of context window). This is a small cost and worthwhile for discoverability.
+
+---
+
+## Question 3: What `allowed-tools` are appropriate?
+
+**Recommendation: Do NOT specify `allowed-tools`. Let the skill inherit the parent agent's tool capabilities.**
+
+### Rationale
+
+- Per the specification: "When an `allowed-tools` field is not specified, the skill inherits the tool capabilities of the parent agent. This is a common pattern for skills that need to use tools from the parent agent."
+- The skill is an inline knowledge skill, not a forked agent. It loads into the main conversation context. The orchestrator/main agent already has access to Read, Bash, Grep, Glob, Edit, Write, etc. Specifying `allowed-tools` would actually RESTRICT the agent to only those tools (the field is both a pre-approval and a scoping mechanism).
+- The skill needs Claude to be able to:
+  - Run `skilllint` via Bash (to scan, check versions, etc.)
+  - Read files (to look at linting output, SKILL.md files being linted)
+  - Edit files (to apply manual fixes based on rule guidance)
+  - Search files (Grep/Glob to find files to lint)
+- Restricting to a subset would break the natural workflow. The user might ask Claude to fix a violation, which requires Edit/Write -- tools that would need to be explicitly listed if `allowed-tools` were set.
+
+### Exception case
+
+If the skill were `context: fork`, we would need `allowed-tools: Read, Bash, Grep, Glob, Edit, Write` to grant those tools to the subagent. Since we are not forking, this is unnecessary.
+
+---
+
+## Question 4: Should the skill use `argument-hint`?
+
+**Recommendation: YES. Use `argument-hint: "[rule-id | path]"`.**
+
+### Rationale
+
+- Per discuss-CONTEXT.md: "Argument support: YES -- `skilllint <rule-id>` should explain a specific rule; no args = full guide."
+- The `argument-hint` field provides autocomplete guidance in the `/` menu. When the user starts typing `/skilllint`, they see `[rule-id | path]` as a hint, making it clear the skill accepts arguments.
+- The skill content should use `<$ARGUMENTS>` for argument substitution. When invoked as `/skilllint FM004`, the `<$ARGUMENTS>` placeholder resolves to `FM004`, and the skill instructions can branch: "If a rule ID is provided, explain that specific rule and how to fix it."
+
+### Implementation pattern
+
+```yaml
+---
+argument-hint: "[rule-id | path]"
+---
+
+# skilllint Guide
+
+<$ARGUMENTS>
+
+If a rule ID was provided above (e.g., FM004, SK006, HK001), explain that rule...
+If a path was provided, show how to run skilllint on that path...
+If no arguments, show the full usage guide...
+```
+
+---
+
+## Question 5: Is a `references/` subdirectory appropriate for a rule catalog?
+
+**Recommendation: YES, use `references/` for the full rule catalog, but keep it to a single file.**
+
+### Rationale
+
+- The skilllint tool validates across multiple rule series: FM (frontmatter), SK (skill structure/tokens), HK (hooks), PL (plugin), NR (namespace references), AS (agentskills standard). Based on the test files, there are at least 25+ distinct rule codes.
+- Putting the full catalog inline in SKILL.md would bloat the skill body. The skill specification encourages progressive disclosure: "Supporting files can also live at the skill root. Reference them from SKILL.md so Claude knows what each file contains and when to load it."
+- SKILL.md should contain: the guide workflow (install, scan, interpret output, fix), a compact rule-series overview, and a pointer to `references/rule-catalog.md` for the detailed per-rule explanations.
+- A single `references/rule-catalog.md` is sufficient. There is no need for one file per series -- the catalog is a lookup table, not a set of independent documents.
+
+### Token budget consideration
+
+- SKILL.md content only loads when the skill is activated (not at startup). The references/ files load on demand when Claude reads them. This two-tier approach keeps the initial activation cost low.
+- Per the specification, if SKILL.md exceeds 4000 tokens, the plugin assessor flags SK006 (warning) or SK007 (error). Keeping the detailed catalog in references/ avoids this.
+
+### Discovered rule codes (from test files)
+
+| Series | Codes Found | Category |
+|--------|-------------|----------|
+| FM | FM001, FM002, FM003, FM004, FM007, FM008, FM009, FM010 | Frontmatter validation |
+| SK | SK001, SK002, SK003, SK006, SK007, SK009 | Skill structure/tokens |
+| HK | HK001, HK002, HK003, HK004, HK005 | Hook validation |
+| PL | PL002, PL003 | Plugin manifest |
+| NR | NR001 | Namespace references |
+| AS | AS001, AS002, AS003, AS004, AS005, AS006 | AgentSkills standard |
+
+Note: The actual rule registry in the source code may contain additional rules not exercised in tests. The rule catalog should be generated from the source, not hardcoded.
+
+---
+
+## Question 6: Should we use dynamic context injection (`!`command``) to show live skilllint output?
+
+**Recommendation: YES, but selectively -- use it for version checking only, not for full scan output.**
+
+### Good use case: Version check
+
+```markdown
+Current installed version:
+!`skilllint --version 2>/dev/null || echo "not installed"`
+```
+
+This runs at skill activation time (preprocessing), so Claude immediately knows whether skilllint is installed and what version is available. This enables the skill to give contextual advice ("you have version X, consider upgrading" vs "skilllint is not installed, here is how to install it").
+
+### Bad use case: Full scan output
+
+Do NOT use dynamic injection for `!`skilllint .``. Reasons:
+- The scan target depends on user context (what directory? what files?). Dynamic injection runs before Claude sees the prompt, so there is no way to parameterize it.
+- Scan output can be very large (hundreds of violations), which would bloat the skill content injected into context.
+- The skill should instruct Claude to run `skilllint` as a Bash command, not pre-run it.
+
+### Implementation
+
+```yaml
+---
+name: skilllint
+description: Guide for using the skilllint CLI to validate Claude Code plugins, skills, and agents. Use when discussing linting, plugin validation, rule violations, or skilllint installation.
+argument-hint: "[rule-id | path]"
+---
+
+skilllint status: !`command -v skilllint >/dev/null 2>&1 && skilllint --version 2>/dev/null || echo "NOT INSTALLED"`
+
+# skilllint Guide
+...
+```
+
+---
+
+## Proposed Skill Structure
+
+```
+plugins/agentskills-skilllint/
+├── .claude-plugin/
+│   └── plugin.json
+└── skills/
+    └── skilllint/
+        ├── SKILL.md
+        └── references/
+            └── rule-catalog.md
+```
+
+### Proposed SKILL.md frontmatter
+
+```yaml
+---
+name: skilllint
+description: Guide for using the skilllint CLI to validate Claude Code plugins, skills, and agents. Explains rule violations (FM/SK/HK/PL/NR/AS series), fix workflows, installation via uv/pipx/pip, and version management. Use when discussing linting errors, plugin validation, or skilllint commands.
+argument-hint: "[rule-id | path]"
+---
+```
+
+### Frontmatter field decisions (summary)
+
+| Field | Value | Reason |
+|-------|-------|--------|
+| `name` | `skilllint` | Matches directory name, creates `/skilllint` command |
+| `description` | (see above) | Includes trigger keywords for auto-invocation |
+| `argument-hint` | `[rule-id \| path]` | Shows users can pass a rule ID or file path |
+| `context` | (omitted = inline) | Needs conversation context, not isolated |
+| `agent` | (omitted) | Not applicable without `context: fork` |
+| `disable-model-invocation` | (omitted = false) | Should auto-activate on linting topics |
+| `user-invocable` | (omitted = true) | Users should be able to invoke directly |
+| `allowed-tools` | (omitted) | Inherits parent tools; no restriction needed |
+| `model` | (omitted) | Inherits session model |
+| `hooks` | (omitted) | No lifecycle hooks needed |
+
+---
+
+## Additional Design Notes
+
+### No `skilllint rule` subcommand exists yet
+
+The current CLI (`skilllint --help`) has no `rule` subcommand. The discuss-CONTEXT.md mentions `skilllint rule <rule-id>` but this does not exist in the current codebase. The skill should document the actual CLI interface:
+- `skilllint <path>` -- validate a plugin/skill/agent
+- `skilllint --fix <path>` -- auto-fix where possible
+- `skilllint --check <path>` -- validate only
+- `skilllint --filter-type skills|agents|commands <path>` -- filter by file type
+- `skilllint --platform claude-code|cursor|codex <path>` -- platform-specific validation
+
+The rule catalog in `references/rule-catalog.md` serves the "explain a rule" function until a `rule` subcommand is implemented.
+
+### Installation instructions should cover three methods
+
+1. `uv tool install skilllint` / `uv tool upgrade skilllint`
+2. `pipx install skilllint` / `pipx upgrade skilllint`
+3. `pip install skilllint` / `pip install --upgrade skilllint`
+
+### The `<$ARGUMENTS>` branching pattern
+
+The skill body should handle three invocation patterns:
+1. `/skilllint` (no args) -- show full usage guide
+2. `/skilllint FM004` (rule ID) -- explain that specific rule, show fix
+3. `/skilllint ./path/to/plugin` (path) -- show how to run skilllint on that path
+
+---
+
+## Sources
+
+- Skill specification: `claude-skills-overview-2026` (loaded via plugin-creator skill)
+- Plugin specification: `claude-plugins-reference-2026` (loaded via plugin-creator skill)
+- Project context: `/home/user/agentskills-linter/.claude/plan/agentskills-skilllint/discuss-CONTEXT.md`
+- CLI help: `skilllint --help` output
+- Rule codes: extracted from test files in `/home/user/agentskills-linter/packages/skilllint/tests/`

--- a/.claude/plan/agentskills-skilllint/research-2-features.md
+++ b/.claude/plan/agentskills-skilllint/research-2-features.md
@@ -105,7 +105,7 @@ If no arguments, show the full usage guide...
 ### Token budget consideration
 
 - SKILL.md content only loads when the skill is activated (not at startup). The references/ files load on demand when Claude reads them. This two-tier approach keeps the initial activation cost low.
-- Per the specification, if SKILL.md exceeds 4000 tokens, the plugin assessor flags SK006 (warning) or SK007 (error). Keeping the detailed catalog in references/ avoids this.
+- Per the specification, if SKILL.md body exceeds 4400 tokens, the plugin assessor flags SK006 (warning); if it exceeds 8800 tokens, it flags SK007 (error). Keeping the detailed catalog in references/ avoids this.
 
 ### Discovered rule codes (from test files)
 

--- a/.claude/plan/agentskills-skilllint/research-3-architecture.md
+++ b/.claude/plan/agentskills-skilllint/research-3-architecture.md
@@ -1,0 +1,240 @@
+# Research 3: Architecture Patterns for agentskills-skilllint Plugin
+
+## 1. Directory Layout
+
+Based on the plugin-creator plugin structure and Claude Code plugin conventions:
+
+```
+plugins/agentskills-skilllint/
+├── .claude-plugin/
+│   └── plugin.json              # Required: plugin manifest
+├── skills/
+│   └── skilllint/
+│       ├── SKILL.md             # Primary skill: guides agents through skilllint CLI
+│       └── references/
+│           └── rule-catalog.md  # Complete rule ID catalog (FM/SK/LN/ST/AG/PJ series)
+├── scripts/                     # Optional: hook scripts if needed later
+└── LICENSE
+```
+
+Rationale:
+- Single skill (`skilllint`) keeps things focused. The plugin wraps one CLI tool.
+- `references/rule-catalog.md` holds the full error code explanations so the SKILL.md body stays lean (progressive disclosure).
+- No `agents/` directory needed — this is a skill-only plugin.
+- No `commands/` directory — skills supersede commands in the unified system.
+
+## 2. plugin.json Fields
+
+```json
+{
+  "name": "agentskills-skilllint",
+  "version": "0.1.0",
+  "description": "Guide AI agents through using the skilllint CLI to validate, lint, and auto-fix Claude Code plugins, skills, agents, and commands. Use when checking plugin quality, resolving frontmatter violations, or understanding linting rules.",
+  "author": {
+    "name": "Jamie Nelson",
+    "url": "https://github.com/bitflight-devops"
+  },
+  "homepage": "https://github.com/bitflight-devops/agentskills-linter",
+  "repository": "https://github.com/bitflight-devops/agentskills-linter",
+  "license": "MIT",
+  "keywords": [
+    "skilllint",
+    "linter",
+    "validation",
+    "claude-code",
+    "plugin",
+    "skill",
+    "agent",
+    "frontmatter"
+  ]
+}
+```
+
+Required fields per plugin schema (source: `claude-plugins-reference-2026`):
+- `name` (string, kebab-case) — REQUIRED, only strictly required field
+- `version` (string, semver) — metadata, strongly recommended
+- `description` (string) — metadata, strongly recommended for discovery
+
+Optional metadata used above: `author`, `homepage`, `repository`, `license`, `keywords`.
+
+Component path fields NOT needed:
+- `skills` — omitted because `skills/` at plugin root is auto-discovered
+- `agents` — no agents in this plugin
+- `commands` — no legacy commands
+- `hooks` — no hooks initially
+- `mcpServers` — not applicable
+- `lspServers` — not applicable
+
+## 3. SKILL.md Structure
+
+### Frontmatter
+
+```yaml
+---
+name: skilllint
+description: Run the skilllint CLI to validate, lint, and auto-fix Claude Code plugins, skills, agents, and commands. Use when checking plugin quality, resolving frontmatter violations (FM001-FM010), skill naming issues (SK001-SK007), or understanding what a lint error means. Pass a path or rule ID as argument.
+argument-hint: <path-or-rule-id>
+allowed-tools: Read, Grep, Glob, Bash(skilllint:*, uv run skilllint:*)
+user-invocable: true
+---
+```
+
+Field choices explained:
+
+| Field | Value | Rationale |
+|-------|-------|-----------|
+| `name` | `skilllint` | Matches directory name; required per agentskills.io spec |
+| `description` | (see above) | Includes both what it does AND trigger keywords (frontmatter, violations, FM/SK codes). Single-line, no multiline YAML indicators (per known indexer bug). Under 1024 chars. |
+| `argument-hint` | `<path-or-rule-id>` | Indicates the skill accepts either a file/dir path to lint OR a rule ID to explain |
+| `allowed-tools` | `Read, Grep, Glob, Bash(skilllint:*, uv run skilllint:*)` | Scoped Bash access to only skilllint commands. Read/Grep/Glob for file inspection. |
+| `user-invocable` | `true` (default) | Users should be able to invoke `/skilllint path/to/plugin` directly |
+
+Fields deliberately omitted:
+- `model` — inherit from parent; no need for specific model
+- `context` — NOT forked; skill needs conversation context to understand what the user wants linted
+- `agent` — not applicable without `context: fork`
+- `disable-model-invocation` — leave false; Claude should auto-invoke when user mentions linting/validation
+- `hooks` — not needed initially; could add PostToolUse lint hook later
+
+### Body Structure
+
+The SKILL.md body should follow a workflow-guidance pattern (similar to `plugin-creator:lint`):
+
+```markdown
+# skilllint
+
+<target>$ARGUMENTS</target>
+
+## Workflow
+
+### 1. Determine intent from arguments
+
+- If `<target/>` is a rule ID (matches pattern `FM\d{3}`, `SK\d{3}`, etc.): read [references/rule-catalog.md](./references/rule-catalog.md) and explain that rule.
+- If `<target/>` is a path: proceed to validation.
+- If `<target/>` is empty: ask what to lint, or scan current directory.
+
+### 2. Run validation
+
+```bash
+skilllint <target/> --show-summary --show-progress
+```
+
+If not installed or command fails, try:
+```bash
+uv run skilllint <target/> --show-summary --show-progress
+```
+
+### 3. Interpret results
+
+For each violation reported, read its explanation from [references/rule-catalog.md](./references/rule-catalog.md).
+
+### 4. Fix (if requested)
+
+```bash
+skilllint --fix <target/>
+```
+
+Auto-fixable rules: FM004, FM007, FM008, FM009. For non-auto-fixable rules, provide manual fix guidance from the rule catalog.
+
+## Installation
+
+skilllint is available via: `uv tool install skilllint`, `pipx install skilllint`, or `pip install skilllint`.
+
+## Reference Files
+
+- [references/rule-catalog.md](./references/rule-catalog.md) — Complete rule ID catalog with explanations, examples, and fix guidance
+```
+
+Key design decisions:
+- Uses `$ARGUMENTS` substitution (same pattern as `plugin-creator:lint`)
+- Dynamic context injection (`!` backtick) is NOT used here because skilllint output changes per invocation — the agent runs it via Bash instead.
+- Progressive disclosure: rule catalog lives in references/, loaded only when agent needs to explain a specific rule.
+
+## 4. References: Rule Catalog
+
+Yes, a `references/rule-catalog.md` is strongly recommended. Rationale:
+
+1. **Token efficiency**: The full rule catalog from the plugin-creator's ERROR_CODES.md is ~780 lines. Putting this in SKILL.md would blow past the SK006 warning threshold (4000 tokens). In `references/`, it loads on demand.
+
+2. **Content**: The catalog should contain all rule series with their:
+   - Rule ID and name
+   - Severity (ERROR/WARNING/INFO)
+   - Whether auto-fixable
+   - What triggers it
+   - Example of violation and fix
+   - For FM-series: exact YAML before/after
+
+3. **Source**: Generate from skilllint's own internal rule definitions rather than copying from plugin-creator's ERROR_CODES.md. This keeps it in sync with the actual tool version.
+
+4. **Size concern**: If the catalog exceeds ~10k words, add grep search patterns in SKILL.md so the agent can find specific rules without loading the full file:
+   ```markdown
+   For specific rule details, grep `references/rule-catalog.md` for the rule ID (e.g., `FM004`).
+   ```
+
+## 5. Marketplace JSON
+
+A `marketplace.json` is NOT needed at this stage. Reasons:
+
+- `marketplace.json` goes in `.claude-plugin/marketplace.json` and is for repositories that host MULTIPLE plugins for distribution as a catalog.
+- This plugin lives inside the agentskills-linter repo alongside the tool it wraps.
+- For initial distribution, users install via `--plugin-dir` or by adding the repo as a marketplace source.
+- A marketplace.json becomes relevant when:
+  - The repo hosts multiple plugins (currently just one)
+  - There is a need for version pinning via `ref`/`sha` fields
+  - Enterprise teams need managed marketplace restrictions
+
+If a marketplace is desired later, the minimal structure would be:
+
+```json
+{
+  "name": "agentskills-linter",
+  "owner": {
+    "name": "Jamie Nelson",
+    "email": "jamie@bitflight.io"
+  },
+  "plugins": [
+    {
+      "name": "agentskills-skilllint",
+      "source": "./plugins/agentskills-skilllint",
+      "description": "Guide agents through skilllint CLI validation",
+      "version": "0.1.0"
+    }
+  ]
+}
+```
+
+This would live at the repo root, not inside the plugin directory.
+
+## 6. Comparison with plugin-creator:lint
+
+The `plugin-creator:lint` skill is the closest architectural precedent. Key differences:
+
+| Aspect | plugin-creator:lint | agentskills-skilllint:skilllint |
+|--------|--------------------|---------------------------------|
+| Tool invoked | `plugin_validator.py` (Python script) | `skilllint` (installed CLI binary) |
+| Dynamic injection | Uses `!` backtick to run validator at load time | Does NOT use dynamic injection; agent runs CLI via Bash |
+| Error codes ref | `@${CLAUDE_PLUGIN_ROOT}/references/ERROR_CODES.md` (loaded via `@` syntax) | `references/rule-catalog.md` (agent reads on demand) |
+| Arguments | Single path only | Path OR rule ID (dual-mode) |
+| Body size | 3 lines (minimal) | ~40-60 lines (workflow guidance) |
+| Fix support | Not guided | Explicit `--fix` workflow with auto-fixable rule list |
+
+The plugin-creator:lint skill is extremely minimal (3 lines) because it relies on dynamic injection to run the validator and dump results. Our skill is more structured because:
+1. skilllint is a standalone CLI, not a script in the plugin
+2. We want to guide through the full scan-interpret-fix workflow
+3. We support dual-mode (path linting vs. rule explanation)
+
+## 7. Version Synchronization
+
+The plugin version in `plugin.json` should track the skilllint package version from `pyproject.toml`. Since skilllint uses `hatch-vcs` (git tag-based versioning), the plugin version should be updated when skilllint releases change the rule set or CLI interface.
+
+Recommendation: Start at `0.1.0` for the plugin and bump independently of skilllint's version, since the plugin content (SKILL.md prose, rule catalog) can change without the tool changing and vice versa.
+
+## 8. Open Questions (from mission.json backlog)
+
+These were captured in the existing mission.json and remain relevant:
+
+1. **Should the skill guide through creating new plugins from scratch?** — Recommendation: No. That is plugin-creator's domain. This skill focuses on validation/linting of existing artifacts.
+
+2. **Should it link to agentskills.io for AS-series rules?** — Recommendation: Yes, but only as a reference link in rule-catalog.md, not as a dependency.
+
+3. **Should version checking be a separate argument path?** — Recommendation: No separate path. Include `skilllint --version` as a diagnostic step in the troubleshooting section of SKILL.md.

--- a/.claude/plan/agentskills-skilllint/research-4-pitfalls.md
+++ b/.claude/plan/agentskills-skilllint/research-4-pitfalls.md
@@ -1,0 +1,296 @@
+# skilllint — Rule IDs, Pitfalls, and Reference
+
+## PyPI Package
+
+- **Package name:** `skilllint`
+- **Install:** `pip install skilllint` / `pipx install skilllint` / `uv tool install skilllint`
+- **Entry points (all identical):** `skilllint`, `agentlint`, `pluginlint`, `skillint`
+
+## Version Check
+
+```
+skilllint --version
+```
+
+Typer auto-generates `--version` from the package metadata. There is no `skilllint rule <id>` subcommand — the CLI has a single command (`main`) registered via `app.command()(main)`. All flags are options on that single command.
+
+## CLI Flags
+
+```
+skilllint [PATHS]...
+  --check          Validate only, don't auto-fix
+  --fix            Auto-fix issues where possible
+  --verbose / -v   Show detailed output including info messages
+  --no-color       Disable color output for CI
+  --tokens-only    Output only the integer token count (programmatic use)
+  --show-progress  Show per-file PASSED/FAILED status
+  --show-summary   Show validation summary panel at end
+  --filter GLOB    Glob pattern to match files within a directory
+  --filter-type    Shortcut: skills | agents | commands
+  --platform       Restrict to a specific adapter: claude-code | cursor | codex
+```
+
+`--check` and `--fix` are mutually exclusive.
+
+## Auto-Fixable Rules
+
+The `--fix` flag is supported. Validators that return `can_fix() -> True` and implement `fix()`:
+
+| Validator | Rules Fixed |
+|---|---|
+| `FrontmatterValidator` | FM004, FM007, FM008, FM009 (and related frontmatter normalization) |
+| `NameFormatValidator` | SK001 (uppercase), SK002 (underscores), SK003 (bad hyphens), FM010 |
+| `SymlinkTargetValidator` | SL001 (trailing whitespace in symlink targets) |
+
+`ProgressiveDisclosureValidator` explicitly raises `NotImplementedError` in its `fix()` — PD001/PD002/PD003 are **not** auto-fixable.
+
+---
+
+## All Rule IDs
+
+### FM Series — Frontmatter (FM001–FM010)
+
+Fired by `FrontmatterValidator` on SKILL.md, agents/*.md, and commands/*.md files.
+
+| Code | Severity | What It Checks |
+|---|---|---|
+| FM001 | error | Missing required field (`name`, `description`) |
+| FM002 | error | Invalid YAML syntax in frontmatter |
+| FM003 | error | Frontmatter not closed with `---` |
+| FM004 | error | Forbidden multiline indicator (`>-` or `\|-`) in frontmatter values |
+| FM005 | error | Field type mismatch (expected string or bool, got something else) |
+| FM006 | error | Invalid field value (e.g. `model` not in allowed enum) |
+| FM007 | error | `allowed-tools` (or `tools`) field is a YAML array — must be a CSV string |
+| FM008 | error | `skills` field is a YAML array — must be a CSV string |
+| FM009 | info | Unquoted description value containing a colon (causes YAML parse ambiguity) |
+| FM010 | error | `name` field does not match the required pattern (lowercase alphanumeric + hyphens) |
+
+**FM004, FM007, FM008, FM009 are auto-fixable with `--fix`.**
+
+### SK Series — Skill Quality (SK001–SK009)
+
+Fired by `NameFormatValidator`, `DescriptionValidator`, and `ComplexityValidator`.
+
+| Code | Severity | What It Checks |
+|---|---|---|
+| SK001 | error | `name` contains uppercase characters |
+| SK002 | error | `name` contains underscores (use hyphens instead) |
+| SK003 | error | `name` has leading, trailing, or consecutive hyphens |
+| SK004 | error | `description` is too short (minimum 20 characters) |
+| SK005 | warning | `description` missing trigger phrases (e.g. "use when", "trigger", "invoke") |
+| SK006 | warning | SKILL.md body token count exceeds TOKEN_WARNING_THRESHOLD (4400 tokens) |
+| SK007 | error | SKILL.md body token count exceeds TOKEN_ERROR_THRESHOLD (8800 tokens) — must split |
+| SK008 | error | Skill directory name violates naming convention |
+| SK009 | warning | Plugin uses manual skill selection (overrides auto-discovery) |
+
+**SK001, SK002, SK003 are auto-fixable with `--fix`.**
+
+### AS Series — agentskills.io Cross-Platform (AS001–AS006)
+
+Fired by `check_skill_md()` / `run_as_series()` in `rules/as_series.py` on any SKILL.md, regardless of platform adapter. Applies to Claude Code, Cursor, and Codex adapters.
+
+| Code | Severity | What It Checks |
+|---|---|---|
+| AS001 | error | `name` must be lowercase alphanumeric + hyphens, 1–64 chars, no consecutive hyphens |
+| AS002 | error | `name` must equal the parent directory name |
+| AS003 | error | `description` field must be present and non-empty |
+| AS004 | error | `description` must not contain HTML tags (`<` or `>`) |
+| AS005 | warning/error | SKILL.md body token count: warning at 4400, error at 8800 tokens |
+| AS006 | info | No `eval_queries.json` (or `*eval*.json` / `*queries*.json`) found in skill directory |
+
+**AS series rules are not auto-fixable.**
+
+### LK Series — Internal Links (LK001–LK002)
+
+Fired by `InternalLinkValidator` on markdown files.
+
+| Code | Severity | What It Checks |
+|---|---|---|
+| LK001 | error | Broken internal link — referenced file does not exist |
+| LK002 | warning | Relative link missing `./` prefix |
+
+### PD Series — Progressive Disclosure (PD001–PD003)
+
+Fired by `ProgressiveDisclosureValidator` on skill directories.
+
+| Code | Severity | What It Checks |
+|---|---|---|
+| PD001 | warning | No `references/` directory found in skill |
+| PD002 | warning | No `examples/` directory found in skill |
+| PD003 | warning | No `scripts/` directory found in skill |
+
+**Not auto-fixable.**
+
+### PL Series — Plugin Manifest (PL001–PL005)
+
+Fired by `ClaudeCodeAdapter.validate()` and plugin structure checks.
+
+| Code | Severity | What It Checks |
+|---|---|---|
+| PL001 | error | Missing `plugin.json` file |
+| PL002 | error | Invalid JSON syntax in `plugin.json` |
+| PL003 | error | Missing required field (e.g. `name`) in plugin manifest |
+| PL004 | error | Component path does not start with `./` |
+| PL005 | error | Referenced component file does not exist |
+
+### PR Series — Plugin Registration (PR001–PR005)
+
+Fired by `PluginRegistrationValidator`.
+
+| Code | Severity | What It Checks |
+|---|---|---|
+| PR001 | warning | Capability (skill/agent/command) exists but is not registered in `plugin.json` |
+| PR002 | error | Registered capability path does not exist |
+| PR003 | warning | Plugin metadata fields (`repository`, `homepage`, `author`) not populated |
+| PR004 | warning | Plugin metadata `repository` URL mismatches git remote URL |
+| PR005 | error | Registered command path is a skill directory (contains SKILL.md) |
+
+### HK Series — Hooks (HK001–HK005)
+
+Fired by `HookValidator` on `hooks.json` files.
+
+| Code | Severity | What It Checks |
+|---|---|---|
+| HK001 | error | Invalid `hooks.json` structure |
+| HK002 | error | Invalid event type in `hooks.json` |
+| HK003 | error | Invalid hook entry structure |
+| HK004 | error | Hook script referenced in `hooks.json` but file not found |
+| HK005 | warning | Hook script exists but is not executable |
+
+### NR Series — Namespace References (NR001–NR002)
+
+Fired by `NamespaceReferenceValidator`.
+
+| Code | Severity | What It Checks |
+|---|---|---|
+| NR001 | error | Namespace reference target does not exist |
+| NR002 | error | Namespace reference points outside the plugin directory |
+
+### SL Series — Symlinks (SL001)
+
+Fired by `SymlinkTargetValidator`.
+
+| Code | Severity | What It Checks |
+|---|---|---|
+| SL001 | error | Symlink target has trailing whitespace or newlines |
+
+**Auto-fixable with `--fix`.**
+
+### CM Series — Commands (CM001)
+
+| Code | Severity | What It Checks |
+|---|---|---|
+| CM001 | reserved | Command-specific validation (reserved for future use) |
+
+### TC Series — Token Count (TC001)
+
+| Code | Severity | What It Checks |
+|---|---|---|
+| TC001 | info | Token count report (total, frontmatter, body) — informational only |
+
+### Cursor Adapter — Platform-Specific Codes
+
+Fired by `CursorAdapter.validate()` on `.mdc` files only. These use string codes, not the FM/SK pattern:
+
+| Code | Severity | What It Checks |
+|---|---|---|
+| `cursor-mdc-missing-required` | error | Required field missing from `.mdc` frontmatter |
+| `cursor-mdc-unknown-field` | error | Unknown field in `.mdc` frontmatter when `additionalProperties` is false |
+
+---
+
+## Adapter Scope
+
+| Adapter | Applicable Rule Series | File Patterns |
+|---|---|---|
+| `claude_code` | SK, PR, HK, AS | `.claude/**/*.md`, `plugin.json`, `hooks.json`, `agents/**/*.md`, `commands/**/*.md` |
+| `cursor` | AS | `**/*.mdc`, `.cursor/skills/**/*.md`, `.claude/skills/**/*.md`, `.agents/skills/**/*.md` |
+| `codex` | (see adapter) | (see adapter) |
+
+---
+
+## Common Agent Mistakes the Linter Catches
+
+### FM004 — Multiline block scalars in frontmatter
+Agents sometimes write descriptions using YAML block scalar syntax:
+```yaml
+description: >-
+  This skill helps you do things.
+```
+The `>-` (or `|-`) indicator is forbidden. Use a plain single-line string:
+```yaml
+description: This skill helps you do things.
+```
+**Auto-fixable.**
+
+### FM007 / FM008 — YAML arrays instead of CSV strings
+Agents write `allowed-tools` or `skills` as YAML lists:
+```yaml
+allowed-tools:
+  - Bash
+  - Read
+```
+Must be a CSV string:
+```yaml
+allowed-tools: Bash, Read
+```
+**Auto-fixable.**
+
+### FM009 — Unquoted colons in description
+```yaml
+description: Use this skill: it does X
+```
+The `: ` after "skill" is a YAML mapping indicator. Quote the value:
+```yaml
+description: "Use this skill: it does X"
+```
+**Auto-fixable.**
+
+### AS001 / FM010 / SK001 / SK002 — Name format violations
+- Uppercase letters in `name` (SK001): `name: MySkill` → `name: my-skill`
+- Underscores (SK002): `name: my_skill` → `name: my-skill`
+- `name` not matching directory (AS002): directory is `git-helper` but frontmatter says `name: git_helper`
+
+### AS002 — Name/directory mismatch
+The `name` field must exactly equal the parent directory name. Creating a skill in a directory `my-skill/` but writing `name: mySKill` will fail both AS001 and AS002.
+
+### SK004 — Description too short
+A one-word or very brief description like `description: Git tool` fails (minimum 20 characters).
+
+### SK005 — No trigger phrase in description
+The description must include at least one of: `use when`, `use this`, `use on`, `used when`, `used by`, `when `, `trigger`, `activate`, `load this`, `load when`, `invoke`. Without a trigger phrase the AI cannot determine when to invoke the skill.
+
+### SK006 / SK007 / AS005 — Token bloat
+SKILL.md body over 4400 tokens triggers SK006/AS005 warning. Over 8800 tokens is SK007/AS005 error — the skill must be split into sub-skills.
+
+### PR001 — Unregistered capabilities
+Creating a skill directory without adding it to `plugin.json`'s skills array triggers PR001. Auto-discovery does not replace explicit registration.
+
+### HK004 / HK005 — Hook script issues
+Referencing a hook script path that doesn't exist (HK004) or exists but lacks execute permission (HK005). On Windows/Linux discrepancy: a script checked in without `chmod +x` will pass on Windows but fail HK005 on Linux CI.
+
+### AS006 — No eval_queries.json
+Every skill should have an `eval_queries.json` (or a file matching `*eval*.json` / `*queries*.json`) in its directory for automated quality assessment. Absence fires AS006 (info severity).
+
+---
+
+## Suppressing Rules
+
+Per-plugin suppression via `.claude-plugin/validator.json`:
+```json
+{
+  "ignore": {
+    "skills/my-skill": ["SK006", "PD001"]
+  }
+}
+```
+Keys are path prefixes relative to the plugin root. All files under that prefix have the listed codes suppressed.
+
+---
+
+## Token Thresholds (from `token_counter.py`)
+
+- `TOKEN_WARNING_THRESHOLD` = 4400 tokens → SK006 / AS005 warning
+- `TOKEN_ERROR_THRESHOLD` = 8800 tokens → SK007 / AS005 error
+
+Encoding: `tiktoken` `cl100k_base`. Token counting covers only the body (frontmatter excluded).

--- a/.claude/plan/agentskills-skilllint/research-FINDINGS.md
+++ b/.claude/plan/agentskills-skilllint/research-FINDINGS.md
@@ -1,0 +1,126 @@
+# Research Findings: agentskills-skilllint
+Date: 2026-03-13
+
+## 1. Existing Solutions
+
+No skilllint-specific plugin or skill exists anywhere in the project — not in `.claude/skills/`, `.claude/commands/`, or the installed plugin cache at `/root/.claude/plugins/cache/`. The only validation-adjacent capability is the `schema-drift-auditor` agent, which does cross-referencing of vendor docs against schema definitions — complementary to, but distinct from, a skilllint guide.
+
+Structural templates are available from 13 vendor plugins in `.claude/vendor/claude_code/plugins/`. The standard layout is:
+
+```
+plugin-name/
+  .claude-plugin/plugin.json
+  skills/<skill-name>/SKILL.md
+  skills/<skill-name>/references/  (optional, loaded on demand)
+```
+
+The `plugins/agentskills-skilllint/` target directory does not exist and must be created from scratch. No argument-driven skill exists in the project; the vendor plugin `claude-opus-4-5-migration` provides the closest reference for skills with a `references/` subdirectory.
+
+Key pattern: `plugin.json` requires only `name`. All other fields (`version`, `description`, `author`, `keywords`) are strongly recommended metadata. Component path fields (`skills`, `agents`, etc.) are omitted when the default directory layout is used — auto-discovery handles them.
+
+## 2. Recommended Features
+
+**context: fork** — Do NOT use. The skill needs conversation context to understand what the user is working on (e.g., which plugin path is relevant, what error they saw). Inline context is the correct choice for a guide/reference skill.
+
+**disable-model-invocation** — Do NOT set. Per `discuss-CONTEXT.md`, the skill must auto-activate when Claude encounters linting errors, rule violations, or plugin validation topics. Setting this would make the skill invisible to Claude unless the user explicitly types `/skilllint`.
+
+**allowed-tools** — The research is split: research-2 recommends omitting it (inherits parent tools, avoids restriction); research-3 recommends `Read, Grep, Glob, Bash(skilllint:*, uv run skilllint:*)`. The task spec requires `allowed-tools="Read, Bash, Glob, Grep"`. This is the value to use — it explicitly grants the four needed tools without relying on parent inheritance.
+
+**argument-hint** — Use `[rule-id|path]`. The `$ARGUMENTS` substitution enables three invocation modes: no args (full guide), rule ID (explain that rule from catalog), path (run lint on that path).
+
+**references/ subdirectory** — Yes, one file: `references/rule-catalog.md`. The full catalog is ~780 lines and would exceed the SK006 warning threshold (4400 tokens) if inlined. Progressive disclosure: SKILL.md contains the workflow guide and a rule-series overview; the catalog is loaded on demand.
+
+**Dynamic context injection (`!` backtick)** — Selective use: a version/install check at skill activation (`!command -v skilllint ...`) is appropriate. Do NOT use it for scan output — scan targets depend on user context and cannot be parameterized at load time.
+
+**`skilllint rule <id>` subcommand** — Does NOT exist. The CLI is a single command with options. The skill must tell agents to look up rules in `references/rule-catalog.md`, and use `skilllint --verbose <path>` for detailed output.
+
+## 3. Architecture Patterns
+
+**Minimal plugin structure** (no agents, no commands, no hooks initially):
+
+```
+plugins/agentskills-skilllint/
+├── .claude-plugin/
+│   └── plugin.json
+└── skills/
+    └── skilllint/
+        ├── SKILL.md
+        └── references/
+            └── rule-catalog.md
+```
+
+**plugin.json** — Include `name`, `version`, `description`, `author`, `homepage`, `repository`, `license`, `keywords`. Omit path override fields (`skills`, `agents`, etc.) — auto-discovery handles them. No `agents` array is needed.
+
+**SKILL.md frontmatter** — Single-line description (multiline YAML indicators are an FM004 violation). Include trigger keywords for auto-invocation. Use `argument-hint` for slash-command UX.
+
+**SKILL.md body structure** — Argument routing first (`$ARGUMENTS`), then: installation, running skilllint, reading output, looking up rules (via catalog), fixing issues, version management. Keep body under 4400 tokens (SK006 threshold).
+
+**rule-catalog.md** — One file covering all series: FM, SK, AS, LK, PD, PL, PR, HK, NR, SL, CM, TC. Each entry: rule ID, severity, what it checks, auto-fixable (yes/no). This is the authoritative lookup table the agent reads when explaining a specific violation.
+
+**Version comparison with plugin-creator:lint** — The closest precedent. Key difference: plugin-creator:lint uses dynamic injection (`!` backtick) to run its validator at load time and dump results inline. The agentskills-skilllint skill does NOT do this — agents run `skilllint` via Bash because: (1) the scan target is unknown at load time, (2) scan output can be large, (3) dual-mode (path vs. rule ID) requires interactive routing.
+
+## 4. Pitfalls & Requirements
+
+**PyPI package name:** `skilllint`. Entry points: `skilllint`, `agentlint`, `pluginlint`, `skillint` (all identical).
+
+**Version check command:** `skilllint --version` (Typer auto-generates from package metadata).
+
+**No `rule` subcommand:** The CLI is a single command. Use `references/rule-catalog.md` for rule lookups.
+
+**Auto-fixable rules:**
+- FM004, FM007, FM008, FM009 — frontmatter normalization (`FrontmatterValidator`)
+- SK001, SK002, SK003, FM010 — name format (`NameFormatValidator`)
+- SL001 — symlink trailing whitespace (`SymlinkTargetValidator`)
+- NOT fixable: PD001, PD002, PD003, all AS series, all HK series (except indirectly)
+
+**Token thresholds:** SK006/AS005 warning at 4400 tokens; SK007/AS005 error at 8800 tokens. Keep SKILL.md body under 4400 tokens.
+
+**YAML multiline bug (FM004):** Never use `>-` or `|-` in frontmatter. Description must be a single plain string on one line.
+
+**FM009 colon trap:** If a description contains a colon followed by a space (e.g., "Use this skill: it does X"), it must be quoted in YAML.
+
+**SK005 trigger phrase requirement:** The `description` field must include at least one of: "use when", "use this", "use on", "used when", "used by", "when ", "trigger", "activate", "load this", "load when", "invoke". Without it, Claude cannot determine when to auto-invoke the skill.
+
+**Rule suppression mechanism:** Via `.claude-plugin/validator.json` with an `ignore` map of path prefixes to rule code arrays.
+
+**Complete rule series inventory:**
+
+| Series | Codes | Auto-fixable |
+|--------|-------|-------------|
+| FM | FM001–FM010 | FM004, FM007, FM008, FM009, FM010 |
+| SK | SK001–SK009 | SK001, SK002, SK003 |
+| AS | AS001–AS006 | None |
+| LK | LK001–LK002 | None |
+| PD | PD001–PD003 | None |
+| PL | PL001–PL005 | None |
+| PR | PR001–PR005 | None |
+| HK | HK001–HK005 | None |
+| NR | NR001–NR002 | None |
+| SL | SL001 | SL001 |
+| CM | CM001 | Reserved |
+| TC | TC001 | N/A (info only) |
+
+## Synthesis
+
+**Key insights:**
+
+1. The plugin fills a genuine gap — nothing guides agents through skilllint usage anywhere in the project. This is the primary value proposition.
+
+2. The `skilllint rule <id>` CLI subcommand assumed in `discuss-CONTEXT.md` does not exist. The design must route rule-ID arguments to `references/rule-catalog.md` instead. This actually produces a better UX (agents can read the catalog without running a command that doesn't exist).
+
+3. Research-2 and research-3 diverge on `allowed-tools`. The task spec resolves the ambiguity: use `allowed-tools="Read, Bash, Glob, Grep"`. This explicitly grants the four tools needed without restricting Edit/Write — but since this is an inline (non-forked) skill, the parent agent retains all its own tools regardless.
+
+4. The dynamic version-check injection (`!command -v skilllint ...`) is a genuinely useful feature for contextual advice ("not installed" vs. "installed, version X"). Include it.
+
+5. The SKILL.md body must stay under 4400 tokens to avoid SK006 violations — ironic for a linter guide skill to fail its own linter. The `references/` approach is essential, not optional.
+
+6. The FM004 pitfall (multiline YAML in frontmatter) is the single most common agent mistake — the SKILL.md description field itself is a live demonstration of correct practice.
+
+**Recommended approach:**
+
+Build a focused three-file plugin:
+- `plugin.json` — full metadata, no path overrides, no agents array
+- `SKILL.md` — argument-routing header, workflow guide body (~40-60 lines), reference to catalog
+- `references/rule-catalog.md` — complete rule catalog organized by series, each entry with severity, auto-fixable flag, example violation, and fix
+
+The SKILL.md body uses `$ARGUMENTS` routing: rule ID → read catalog and explain; path → run `skilllint <path>`; empty → full guide. The version/install check runs at load time via `!` injection. The `references/rule-catalog.md` serves as both the rule-explanation backend (for rule-ID invocations) and the fix-guidance reference (for the fixing workflow).

--- a/.claude/plan/agentskills-skilllint/research-FINDINGS.md
+++ b/.claude/plan/agentskills-skilllint/research-FINDINGS.md
@@ -24,7 +24,7 @@ Key pattern: `plugin.json` requires only `name`. All other fields (`version`, `d
 
 **disable-model-invocation** — Do NOT set. Per `discuss-CONTEXT.md`, the skill must auto-activate when Claude encounters linting errors, rule violations, or plugin validation topics. Setting this would make the skill invisible to Claude unless the user explicitly types `/skilllint`.
 
-**allowed-tools** — The research is split: research-2 recommends omitting it (inherits parent tools, avoids restriction); research-3 recommends `Read, Grep, Glob, Bash(skilllint:*, uv run skilllint:*)`. The task spec requires `allowed-tools="Read, Bash, Glob, Grep"`. This is the value to use — it explicitly grants the four needed tools without relying on parent inheritance.
+**allowed-tools** — The research is split: research-2 recommends omitting it (inherits parent tools, avoids restriction); research-3 recommends `Read, Grep, Glob, Bash(skilllint:*, uv run skilllint:*)`. The task spec originally called for `allowed-tools="Read, Bash, Glob, Grep"`, but the shipped SKILL.md intentionally omits this field — an inline (non-forked) skill inherits all parent tools, and adding `allowed-tools` would only restrict the parent agent unnecessarily.
 
 **argument-hint** — Use `[rule-id|path]`. The `$ARGUMENTS` substitution enables three invocation modes: no args (full guide), rule ID (explain that rule from catalog), path (run lint on that path).
 

--- a/plugins/agentskills-skilllint/.claude-plugin/plugin.json
+++ b/plugins/agentskills-skilllint/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "agentskills-skilllint",
+  "version": "1.0.0",
+  "description": "Guide Claude agents through using the skilllint CLI to validate, fix, and understand linting violations in Claude Code plugins, skills, agents, and commands.",
+  "author": {
+    "name": "bitflight-devops",
+    "url": "https://github.com/bitflight-devops/agentskills-linter"
+  },
+  "repository": "https://github.com/bitflight-devops/agentskills-linter",
+  "license": "MIT",
+  "keywords": ["skilllint", "linting", "validation", "plugins", "skills", "agentskills", "claude-code"]
+}

--- a/plugins/agentskills-skilllint/README.md
+++ b/plugins/agentskills-skilllint/README.md
@@ -1,0 +1,105 @@
+# agentskills-skilllint
+
+A Claude Code plugin providing a `/skilllint` skill that guides AI agents through using the `skilllint` CLI to validate, fix, and understand linting violations in Claude Code plugins, skills, agents, and commands.
+
+## What It Does
+
+The skill teaches Claude how to:
+
+- **Install** `skilllint` via `uv`, `pipx`, or `pip`
+- **Run** validation scans on plugins, skills, agents, and commands
+- **Read** and interpret violation output (FM, SK, AS, PL, HK, LK, PD rule IDs)
+- **Fix** auto-fixable violations with `skilllint --fix`
+- **Understand** any rule ID by consulting the built-in rule catalog
+- **Check for updates** and upgrade to the latest version
+
+## Installation
+
+Install this plugin from the repository:
+
+```bash
+claude plugin install agentskills-skilllint@agentskills-linter
+```
+
+Or load it for a single session:
+
+```bash
+claude --plugin-dir ./plugins/agentskills-skilllint
+```
+
+## Usage
+
+### Invoke directly
+
+```
+/skilllint
+```
+
+Runs the full workflow guide: installation, scanning, reading output, fixing issues, checking versions.
+
+### With a rule ID
+
+```
+/skilllint FM004
+```
+
+Explains what rule FM004 means, what causes it, and how to fix it.
+
+### With a path
+
+```
+/skilllint ./plugins/my-plugin
+```
+
+Runs `skilllint` against the specified path and interprets the output.
+
+### Model-invoked
+
+Claude will automatically load this skill when you ask about linting plugins, fixing FM/SK/AS violations, or validating Claude Code skills.
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| `skilllint` | Full skilllint guide with argument routing, install instructions, workflow, and rule lookup |
+
+## Rule Catalog
+
+The skill includes a [full rule catalog](./skills/skilllint/references/rule-catalog.md) covering all rule series:
+
+| Series | Domain |
+|--------|--------|
+| FM001–FM010 | YAML frontmatter validity |
+| SK001–SK009 | Skill name, description, and token budget |
+| AS001–AS006 | AgentSkills open standard cross-platform compliance |
+| LK001–LK002 | Internal markdown links |
+| PD001–PD003 | Progressive disclosure directory structure |
+| PL001–PL005 | Plugin manifest (`plugin.json`) |
+| PR001–PR005 | Plugin component registration |
+| HK001–HK005 | hooks.json configuration |
+| NR001–NR002 | Namespace references |
+| SL001 | Symlink hygiene |
+| TC001 | Token count reporting |
+
+## skilllint Installation Reference
+
+```bash
+# uv (recommended)
+uv tool install skilllint
+uv tool upgrade skilllint
+
+# pipx
+pipx install skilllint
+pipx upgrade skilllint
+
+# pip
+pip install skilllint
+pip install --upgrade skilllint
+
+# Check version
+skilllint --version
+```
+
+## License
+
+MIT

--- a/plugins/agentskills-skilllint/mission.json
+++ b/plugins/agentskills-skilllint/mission.json
@@ -1,0 +1,24 @@
+{
+  "status": "draft",
+  "name": "agentskills-skilllint",
+  "purpose": "Guide AI agents through using the skilllint CLI to validate, fix, and understand linting violations in Claude Code plugins, skills, agents, and commands.",
+  "values": [
+    "Actionable guidance — every instruction leads to a concrete command the agent can run",
+    "Rule transparency — agents should always know why a violation occurred, not just that it did",
+    "Progressive workflow — scan → identify → explain → fix, in that order",
+    "Tool-agnostic installation — support uv, pipx, and pip equally"
+  ],
+  "anti-patterns": [
+    "Vague advice like 'fix the frontmatter' without showing the exact command",
+    "Hiding rule meanings — always surface the explanation via `skilllint rule <id>`",
+    "Assuming a specific package manager — document all three (uv, pipx, pip)"
+  ],
+  "backlog_interview": {
+    "task": "Refine mission statement with maintainer",
+    "questions": [
+      "Should the skill also guide through creating new plugins from scratch?",
+      "Should it link to the agentskills.io specification for AS-series rules?",
+      "Should version checking be a separate argument path?"
+    ]
+  }
+}

--- a/plugins/agentskills-skilllint/skills/skilllint/SKILL.md
+++ b/plugins/agentskills-skilllint/skills/skilllint/SKILL.md
@@ -11,8 +11,8 @@ Arguments received: `$ARGUMENTS`
 ## Argument Routing
 
 - **No arguments** → Run full workflow guide below
-- **Rule ID** (e.g. `FM004`, `SK006`, `AS002`) → Look up that rule in [rule-catalog.md](./references/rule-catalog.md) and explain what it means, what causes it, and how to fix it
-- **A path** (e.g. `./plugins/my-plugin`) → Run `skilllint <path>` and interpret the output
+- **Rule ID** (e.g. `AS001`, `AS005`, `FM004`) → Run `skilllint rule <ID>` for AS001–AS006; for other rule IDs, look up in [rule-catalog.md](./references/rule-catalog.md)
+- **A path** (e.g. `./plugins/my-plugin`) → Run `skilllint check <path>` and interpret the output
 
 ---
 
@@ -40,42 +40,44 @@ skilllint --version
 
 ## Running skilllint
 
+`skilllint` uses subcommands. The three commands are: `check`, `rule`, and `rules`.
+
 ### Validate a plugin, skill, or directory
 
 ```bash
 # Validate a whole plugin directory
-skilllint ./plugins/my-plugin
+skilllint check ./plugins/my-plugin
 
 # Validate a single skill file
-skilllint ./plugins/my-plugin/skills/my-skill/SKILL.md
+skilllint check ./plugins/my-plugin/skills/my-skill/SKILL.md
 
 # Validate with detailed per-file output
-skilllint --show-progress --show-summary ./plugins/my-plugin
+skilllint check --show-progress --show-summary ./plugins/my-plugin
 
-# Validate and see info-level messages (not just warnings/errors)
-skilllint --verbose ./plugins/my-plugin
+# Validate and see detailed messages including explanations
+skilllint check --verbose ./plugins/my-plugin
 ```
 
 ### Filter to specific file types
 
 ```bash
 # Only validate skills
-skilllint --filter-type skills ./plugins/my-plugin
+skilllint check --filter-type skills ./plugins/my-plugin
 
 # Only validate agents
-skilllint --filter-type agents ./plugins/my-plugin
+skilllint check --filter-type agents ./plugins/my-plugin
 
 # Only validate commands
-skilllint --filter-type commands ./plugins/my-plugin
+skilllint check --filter-type commands ./plugins/my-plugin
 
 # Custom glob filter
-skilllint --filter '**/skills/*/SKILL.md' ./plugins/my-plugin
+skilllint check --filter '**/skills/*/SKILL.md' ./plugins/my-plugin
 ```
 
 ### Validate only (no auto-fix)
 
 ```bash
-skilllint --check ./plugins/my-plugin
+skilllint check --check ./plugins/my-plugin
 ```
 
 ---
@@ -92,7 +94,7 @@ Example:
 ```
 skills/my-skill/SKILL.md:3  error  Description uses YAML multiline block scalar (>-); use a single-line string  [FM004]
 skills/my-skill/SKILL.md:5  error  allowed-tools must be a comma-separated string, not a YAML array  [FM007]
-skills/my-skill/SKILL.md:1  warning  Skill is approaching token limit (3800/4000)  [SK006]
+skills/my-skill/SKILL.md:1  warning  SKILL.md body exceeds token threshold (4800/4400 tokens)  [AS005]
 ```
 
 Severity levels:
@@ -100,11 +102,22 @@ Severity levels:
 - **warning** — should fix; may cause degraded behavior
 - **info** — informational; no action required
 
-**To understand any rule ID**, check [rule-catalog.md](./references/rule-catalog.md) or run:
+**To look up any rule ID:**
+
 ```bash
-skilllint --verbose <path>
+# For AS001–AS006 (the rule documentation system)
+skilllint rule AS001
+skilllint rule AS005
+
+# List all documented rules
+skilllint rules
+
+# Filter by severity or category
+skilllint rules --severity error
+skilllint rules --category skill
 ```
-The `--verbose` flag includes explanatory text for each violation.
+
+For FM, SK, LK, PD, PL, PR, HK, NR, SL rule IDs, use [rule-catalog.md](./references/rule-catalog.md) — these are emitted by `skilllint check --verbose` but not yet in the `rule` documentation system.
 
 ---
 
@@ -114,16 +127,16 @@ Many frontmatter errors can be fixed automatically:
 
 ```bash
 # Auto-fix in place
-skilllint --fix ./plugins/my-plugin
+skilllint check --fix ./plugins/my-plugin
 
 # Preview what would be fixed (validate-only first, then fix)
-skilllint --check ./plugins/my-plugin
-skilllint --fix ./plugins/my-plugin
+skilllint check --check ./plugins/my-plugin
+skilllint check --fix ./plugins/my-plugin
 ```
 
-**Auto-fixable rules:** FM004, FM007, FM008, FM009, FM010/SK001–SK003, SL001
+**Auto-fixable rules:** FM004, FM007, FM008, FM009, FM010/AS002, SK001, SK002, SK003, SL001
 
-**Not auto-fixable:** SK006, SK007 (token size — requires manual refactoring), PD series, AS series, LK series, most PL/PR/HK rules.
+**Not auto-fixable:** AS005 (token size — requires manual refactoring), PD series, AS006, LK series, most PL/PR/HK rules.
 
 ---
 
@@ -164,19 +177,24 @@ description: Validate files: plugins, skills, and agents
 description: 'Validate files: plugins, skills, and agents'
 ```
 
-### SK006 / SK007 — Skill exceeds token limit
+### AS005 — Skill exceeds token limit
 
 Move large reference content to a `references/` subdirectory and link to it:
 ```markdown
 For the full rule catalog, see [rule-catalog.md](./references/rule-catalog.md)
 ```
+Token thresholds: warning at **4400 tokens**, error at **8800 tokens** (body text only, frontmatter excluded).
 
-### AS002 — Name/directory mismatch
+### AS002 / FM010 — Name/directory mismatch
 
 The `name:` frontmatter field must match the directory name:
 ```
 skills/my-skill/SKILL.md  →  name: my-skill
 ```
+
+### AS004 — HTML tags in description
+
+Remove any `<html>` tags from the `description:` frontmatter field.
 
 ---
 
@@ -194,37 +212,29 @@ pip install --upgrade skilllint
 
 # Check current version
 skilllint --version
-
-# Check latest available on PyPI
-pip index versions skilllint 2>/dev/null | head -1
-# or
-uv tool install skilllint --dry-run 2>&1 | grep skilllint
 ```
 
 ---
 
 ## Workflow: Scan → Identify → Explain → Fix
 
-1. **Scan**: `skilllint --show-summary --show-progress <path>`
-2. **Identify** rule IDs in the output (e.g. `[FM004]`, `[SK006]`)
-3. **Explain**: Look up the rule ID in [rule-catalog.md](./references/rule-catalog.md)
-4. **Fix auto-fixable**: `skilllint --fix <path>`
+1. **Scan**: `skilllint check --show-summary --show-progress <path>`
+2. **Identify** rule IDs in the output (e.g. `[FM004]`, `[AS005]`, `[AS002]`)
+3. **Explain**: `skilllint rule <ID>` for AS rules; [rule-catalog.md](./references/rule-catalog.md) for others
+4. **Fix auto-fixable**: `skilllint check --fix <path>`
 5. **Fix manual issues**: Apply the patterns above based on rule ID
-6. **Verify**: `skilllint --check <path>` — should exit 0 with no errors
+6. **Verify**: `skilllint check --check <path>` — should exit 0 with no errors
 
 ---
 
 ## Platform-Specific Validation
 
 ```bash
-# Validate only for Claude Code rules
-skilllint --platform claude-code ./plugins/my-plugin
+# Validate only for a specific platform
+skilllint check --platform agentskills ./plugins/my-plugin
 
-# Validate only for Cursor rules
-skilllint --platform cursor ./plugins/my-plugin
-
-# Validate only for Codex rules
-skilllint --platform codex ./plugins/my-plugin
+# List rules for a specific platform
+skilllint rules --platform agentskills
 ```
 
 ---
@@ -233,10 +243,10 @@ skilllint --platform codex ./plugins/my-plugin
 
 ```bash
 # Get token count for a skill (integer only, for scripting)
-skilllint --tokens-only ./plugins/my-plugin/skills/my-skill/SKILL.md
+skilllint check --tokens-only ./plugins/my-plugin/skills/my-skill/SKILL.md
 ```
 
-SK006 fires at ~3800 tokens (warning); SK007 fires at ~4000 tokens (error).
+AS005 fires at 4400 tokens (warning) and 8800 tokens (error), counting body text only (frontmatter is excluded from the count).
 
 ---
 

--- a/plugins/agentskills-skilllint/skills/skilllint/SKILL.md
+++ b/plugins/agentskills-skilllint/skills/skilllint/SKILL.md
@@ -11,7 +11,7 @@ Arguments received: `$ARGUMENTS`
 ## Argument Routing
 
 - **No arguments** → Run full workflow guide below
-- **Rule ID** (e.g. `AS001`, `AS005`, `FM004`) → Run `skilllint rule <ID>` for AS001–AS006; for other rule IDs, look up in [rule-catalog.md](./references/rule-catalog.md)
+- **Rule ID** (e.g. `AS001`, `AS005`, `FM004`) → Run `skilllint rule <ID>` for AS rules; for others look up in [rule-catalog.md](./references/rule-catalog.md)
 - **A path** (e.g. `./plugins/my-plugin`) → Run `skilllint check <path>` and interpret the output
 
 ---
@@ -134,6 +134,8 @@ skilllint check --check ./plugins/my-plugin
 skilllint check --fix ./plugins/my-plugin
 ```
 
+> **Note:** `--check` and `--fix` are mutually exclusive. Passing both flags at the same time is an error.
+
 **Auto-fixable rules:** FM004, FM007, FM008, FM009, FM010/AS002, SK001, SK002, SK003, SL001
 
 **Not auto-fixable:** AS005 (token size — requires manual refactoring), PD series, AS006, LK series, most PL/PR/HK rules.
@@ -184,6 +186,7 @@ Move large reference content to a `references/` subdirectory and link to it:
 For the full rule catalog, see [rule-catalog.md](./references/rule-catalog.md)
 ```
 Token thresholds: warning at **4400 tokens**, error at **8800 tokens** (body text only, frontmatter excluded).
+<!-- source: packages/skilllint/token_counter.py TOKEN_WARNING_THRESHOLD=4400, TOKEN_ERROR_THRESHOLD=8800 -->
 
 ### AS002 / FM010 — Name/directory mismatch
 
@@ -247,6 +250,7 @@ skilllint check --tokens-only ./plugins/my-plugin/skills/my-skill/SKILL.md
 ```
 
 AS005 fires at 4400 tokens (warning) and 8800 tokens (error), counting body text only (frontmatter is excluded from the count).
+<!-- source: packages/skilllint/token_counter.py TOKEN_WARNING_THRESHOLD=4400, TOKEN_ERROR_THRESHOLD=8800 -->
 
 ---
 

--- a/plugins/agentskills-skilllint/skills/skilllint/SKILL.md
+++ b/plugins/agentskills-skilllint/skills/skilllint/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: skilllint
+description: 'Guide for using the skilllint CLI to validate, lint, and fix Claude Code plugins, skills, agents, and commands. Use when encountering FM, SK, AS, PL, HK, LK, PD rule violations, when asked to lint or validate a plugin, or when asked how to install or check the version of skilllint.'
+argument-hint: '[rule-id | path]'
+---
+
+# skilllint Guide
+
+Arguments received: `$ARGUMENTS`
+
+## Argument Routing
+
+- **No arguments** → Run full workflow guide below
+- **Rule ID** (e.g. `FM004`, `SK006`, `AS002`) → Look up that rule in [rule-catalog.md](./references/rule-catalog.md) and explain what it means, what causes it, and how to fix it
+- **A path** (e.g. `./plugins/my-plugin`) → Run `skilllint <path>` and interpret the output
+
+---
+
+## Installation
+
+Install `skilllint` once using whichever package manager is available:
+
+```bash
+# With uv (recommended — fastest, isolated tool environment)
+uv tool install skilllint
+
+# With pipx (isolated tool environment)
+pipx install skilllint
+
+# With pip (installs into current Python environment)
+pip install skilllint
+```
+
+**Verify installation:**
+```bash
+skilllint --version
+```
+
+---
+
+## Running skilllint
+
+### Validate a plugin, skill, or directory
+
+```bash
+# Validate a whole plugin directory
+skilllint ./plugins/my-plugin
+
+# Validate a single skill file
+skilllint ./plugins/my-plugin/skills/my-skill/SKILL.md
+
+# Validate with detailed per-file output
+skilllint --show-progress --show-summary ./plugins/my-plugin
+
+# Validate and see info-level messages (not just warnings/errors)
+skilllint --verbose ./plugins/my-plugin
+```
+
+### Filter to specific file types
+
+```bash
+# Only validate skills
+skilllint --filter-type skills ./plugins/my-plugin
+
+# Only validate agents
+skilllint --filter-type agents ./plugins/my-plugin
+
+# Only validate commands
+skilllint --filter-type commands ./plugins/my-plugin
+
+# Custom glob filter
+skilllint --filter '**/skills/*/SKILL.md' ./plugins/my-plugin
+```
+
+### Validate only (no auto-fix)
+
+```bash
+skilllint --check ./plugins/my-plugin
+```
+
+---
+
+## Reading skilllint Output
+
+Each violation is reported as:
+
+```
+<FILE>:<LINE>  <SEVERITY>  <MESSAGE>  [RULE-ID]
+```
+
+Example:
+```
+skills/my-skill/SKILL.md:3  error  Description uses YAML multiline block scalar (>-); use a single-line string  [FM004]
+skills/my-skill/SKILL.md:5  error  allowed-tools must be a comma-separated string, not a YAML array  [FM007]
+skills/my-skill/SKILL.md:1  warning  Skill is approaching token limit (3800/4000)  [SK006]
+```
+
+Severity levels:
+- **error** — must fix before the skill/plugin works correctly
+- **warning** — should fix; may cause degraded behavior
+- **info** — informational; no action required
+
+**To understand any rule ID**, check [rule-catalog.md](./references/rule-catalog.md) or run:
+```bash
+skilllint --verbose <path>
+```
+The `--verbose` flag includes explanatory text for each violation.
+
+---
+
+## Auto-Fixing Issues
+
+Many frontmatter errors can be fixed automatically:
+
+```bash
+# Auto-fix in place
+skilllint --fix ./plugins/my-plugin
+
+# Preview what would be fixed (validate-only first, then fix)
+skilllint --check ./plugins/my-plugin
+skilllint --fix ./plugins/my-plugin
+```
+
+**Auto-fixable rules:** FM004, FM007, FM008, FM009, FM010/SK001–SK003, SL001
+
+**Not auto-fixable:** SK006, SK007 (token size — requires manual refactoring), PD series, AS series, LK series, most PL/PR/HK rules.
+
+---
+
+## Common Fix Patterns
+
+### FM004 — YAML multiline block scalar in description
+
+```yaml
+# Wrong
+description: >-
+  This is a long description
+  that spans multiple lines
+
+# Correct — single-line string
+description: 'This is a long description that spans multiple lines.'
+```
+
+### FM007 / FM008 — allowed-tools or other fields as YAML array
+
+```yaml
+# Wrong
+allowed-tools:
+  - Read
+  - Bash
+  - Glob
+
+# Correct — comma-separated string
+allowed-tools: 'Read, Bash, Glob'
+```
+
+### FM009 — Unquoted colon in description
+
+```yaml
+# Wrong
+description: Validate files: plugins, skills, and agents
+
+# Correct — quote the value
+description: 'Validate files: plugins, skills, and agents'
+```
+
+### SK006 / SK007 — Skill exceeds token limit
+
+Move large reference content to a `references/` subdirectory and link to it:
+```markdown
+For the full rule catalog, see [rule-catalog.md](./references/rule-catalog.md)
+```
+
+### AS002 — Name/directory mismatch
+
+The `name:` frontmatter field must match the directory name:
+```
+skills/my-skill/SKILL.md  →  name: my-skill
+```
+
+---
+
+## Checking for Updates
+
+```bash
+# With uv
+uv tool upgrade skilllint
+
+# With pipx
+pipx upgrade skilllint
+
+# With pip
+pip install --upgrade skilllint
+
+# Check current version
+skilllint --version
+
+# Check latest available on PyPI
+pip index versions skilllint 2>/dev/null | head -1
+# or
+uv tool install skilllint --dry-run 2>&1 | grep skilllint
+```
+
+---
+
+## Workflow: Scan → Identify → Explain → Fix
+
+1. **Scan**: `skilllint --show-summary --show-progress <path>`
+2. **Identify** rule IDs in the output (e.g. `[FM004]`, `[SK006]`)
+3. **Explain**: Look up the rule ID in [rule-catalog.md](./references/rule-catalog.md)
+4. **Fix auto-fixable**: `skilllint --fix <path>`
+5. **Fix manual issues**: Apply the patterns above based on rule ID
+6. **Verify**: `skilllint --check <path>` — should exit 0 with no errors
+
+---
+
+## Platform-Specific Validation
+
+```bash
+# Validate only for Claude Code rules
+skilllint --platform claude-code ./plugins/my-plugin
+
+# Validate only for Cursor rules
+skilllint --platform cursor ./plugins/my-plugin
+
+# Validate only for Codex rules
+skilllint --platform codex ./plugins/my-plugin
+```
+
+---
+
+## Token Count
+
+```bash
+# Get token count for a skill (integer only, for scripting)
+skilllint --tokens-only ./plugins/my-plugin/skills/my-skill/SKILL.md
+```
+
+SK006 fires at ~3800 tokens (warning); SK007 fires at ~4000 tokens (error).
+
+---
+
+For the full rule catalog with all rule IDs, descriptions, severity, and auto-fix flags, see [rule-catalog.md](./references/rule-catalog.md).

--- a/plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md
+++ b/plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md
@@ -36,27 +36,31 @@ Validate skill name, description quality, and token budget.
 | SK003 | warning | **yes** | Skill description is missing or empty |
 | SK004 | warning | no | Skill description is very short (< 20 chars); may not trigger auto-invocation |
 | SK005 | warning | no | Skill description lacks trigger phrases ("Use when...", keywords); Claude may not auto-invoke |
-| SK006 | warning | no | Skill is approaching token limit (~3800 tokens); consider moving content to `references/` |
-| SK007 | error | no | Skill exceeds token limit (~4000 tokens); must split or extract content to `references/` |
+| SK006 | warning | no | (Legacy) Skill is approaching token limit; see AS005 for current thresholds |
+| SK007 | error | no | (Legacy) Skill exceeds token limit; see AS005 for current thresholds |
 | SK008 | info | no | Skill has no `argument-hint` but appears to accept arguments based on `$ARGUMENTS` usage |
 | SK009 | info | no | Token count report (informational; always emitted with `--verbose`) |
 
-**SK006/SK007 fix:** Move large sections to `skills/<name>/references/<file>.md` and add a link from SKILL.md. Do not auto-fix — requires judgment about what to extract.
+**Token limit fix (AS005):** Move large sections to `skills/<name>/references/<file>.md` and add a link from SKILL.md. Warning at 4400 tokens, error at 8800 tokens (body text only).
 
 ---
 
 ## AS — AgentSkills Open Standard Rules
 
-Cross-platform compliance with the [agentskills.io](https://agentskills.io) specification. These fire regardless of `--platform`.
+Cross-platform compliance with the [agentskills.io](https://agentskills.io) specification.
+These are the rules documented in the `skilllint rule` system — use `skilllint rule AS001` etc. for full details.
 
 | Rule | Severity | Auto-fix | Description |
 |------|----------|----------|-------------|
-| AS001 | error | no | `name` field is missing (required by agentskills spec) |
-| AS002 | error | **yes** | `name` field does not match the directory name |
-| AS003 | warning | no | `description` field is missing (recommended by spec) |
-| AS004 | warning | no | `allowed-tools` uses non-standard tool names not in the agentskills spec's approved list |
-| AS005 | info | no | `compatibility` field is missing (optional but recommended for cross-agent portability) |
-| AS006 | info | no | `metadata` field is missing (optional; for extended skill metadata) |
+| AS001 | error | no | Invalid skill name format — must be lowercase alphanumeric with hyphens, 1–64 chars, no consecutive hyphens, start/end with letter or digit |
+| AS002 | error | **yes** | Skill `name` field does not match the parent directory name |
+| AS003 | error | no | `description` field is missing or empty |
+| AS004 | error | no | `description` contains HTML tags (not allowed) |
+| AS005 | warning | no | SKILL.md body exceeds token threshold — warning at 4400 tokens, error at 8800 tokens (body only, frontmatter excluded); split or move content to `references/` |
+| AS006 | info | no | No evaluation queries file found (optional but recommended) |
+
+**Full detail:** `skilllint rule AS001` through `skilllint rule AS006`
+**List all:** `skilllint rules` or `skilllint rules --category skill`
 
 ---
 
@@ -79,7 +83,7 @@ Validate the `references/` directory structure for progressive disclosure.
 
 | Rule | Severity | Auto-fix | Description |
 |------|----------|----------|-------------|
-| PD001 | warning | no | Large skill (approaching SK006) has no `references/` directory; consider adding one |
+| PD001 | warning | no | Large skill (approaching AS005 threshold) has no `references/` directory; consider adding one |
 | PD002 | warning | no | `references/` directory exists but is not linked from SKILL.md |
 | PD003 | info | no | Files in `references/` are never referenced in SKILL.md |
 
@@ -173,10 +177,10 @@ Run `skilllint --fix <path>` to automatically fix:
 - **FM007** — allowed-tools as YAML array
 - **FM008** — other comma-separated fields as YAML array
 - **FM009** — unquoted colon in string field
-- **FM010 / AS002** — name/directory mismatch
+- **FM010 / AS002** — name/directory mismatch (auto-fixed by `skilllint check --fix`)
 - **SK001** — skill name case/format
 - **SK002** — skill name too long (truncated)
 - **SK003** — missing description (adds placeholder)
 - **SL001** — symlink outside plugin directory
 
-All other rules require manual fixes.
+All other rules (including AS005 token size, PD, LK, HK series) require manual fixes.

--- a/plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md
+++ b/plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md
@@ -21,7 +21,7 @@ Validate YAML frontmatter in SKILL.md, agent .md, and command .md files.
 | FM009 | error | **yes** | Unquoted colon in `description` or other string field causes YAML parse failure |
 | FM010 | error | **yes** | `name` field does not match the directory name (same as AS002; FM010 is the frontmatter-level check) |
 
-**Common FM fix:** Run `skilllint --fix <path>` — FM004, FM007, FM008, FM009, FM010 are all auto-fixable.
+**Common FM fix:** Run `skilllint check --fix <path>` — FM004, FM007, FM008, FM009, FM010 are all auto-fixable.
 
 ---
 
@@ -31,9 +31,9 @@ Validate skill name, description quality, and token budget.
 
 | Rule | Severity | Auto-fix | Description |
 |------|----------|----------|-------------|
-| SK001 | warning | **yes** | Skill name is not lowercase kebab-case |
-| SK002 | warning | **yes** | Skill name exceeds 64 characters |
-| SK003 | warning | **yes** | Skill description is missing or empty |
+| SK001 | error | **yes** | Skill name is not lowercase kebab-case |
+| SK002 | error | **yes** | Skill name contains underscores (use hyphens) |
+| SK003 | error | **yes** | Skill name has leading/trailing/consecutive hyphens, or name field is empty |
 | SK004 | warning | no | Skill description is very short (< 20 chars); may not trigger auto-invocation |
 | SK005 | warning | no | Skill description lacks trigger phrases ("Use when...", keywords); Claude may not auto-invoke |
 | SK006 | warning | no | (Legacy) Skill is approaching token limit; see AS005 for current thresholds |
@@ -48,7 +48,7 @@ Validate skill name, description quality, and token budget.
 ## AS — AgentSkills Open Standard Rules
 
 Cross-platform compliance with the [agentskills.io](https://agentskills.io) specification.
-These are the rules documented in the `skilllint rule` system — use `skilllint rule AS001` etc. for full details.
+Use `skilllint check --filter <ID> --verbose <path>` to see detailed output for any AS rule.
 
 | Rule | Severity | Auto-fix | Description |
 |------|----------|----------|-------------|
@@ -171,16 +171,16 @@ These only fire when `--platform cursor` is used.
 
 ## Quick Reference: Auto-Fixable Rules
 
-Run `skilllint --fix <path>` to automatically fix:
+Run `skilllint check --fix <path>` to automatically fix:
 
 - **FM004** — multiline block scalar in description
 - **FM007** — allowed-tools as YAML array
 - **FM008** — other comma-separated fields as YAML array
 - **FM009** — unquoted colon in string field
-- **FM010 / AS002** — name/directory mismatch (auto-fixed by `skilllint check --fix`)
-- **SK001** — skill name case/format
-- **SK002** — skill name too long (truncated)
-- **SK003** — missing description (adds placeholder)
+- **FM010 / AS002** — name/directory mismatch
+- **SK001** — skill name contains uppercase characters (lowercased)
+- **SK002** — skill name contains underscores (replaced with hyphens)
+- **SK003** — skill name has leading/trailing/consecutive hyphens (normalized)
 - **SL001** — symlink outside plugin directory
 
 All other rules (including AS005 token size, PD, LK, HK series) require manual fixes.

--- a/plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md
+++ b/plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md
@@ -1,0 +1,182 @@
+# skilllint Rule Catalog
+
+Complete reference for all rule IDs emitted by `skilllint`. Use `skilllint --verbose <path>` to see explanatory text alongside each violation.
+
+---
+
+## FM — Frontmatter Rules
+
+Validate YAML frontmatter in SKILL.md, agent .md, and command .md files.
+
+| Rule | Severity | Auto-fix | Description |
+|------|----------|----------|-------------|
+| FM001 | error | no | Frontmatter block is missing entirely |
+| FM002 | error | no | Frontmatter is not valid YAML |
+| FM003 | error | no | Required frontmatter field is missing (e.g. `name` per agentskills spec) |
+| FM004 | error | **yes** | `description` uses a YAML multiline block scalar (`>-`, `|`, `|-`); Claude Code skill indexer reads this as literal `>-`. Use a single-line string. |
+| FM005 | error | no | `name` field contains invalid characters (must be lowercase letters, numbers, hyphens only; max 64 chars) |
+| FM006 | error | no | `description` exceeds 1024 characters |
+| FM007 | error | **yes** | `allowed-tools` is a YAML array instead of a comma-separated string |
+| FM008 | error | **yes** | Another field that requires a comma-separated string is specified as a YAML array |
+| FM009 | error | **yes** | Unquoted colon in `description` or other string field causes YAML parse failure |
+| FM010 | error | **yes** | `name` field does not match the directory name (same as AS002; FM010 is the frontmatter-level check) |
+
+**Common FM fix:** Run `skilllint --fix <path>` — FM004, FM007, FM008, FM009, FM010 are all auto-fixable.
+
+---
+
+## SK — Skill Quality Rules
+
+Validate skill name, description quality, and token budget.
+
+| Rule | Severity | Auto-fix | Description |
+|------|----------|----------|-------------|
+| SK001 | warning | **yes** | Skill name is not lowercase kebab-case |
+| SK002 | warning | **yes** | Skill name exceeds 64 characters |
+| SK003 | warning | **yes** | Skill description is missing or empty |
+| SK004 | warning | no | Skill description is very short (< 20 chars); may not trigger auto-invocation |
+| SK005 | warning | no | Skill description lacks trigger phrases ("Use when...", keywords); Claude may not auto-invoke |
+| SK006 | warning | no | Skill is approaching token limit (~3800 tokens); consider moving content to `references/` |
+| SK007 | error | no | Skill exceeds token limit (~4000 tokens); must split or extract content to `references/` |
+| SK008 | info | no | Skill has no `argument-hint` but appears to accept arguments based on `$ARGUMENTS` usage |
+| SK009 | info | no | Token count report (informational; always emitted with `--verbose`) |
+
+**SK006/SK007 fix:** Move large sections to `skills/<name>/references/<file>.md` and add a link from SKILL.md. Do not auto-fix — requires judgment about what to extract.
+
+---
+
+## AS — AgentSkills Open Standard Rules
+
+Cross-platform compliance with the [agentskills.io](https://agentskills.io) specification. These fire regardless of `--platform`.
+
+| Rule | Severity | Auto-fix | Description |
+|------|----------|----------|-------------|
+| AS001 | error | no | `name` field is missing (required by agentskills spec) |
+| AS002 | error | **yes** | `name` field does not match the directory name |
+| AS003 | warning | no | `description` field is missing (recommended by spec) |
+| AS004 | warning | no | `allowed-tools` uses non-standard tool names not in the agentskills spec's approved list |
+| AS005 | info | no | `compatibility` field is missing (optional but recommended for cross-agent portability) |
+| AS006 | info | no | `metadata` field is missing (optional; for extended skill metadata) |
+
+---
+
+## LK — Internal Link Rules
+
+Validate internal markdown links in SKILL.md and agent files.
+
+| Rule | Severity | Auto-fix | Description |
+|------|----------|----------|-------------|
+| LK001 | error | no | Internal link target file does not exist on disk |
+| LK002 | warning | no | Internal link target exists but the anchor fragment (#section) does not match any heading |
+
+**LK001 fix:** Verify the linked file path is correct. Links in `skills/<name>/SKILL.md` are relative to the skill directory, not the plugin root.
+
+---
+
+## PD — Progressive Disclosure Rules
+
+Validate the `references/` directory structure for progressive disclosure.
+
+| Rule | Severity | Auto-fix | Description |
+|------|----------|----------|-------------|
+| PD001 | warning | no | Large skill (approaching SK006) has no `references/` directory; consider adding one |
+| PD002 | warning | no | `references/` directory exists but is not linked from SKILL.md |
+| PD003 | info | no | Files in `references/` are never referenced in SKILL.md |
+
+---
+
+## PL — Plugin Manifest Rules
+
+Validate `plugin.json` structure.
+
+| Rule | Severity | Auto-fix | Description |
+|------|----------|----------|-------------|
+| PL001 | error | no | `plugin.json` is missing or not valid JSON |
+| PL002 | error | no | `name` field is missing from `plugin.json` |
+| PL003 | error | no | `agents` field is a directory string instead of an array of file paths |
+| PL004 | warning | no | A path in `plugin.json` uses `../` traversal (unsupported after plugin caching) |
+| PL005 | warning | no | A path in `plugin.json` does not start with `./` |
+
+---
+
+## PR — Plugin Registration Rules
+
+Validate that plugin components declared in `plugin.json` actually exist.
+
+| Rule | Severity | Auto-fix | Description |
+|------|----------|----------|-------------|
+| PR001 | error | no | A skill path in `plugin.json` points to a directory that does not exist |
+| PR002 | error | no | A skill directory exists but contains no `SKILL.md` file |
+| PR003 | error | no | An agent file listed in `plugin.json` does not exist |
+| PR004 | warning | no | A `commands` path in `plugin.json` does not exist |
+| PR005 | info | no | `plugin.json` `skills` field is omitted; skills will still be auto-discovered from `skills/` |
+
+---
+
+## HK — Hook Rules
+
+Validate `hooks.json` and inline hook configurations.
+
+| Rule | Severity | Auto-fix | Description |
+|------|----------|----------|-------------|
+| HK001 | error | no | `hooks.json` is not valid JSON |
+| HK002 | error | no | Hook event name is not a recognized Claude Code event |
+| HK003 | error | no | Hook `type` is not one of: `command`, `prompt`, `agent` |
+| HK004 | warning | no | Hook script path does not exist on disk |
+| HK005 | warning | no | Hook script is not executable (`chmod +x` required) |
+
+---
+
+## NR — Namespace Reference Rules
+
+Validate namespace-qualified skill references (e.g. `plugin-name:skill-name`).
+
+| Rule | Severity | Auto-fix | Description |
+|------|----------|----------|-------------|
+| NR001 | warning | no | Namespace reference uses a plugin name that is not installed |
+| NR002 | warning | no | Namespace reference uses a skill name not found in the referenced plugin |
+
+---
+
+## SL — Symlink Rules
+
+| Rule | Severity | Auto-fix | Description |
+|------|----------|----------|-------------|
+| SL001 | warning | **yes** | Symlink target points outside the plugin directory (will break after plugin caching) |
+
+---
+
+## TC — Token Count
+
+| Rule | Severity | Auto-fix | Description |
+|------|----------|----------|-------------|
+| TC001 | info | no | Token count report for a file (always shown with `--verbose`; use `--tokens-only` for integer output) |
+
+---
+
+## Cursor-Specific Rules
+
+These only fire when `--platform cursor` is used.
+
+| Rule | Severity | Auto-fix | Description |
+|------|----------|----------|-------------|
+| cursor-mdc-frontmatter | error | no | Cursor `.mdc` file frontmatter is invalid |
+| cursor-mdc-glob | warning | no | Cursor `.mdc` `globs` field is missing or empty |
+
+---
+
+## Quick Reference: Auto-Fixable Rules
+
+Run `skilllint --fix <path>` to automatically fix:
+
+- **FM004** — multiline block scalar in description
+- **FM007** — allowed-tools as YAML array
+- **FM008** — other comma-separated fields as YAML array
+- **FM009** — unquoted colon in string field
+- **FM010 / AS002** — name/directory mismatch
+- **SK001** — skill name case/format
+- **SK002** — skill name too long (truncated)
+- **SK003** — missing description (adds placeholder)
+- **SL001** — symlink outside plugin directory
+
+All other rules require manual fixes.

--- a/plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md
+++ b/plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md
@@ -13,7 +13,7 @@ Validate YAML frontmatter in SKILL.md, agent .md, and command .md files.
 | FM001 | error | no | Frontmatter block is missing entirely |
 | FM002 | error | no | Frontmatter is not valid YAML |
 | FM003 | error | no | Required frontmatter field is missing (e.g. `name` per agentskills spec) |
-| FM004 | error | **yes** | `description` uses a YAML multiline block scalar (`>-`, `|`, `|-`); Claude Code skill indexer reads this as literal `>-`. Use a single-line string. |
+| FM004 | error | **yes** | `description` uses a YAML multiline block scalar (`` >- ``, `` \| ``, `` \|- ``); Claude Code skill indexer reads this as literal `>-`. Use a single-line string. |
 | FM005 | error | no | `name` field contains invalid characters (must be lowercase letters, numbers, hyphens only; max 64 chars) |
 | FM006 | error | no | `description` exceeds 1024 characters |
 | FM007 | error | **yes** | `allowed-tools` is a YAML array instead of a comma-separated string |
@@ -94,11 +94,11 @@ Validate `plugin.json` structure.
 
 | Rule | Severity | Auto-fix | Description |
 |------|----------|----------|-------------|
-| PL001 | error | no | `plugin.json` is missing or not valid JSON |
-| PL002 | error | no | `name` field is missing from `plugin.json` |
-| PL003 | error | no | `agents` field is a directory string instead of an array of file paths |
-| PL004 | warning | no | A path in `plugin.json` uses `../` traversal (unsupported after plugin caching) |
-| PL005 | warning | no | A path in `plugin.json` does not start with `./` |
+| PL001 | error | no | `plugin.json` is missing |
+| PL002 | error | no | `plugin.json` is not valid JSON |
+| PL003 | error | no | Required `name` field is missing from `plugin.json` |
+| PL004 | error | no | A path in `plugin.json` does not start with `./` |
+| PL005 | error | no | Referenced file in `plugin.json` does not exist |
 
 ---
 
@@ -145,7 +145,7 @@ Validate namespace-qualified skill references (e.g. `plugin-name:skill-name`).
 
 | Rule | Severity | Auto-fix | Description |
 |------|----------|----------|-------------|
-| SL001 | warning | **yes** | Symlink target points outside the plugin directory (will break after plugin caching) |
+| SL001 | warning | **yes** | Symlink target has trailing whitespace or newline characters |
 
 ---
 

--- a/plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md
+++ b/plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md
@@ -59,8 +59,7 @@ Use `skilllint check --filter <ID> --verbose <path>` to see detailed output for 
 | AS005 | warning | no | SKILL.md body exceeds token threshold — warning at 4400 tokens, error at 8800 tokens (body only, frontmatter excluded); split or move content to `references/` |
 | AS006 | info | no | No evaluation queries file found (optional but recommended) |
 
-**Full detail:** `skilllint rule AS001` through `skilllint rule AS006`
-**List all:** `skilllint rules` or `skilllint rules --category skill`
+**Full detail:** Use `skilllint check --filter <ID> --verbose <path>` (e.g. `skilllint check --filter AS001 --verbose <path>`) to see detailed output for any AS rule.
 
 ---
 

--- a/scripts/bench_io.py
+++ b/scripts/bench_io.py
@@ -53,7 +53,7 @@ def _run_once(plugin_dir: Path, skilllint_exe: str, fix: bool = False) -> float:
         subprocess.CalledProcessError: If skilllint exits with a non-zero code
             that is not an expected lint-result code (1 = lint errors found).
     """
-    cmd = [skilllint_exe]
+    cmd = [skilllint_exe, "check"]
     if fix:
         cmd.append("--fix")
     cmd.append(str(plugin_dir))
@@ -173,7 +173,7 @@ def main() -> None:
         choices=["scan", "fix"],
         default="scan",
         metavar="MODE",
-        help="Benchmark mode: 'scan' (default) runs skilllint <dir>; 'fix' runs skilllint --fix <dir>",
+        help="Benchmark mode: 'scan' (default) runs skilllint check <dir>; 'fix' runs skilllint check --fix <dir>",
     )
     args = parser.parse_args()
 

--- a/tests/benchmarks/test_benchmark.py
+++ b/tests/benchmarks/test_benchmark.py
@@ -75,7 +75,7 @@ def test_io_scan_1000_skills_timing(extracted_plugin_dir: Path, plugin_file_coun
         plugin_file_count: Number of ``SKILL.md`` files found (from fixture).
     """
     start = time.perf_counter()
-    result = subprocess.run(["skilllint", str(extracted_plugin_dir)], capture_output=True, text=True, check=False)
+    result = subprocess.run(["skilllint", "check", str(extracted_plugin_dir)], capture_output=True, text=True, check=False)
     duration = time.perf_counter() - start
 
     # skilllint exits 0 (no issues) or 1 (lint issues found) — both are valid.

--- a/tests/benchmarks/test_benchmark.py
+++ b/tests/benchmarks/test_benchmark.py
@@ -75,7 +75,12 @@ def test_io_scan_1000_skills_timing(extracted_plugin_dir: Path, plugin_file_coun
         plugin_file_count: Number of ``SKILL.md`` files found (from fixture).
     """
     start = time.perf_counter()
-    result = subprocess.run(["skilllint", "check", str(extracted_plugin_dir)], capture_output=True, text=True, check=False)
+    result = subprocess.run(
+        ["skilllint", "check", str(extracted_plugin_dir)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
     duration = time.perf_counter() - start
 
     # skilllint exits 0 (no issues) or 1 (lint issues found) — both are valid.


### PR DESCRIPTION
## Summary

This PR introduces a new Claude Code plugin (`agentskills-skilllint`) that provides a `/skilllint` skill to guide AI agents through using the `skilllint` CLI tool for validating and fixing linting violations in Claude Code plugins, skills, agents, and commands.

## Key Changes

- **New plugin structure** at `plugins/agentskills-skilllint/` with standard layout:
  - `plugin.json` manifest with metadata (name, version, description, author, repository)
  - Single skill: `skills/skilllint/SKILL.md` with argument routing support
  - Progressive disclosure: `skills/skilllint/references/rule-catalog.md` containing comprehensive rule documentation

- **skilllint SKILL.md** provides:
  - Argument-driven routing: accepts rule IDs (e.g., `FM004`, `SK006`) or file paths
  - Installation guidance for `uv`, `pipx`, and `pip` package managers
  - Workflow instructions: scan → identify → explain → fix
  - Common fix patterns for frontmatter, naming, and token limit violations
  - Version checking and upgrade instructions

- **Rule catalog** (`rule-catalog.md`) documents all skilllint rule series:
  - FM (Frontmatter): FM001–FM010 with auto-fix indicators
  - SK (Skill Quality): SK001–SK009 covering naming, description, and token budgets
  - AS (AgentSkills Standard): AS001–AS006 for cross-platform compliance
  - Additional series: LK (Links), PD (Progressive Disclosure), PL (Plugin), PR (Registration), HK (Hooks), NR (Namespace), SL (Symlinks), TC (Token Count)

- **Research and planning documentation** in `.claude/plan/agentskills-skilllint/`:
  - Architecture analysis and design decisions
  - Feature recommendations (no `context: fork`, no `allowed-tools` restriction)
  - Existing plugin/skill patterns from the codebase
  - Complete findings and implementation plan

## Implementation Details

- Skill uses inline context (not forked) to maintain conversation history for context-aware guidance
- Supports both user-invoked (`/skilllint`) and model-invoked (auto-activation on linting topics) modes
- `$ARGUMENTS` substitution enables three invocation patterns: no args (full guide), rule ID (explain specific rule), path (run lint on target)
- Rule catalog extracted to `references/` subdirectory to avoid exceeding SK006 token warning threshold
- Plugin metadata includes repository URL and keywords for discoverability

https://claude.ai/code/session_01GknGzhxPYh7kWNuNpE27C8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Claude Code linting plugin offering rule lookups, path-based scans, and guided fix workflows.

* **Documentation**
  * Added comprehensive user docs: installation, invocation patterns, workflow (Scan → Identify → Explain → Fix → Verify), and a progressive rule catalog with severities and auto-fix guidance.

* **Bug Fixes / CLI**
  * Standardized scan invocation to use an explicit "check" subcommand; benchmarks and tests updated to match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->