### PR TITLE
feat: replace python-frontmatter with native frontmatter.py

### DIFF
--- a/.claude/plan/agentskills-skilllint/discuss-CONTEXT.md
+++ b/.claude/plan/agentskills-skilllint/discuss-CONTEXT.md
@@ -16,7 +16,7 @@ Date: 2026-03-13
 - Installation section covers: uv, pipx, pip
 - Version checking: cover `uv tool upgrade skilllint`, `pipx upgrade skilllint`, `pip install --upgrade skilllint`
 - The `skilllint rule <rule-id>` pattern: document how to look up rule explanations in the CLI
-- Fix workflow: scan → identify rule IDs → `skilllint rule <id>` for explanation → `skilllint --fix` for auto-fixable issues
+- Fix workflow: scan → identify rule IDs → `skilllint rule <id>` for explanation → `skilllint check --fix` for auto-fixable issues
 - Rule categories to cover: FM-series (frontmatter), SK-series (skill structure/tokens), AS-series (agentskills standard)
 - Progressive disclosure: inline rule reference in the skill; separate references/ file for full rule catalog
 - Plugin structure: single skill, no agents, no hooks

--- a/.claude/plan/agentskills-skilllint/research-2-features.md
+++ b/.claude/plan/agentskills-skilllint/research-2-features.md
@@ -205,8 +205,8 @@ argument-hint: "[rule-id | path]"
 
 The current CLI (`skilllint --help`) has no `rule` subcommand. The discuss-CONTEXT.md mentions `skilllint rule <rule-id>` but this does not exist in the current codebase. The skill should document the actual CLI interface:
 - `skilllint <path>` -- validate a plugin/skill/agent
-- `skilllint --fix <path>` -- auto-fix where possible
-- `skilllint --check <path>` -- validate only
+- `skilllint check --fix <path>` -- auto-fix where possible
+- `skilllint check <path>` -- validate only
 - `skilllint --filter-type skills|agents|commands <path>` -- filter by file type
 - `skilllint --platform claude-code|cursor|codex <path>` -- platform-specific validation
 

--- a/.claude/plan/agentskills-skilllint/research-3-architecture.md
+++ b/.claude/plan/agentskills-skilllint/research-3-architecture.md
@@ -131,7 +131,7 @@ For each violation reported, read its explanation from [references/rule-catalog.
 ### 4. Fix (if requested)
 
 ```bash
-skilllint --fix <target/>
+skilllint check --fix <target/>
 ```
 
 Auto-fixable rules: FM004, FM007, FM008, FM009. For non-auto-fixable rules, provide manual fix guidance from the rule catalog.

--- a/.claude/plan/agentskills-skilllint/research-FINDINGS.md
+++ b/.claude/plan/agentskills-skilllint/research-FINDINGS.md
@@ -32,7 +32,7 @@ Key pattern: `plugin.json` requires only `name`. All other fields (`version`, `d
 
 **Dynamic context injection (`!` backtick)** — Selective use: a version/install check at skill activation (`!command -v skilllint ...`) is appropriate. Do NOT use it for scan output — scan targets depend on user context and cannot be parameterized at load time.
 
-**`skilllint rule <id>` subcommand** — Does NOT exist. The CLI is a single command with options. The skill must tell agents to look up rules in `references/rule-catalog.md`, and use `skilllint --verbose <path>` for detailed output.
+**`skilllint rule <id>` subcommand** — Now exists. Use `skilllint rule <id>` to see documentation for a specific rule, or `skilllint rules` to list all rules. Use `skilllint check --verbose <path>` for detailed output with info-level messages.
 
 ## 3. Architecture Patterns
 

--- a/.claude/skills/linear-walkthrough/SKILL.md
+++ b/.claude/skills/linear-walkthrough/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: linear-walkthrough
+description: 'Produce a structured, end-to-end linear walkthrough of an unfamiliar codebase. Use when onboarding to a new repository, understanding how a system works from entry points through execution paths, or generating navigable codebase documentation. Spawns parallel subagents for discovery, tracing, validation, and synthesis across four phases. Covers architecture, execution flows, deployment, testing, and operations.'
+argument-hint: '[target-directory]'
+---
+
+# Linear Walkthrough
+
+Produce a navigable, fact-checked explanation of how a codebase works — from entry points through major execution paths — by orchestrating parallel subagents across four phases.
+
+Target directory: `<target-directory>` (default: current working directory).
+
+Output directory: `<target-directory>/walkthrough/` (created if it does not exist).
+
+> [!IMPORTANT]
+> When provided a process map or Mermaid diagram, treat it as the authoritative procedure. Execute steps in the exact order shown, including branches, decision points, and stop conditions.
+> A Mermaid process diagram is an executable instruction set. Follow it exactly as written: respect sequence, conditions, loops, parallel paths, and terminal states. Do not improvise, reorder, or skip steps. If any node is ambiguous or missing required detail, pause and ask a clarifying question before continuing.
+> When interacting with a user, report before acting the interpreted path you will follow from the diagram, then execute.
+
+## Workflow
+
+The following diagram is the authoritative procedure for linear-walkthrough execution. Execute steps in the exact order shown, including branches, decision points, and stop conditions.
+
+```mermaid
+flowchart TD
+    %% Entry point
+    Invoke(["Invoke /linear-walkthrough with target-directory"]) --> ValidateDir
+
+    %% Input validation gate
+    ValidateDir{"Does target directory exist<br>and contain source files?"}
+    ValidateDir -->|"No — directory missing or empty"| StopInvalid(["STOP — report: target directory does not exist or is empty"])
+    ValidateDir -->|"Yes — directory valid"| SpawnDiscovery
+
+    subgraph Phase1["Phase 1 — Discovery and Planning"]
+        %% Spawn discovery agent
+        SpawnDiscovery["Spawn one general-purpose agent<br>Pass: target directory path,<br>agent-instructions.md (section Discovery Agent Instructions),<br>output-format.md (sections Coverage Plan Format + Entry Point Index Format)"]
+        SpawnDiscovery --> P1Wait["Wait for discovery agent to complete"]
+        P1Wait --> P1Done["Agent produces:<br>walkthrough/coverage-plan.md<br>walkthrough/entry-points.md"]
+    end
+
+    %% Orchestrator reads plan and verifies budgets
+    P1Done --> ReadPlan["Read walkthrough/coverage-plan.md<br>Extract agent assignments (ID, scope, files, entry points, token budget)"]
+    ReadPlan --> CheckBudget
+
+    CheckBudget{"Does any assignment<br>exceed 50k token read budget?"}
+    CheckBudget -->|"Yes — budget exceeded"| SpawnSplit["Spawn general-purpose agent<br>to split the over-budget assignment<br>Pass: coverage-plan.md, offending assignment ID"]
+    SpawnSplit --> ReadPlanAgain["Re-read walkthrough/coverage-plan.md<br>Extract updated assignment list"]
+    ReadPlanAgain --> CheckBudget
+    CheckBudget -->|"No — all assignments within budget"| SpawnTracers
+
+    subgraph Phase2["Phase 2 — Generation (N parallel agents)"]
+        %% Spawn N tracing agents — one per assignment
+        SpawnTracers["Spawn N parallel general-purpose agents<br>(one per assignment from coverage plan)<br>Each agent receives: its own assignment text (ID, scope, files, entry points),<br>target directory path,<br>agent-instructions.md (section Tracing Agent Instructions),<br>output-format.md (section Walkthrough Section Format),<br>constraint: read at most 50k tokens of source files"]
+        SpawnTracers --> P2Wait["Wait for all N tracing agents to complete"]
+        P2Wait --> P2Done["Each agent produces:<br>walkthrough/sections/walkthrough-section-{id}.md"]
+    end
+
+    %% Verify all section files were produced
+    P2Done --> CheckSections
+
+    CheckSections{"Do all expected section files<br>exist in walkthrough/sections/?"}
+    CheckSections -->|"Yes — all sections present"| SpawnValidators
+    CheckSections -->|"No — one or more agents failed to produce output"| MarkGap["Record missing section IDs as gaps<br>Mark gaps for the validation phase"]
+    MarkGap --> SpawnValidators
+
+    subgraph Phase3["Phase 3 — Validation (M parallel agents)"]
+        %% Cross-assignment rotation: validator i checks sections from agent i+1 (wrapping)
+        SpawnValidators["Spawn M parallel general-purpose agents<br>Apply cross-assignment rotation:<br>validator 1 checks sections from agent 2,<br>validator 2 checks sections from agent 3 (wrap around)<br>If M less than N: each validator checks multiple sections<br>If N = 1: single validator checks all sections<br>Each agent receives: paths to assigned walkthrough section files,<br>target directory path,<br>agent-instructions.md (section Validation Agent Instructions),<br>output-format.md (section Validation Report Format),<br>constraint: read at most 50k tokens total"]
+        SpawnValidators --> P3Wait["Wait for all M validation agents to complete"]
+        P3Wait --> P3Done["Each agent produces:<br>walkthrough/validation/validation-report-{id}.md"]
+    end
+
+    %% Check validation reports for critical issues
+    P3Done --> ReadReports["Read all validation reports<br>from walkthrough/validation/"]
+    ReadReports --> CheckCritical
+
+    CheckCritical{"Do any validation reports contain<br>critical corrections?<br>(incorrect sequencing, invented behavior,<br>broken references)"}
+    CheckCritical -->|"Yes — critical corrections exist"| SpawnCorrections["Spawn one general-purpose agent per affected section file<br>Each agent receives: validation report for that section,<br>path to the section file to correct<br>Agent edits the section file in place"]
+    SpawnCorrections --> P4Gate["Corrections applied — proceed to Phase 4"]
+    CheckCritical -->|"No — no critical corrections"| P4Gate
+
+    subgraph Phase4["Phase 4 — Synthesis"]
+        %% Synthesis agent merges all validated sections
+        P4Gate --> SpawnSynthesis["Spawn one general-purpose agent<br>Pass: walkthrough/sections/ directory path,<br>walkthrough/validation/ directory path,<br>walkthrough/entry-points.md,<br>agent-instructions.md (section Synthesis Agent Instructions),<br>output-format.md (section Unified Walkthrough Format)"]
+        SpawnSynthesis --> P4Wait["Wait for synthesis agent to complete"]
+        P4Wait --> P4Done["Agent produces:<br>walkthrough/unified-walkthrough.md<br>walkthrough/open-questions.md"]
+    end
+
+    %% Large output handling — apply large-file-write-strategy
+    P4Done --> CheckSize
+
+    CheckSize{"Does unified-walkthrough.md<br>exceed 25k characters?"}
+    CheckSize -->|"No — single file acceptable"| Complete(["COMPLETE — walkthrough/unified-walkthrough.md<br>is the authoritative output"])
+    CheckSize -->|"Yes — output too large for single file"| SplitOutput["Use Strategy A — multi-file split<br>Create walkthrough/unified/index.md<br>Create per-section files under walkthrough/unified/<br>Each file must be under 25k characters"]
+    SplitOutput --> CheckSingleRequired
+
+    CheckSingleRequired{"Is a single-file output<br>explicitly required by the caller?"}
+    CheckSingleRequired -->|"No — split acceptable"| CompleteSplit(["COMPLETE — walkthrough/unified/index.md<br>is the authoritative output"])
+    CheckSingleRequired -->|"Yes — single file required"| SkeletonFill["Use Strategy B — skeleton + edit-fill<br>Write skeleton under 5k chars,<br>then Edit each section individually<br>Verify no PENDING markers remain"]
+    SkeletonFill --> CompleteSingle(["COMPLETE — walkthrough/unified-walkthrough.md<br>is the authoritative output"])
+```
+
+## Operational Rules
+
+- Start broad (directory structure, configs, READMEs), then narrow (source files, implementation details).
+- Read architecture docs and configs early when available.
+- Prefer primary sources in this order: code, config, tests, scripts, CI/CD, docs.
+- Use tests and deployment config as evidence for intended behavior.
+- Track partial coverage and uncovered areas explicitly in open-questions.md.
+- If the repo is too large for full coverage, prioritize the most operationally important paths first and mark the rest as partial.
+- Agents must not overlap file coverage unless overlap is necessary for shared infrastructure, framework bootstrapping, or cross-cutting concerns.
+- The coverage plan must explicitly track which files are assigned to which agent and why.
+
+## Quality Standards
+
+- Prefer concrete file paths, symbols, commands, configs, and interfaces over vague summaries.
+- Do not fabricate intent or architecture not supported by the repo.
+- Mark unsupported claims as `[INFERENCE]`.
+- Distinguish clearly between verified facts from code/config, reasonable inferences, and unresolved uncertainty.
+- Optimize for onboarding a strong engineer who needs real understanding, not a marketing summary.
+
+## Resources
+
+- [Agent instructions](./references/agent-instructions.md) — detailed prompts for each agent type (discovery, tracing, validation, synthesis)
+- [Output format](./references/output-format.md) — required structure and templates for all artifacts

--- a/.claude/skills/linear-walkthrough/references/agent-instructions.md
+++ b/.claude/skills/linear-walkthrough/references/agent-instructions.md
@@ -1,0 +1,174 @@
+# Agent Instructions
+
+Each section below contains the complete instructions for one agent role. The orchestrator passes the relevant section to each agent.
+
+## Discovery Agent Instructions
+
+### Goal
+
+Scan the target repository and produce two artifacts: a coverage plan partitioning the repo into parallel exploration tasks, and an entry point index cataloging all meaningful entry points.
+
+### Procedure
+
+1. Read the top-level directory structure. Identify languages, frameworks, package boundaries, services, apps, libraries, infrastructure, CI/CD, docs, and configuration.
+
+2. Read high-signal files first:
+   - README, CONTRIBUTING, architecture docs
+   - Package manifests (package.json, pyproject.toml, Cargo.toml, go.mod, pom.xml, Gemfile)
+   - Configuration files (docker-compose, Dockerfile, Makefile, CI configs)
+   - Entry point files (main.*, index.*, app.*, manage.py, cli.*)
+
+3. Identify all entry points. Scan for:
+   - Application bootstraps (main functions, app factories)
+   - CLI commands (argument parsers, command registries)
+   - HTTP or RPC servers (route registrations, server startup)
+   - Worker and job runners (task definitions, queue consumers)
+   - Scheduled tasks (cron configs, scheduler registrations)
+   - Event consumers (message handlers, webhook endpoints)
+   - Test harnesses (test configuration, test runners)
+   - Deployment entry points (Dockerfiles, serverless handlers, cloud function exports)
+   - Local development startup paths (dev scripts, docker-compose services)
+
+4. For each entry point, record: name, type, file location (with line number), purpose, owning subsystem, and discovery evidence.
+
+5. Build agent assignments by clustering related entry points and their downstream paths. Each assignment must:
+   - Focus on one execution path or one tightly related cluster of paths
+   - Stay within 50k tokens of source file reading
+   - Minimize overlap with other assignments (overlap only for shared infrastructure)
+   - Include a rationale for why these files belong together
+
+6. Estimate token budgets per assignment. Use file sizes as proxy: ~4 characters per token for code files.
+
+7. Track files that are not assigned to any agent and document why in the uncovered areas section.
+
+### Output
+
+Write two files:
+
+- `walkthrough/coverage-plan.md` — follow the Coverage Plan Format in [output-format.md](./output-format.md)
+- `walkthrough/entry-points.md` — follow the Entry Point Index Format in [output-format.md](./output-format.md)
+
+Create the `walkthrough/`, `walkthrough/sections/`, and `walkthrough/validation/` directories.
+
+## Tracing Agent Instructions
+
+### Goal
+
+Produce a linear walkthrough for the assigned scope — trace execution from entry points through modules, documenting what happens in order with concrete file paths and symbols.
+
+### Constraints
+
+- Read at most 50k tokens of source files.
+- Stay within the assigned scope from the coverage plan. Read shared infrastructure files only when necessary to understand the assigned flow.
+- Do not speculate about code you have not read. Mark anything not directly verified as `[INFERENCE]`.
+
+### Procedure
+
+1. Read the assigned entry point files first.
+
+2. Follow the execution path forward: what does the entry point call? What does that call? Trace through the call chain, reading each file as needed.
+
+3. At each step, record:
+   - File and line where execution happens
+   - What function/class/module is invoked
+   - What data or control is passed
+   - What prerequisites or setup happened before
+   - What downstream systems or side effects happen after
+   - Where the flow branches, retries, fails, or exits
+
+4. Note configuration files, environment variables, and external dependencies that affect the flow.
+
+5. Document error handling paths, not just the happy path. Note retry logic, fallback behavior, and failure modes.
+
+6. When encountering shared infrastructure (logging, auth, database connections, middleware), describe its role in this flow without fully tracing its internals (that belongs to the agent assigned to infrastructure).
+
+7. Assess confidence for each major claim:
+   - **Verified**: directly read in source code or config
+   - **[INFERENCE]**: reasonable conclusion from patterns, naming, or partial evidence
+   - **[UNCERTAIN]**: could not verify, needs investigation
+
+### Output
+
+Write one file: `walkthrough/sections/walkthrough-section-{id}.md` following the Walkthrough Section Format in [output-format.md](./output-format.md).
+
+## Validation Agent Instructions
+
+### Goal
+
+Fact-check assigned walkthrough sections against source code. Identify incorrect sequencing, invented behavior, missing prerequisites, broken references, contradictions, and ambiguous boundaries.
+
+### Constraints
+
+- Read at most 50k tokens of explanation files plus relevant source context.
+- Do not rewrite walkthrough sections. Produce a validation report with corrections, confidence levels, and unresolved issues.
+
+### Procedure
+
+1. Read each assigned walkthrough section file completely.
+
+2. For each major claim in the section:
+   a. Identify the source file and line referenced.
+   b. Read the referenced source to verify the claim.
+   c. Check: does the code actually do what the walkthrough says? Is the sequence correct? Are the function signatures and return types accurate?
+
+3. Check for these specific failure modes:
+   - **Incorrect sequencing**: steps described out of order relative to actual execution
+   - **Invented behavior**: claims about functionality that does not exist in the code
+   - **Missing prerequisites**: setup steps or initialization that the walkthrough omits
+   - **Broken references**: file paths, function names, or class names that do not exist
+   - **Contradictions with other sections**: claims that conflict with what other walkthrough sections describe (read other sections for cross-reference if assigned)
+   - **Ambiguous boundaries**: unclear where one subsystem ends and another begins
+
+4. Check naming and terminology consistency:
+   - Are the same concepts called the same thing across sections?
+   - Are system boundaries described consistently?
+
+5. Assign a confidence level to each section: High (most claims verified), Medium (some claims unverifiable), Low (significant gaps or errors found).
+
+6. Document unresolved issues — things that could not be verified because source was unavailable, behavior depends on runtime state, or external documentation is needed.
+
+### Output
+
+Write one file: `walkthrough/validation/validation-report-{id}.md` following the Validation Report Format in [output-format.md](./output-format.md).
+
+## Synthesis Agent Instructions
+
+### Goal
+
+Merge all validated walkthrough sections into a single unified walkthrough document that a new engineer can read end-to-end to understand the codebase.
+
+### Procedure
+
+1. Read all walkthrough section files from `walkthrough/sections/`.
+
+2. Read all validation reports from `walkthrough/validation/`. Apply any corrections noted in validation reports to the section content as it is merged.
+
+3. Read `walkthrough/entry-points.md` for the complete entry point index.
+
+4. Determine a logical reading order for sections. Prefer:
+   - Start with application bootstrap and initialization
+   - Follow primary request/data flow paths
+   - Then secondary paths (background jobs, scheduled tasks)
+   - Then infrastructure and cross-cutting concerns
+   - Then development and operations processes
+
+5. Write the unified walkthrough following the Unified Walkthrough Format in [output-format.md](./output-format.md). This includes:
+   - Executive overview
+   - Entry point index with links to walkthrough sections
+   - All walkthrough sections in reading order with navigation links
+   - Cross-cutting system coverage
+   - Repository process coverage
+   - Validation appendix
+
+6. Connect sections with predecessor/successor navigation. Every section must clearly state what comes before and after it.
+
+7. Consolidate all unresolved issues, partial coverage areas, and follow-up suggestions into `walkthrough/open-questions.md`.
+
+8. For cross-cutting coverage: synthesize information from all sections into unified subsections. If the codebase does not include an area (observability, security, data stores), state that explicitly rather than omitting the subsection.
+
+### Output
+
+Write two files:
+
+- `walkthrough/unified-walkthrough.md` — follow the Unified Walkthrough Format in [output-format.md](./output-format.md). If content exceeds 25k characters, split into `walkthrough/unified/index.md` with per-part files.
+- `walkthrough/open-questions.md` — follow the Open Questions Format in [output-format.md](./output-format.md).

--- a/.claude/skills/linear-walkthrough/references/output-format.md
+++ b/.claude/skills/linear-walkthrough/references/output-format.md
@@ -1,0 +1,317 @@
+# Output Format Reference
+
+Templates and required structure for all artifacts produced by the linear-walkthrough skill.
+
+## Coverage Plan Format
+
+File: `walkthrough/coverage-plan.md`
+
+```markdown
+# Coverage Plan
+
+## Repository Summary
+
+- **Repository**: {name}
+- **Primary languages**: {languages}
+- **Frameworks**: {frameworks}
+- **Package boundaries**: {monorepo structure, services, libraries}
+- **Total estimated source tokens**: {estimate}
+
+## Agent Assignments
+
+### Agent {id}: {scope title}
+
+- **Scope**: {1-2 sentence description of what this agent traces}
+- **Entry points**: {list of entry points this agent follows}
+- **Assigned files/directories**:
+  - {path1} — {reason for assignment}
+  - {path2} — {reason for assignment}
+- **Estimated token budget**: {tokens}
+- **Dependencies on other agents**: {none, or list of agent IDs whose output informs this agent}
+- **Shared infrastructure files**: {files this agent reads that are also assigned to other agents, with justification}
+
+## Coverage Map
+
+| File/Directory | Assigned Agent | Reason |
+|---------------|---------------|--------|
+| {path} | Agent {id} | {reason} |
+
+## Uncovered Areas
+
+| File/Directory | Reason Not Covered | Priority |
+|---------------|-------------------|----------|
+| {path} | {reason} | {high/medium/low} |
+```
+
+## Entry Point Index Format
+
+File: `walkthrough/entry-points.md`
+
+```markdown
+# Entry Point Index
+
+## Summary
+
+Total entry points identified: {N}
+
+## Entry Points
+
+### {name}
+
+- **Type**: {application bootstrap | CLI command | HTTP/RPC server | worker/job runner | scheduled task | event consumer | test harness | deployment entry point | local development startup | other}
+- **File**: {file path with line number if applicable}
+- **Purpose**: {what this entry point does}
+- **Owning subsystem**: {subsystem or module name}
+- **Downstream walkthrough section**: Section {id}
+- **Discovery evidence**: {how this was identified — file name pattern, framework convention, config reference, explicit main() call}
+```
+
+## Walkthrough Section Format
+
+File: `walkthrough/sections/walkthrough-section-{id}.md`
+
+Each section answers these questions explicitly:
+
+- What comes before this?
+- What happens here?
+- What comes after this?
+- Why does this section exist?
+- What files define it?
+- What assumptions or dependencies does it rely on?
+- How would a developer verify this behavior?
+
+```markdown
+# Section {id}: {title}
+
+## Metadata
+
+- **Section ID**: {id}
+- **Title**: {descriptive title}
+- **Owning files**: {list of primary files that define this section}
+- **Upstream sections**: {section IDs that feed into this, or "None — entry point"}
+- **Downstream sections**: {section IDs that this feeds into, or "None — terminal"}
+- **Triggering entry points**: {entry point names from entry-points.md}
+- **Agent**: {agent ID that produced this section}
+
+## Context
+
+**What comes before this**: {description of prerequisite state, prior execution, or triggering conditions}
+
+**Why this section exists**: {the role this subsystem plays in the overall codebase}
+
+## Step-by-Step Flow
+
+1. **{Step title}** (`{file:line}`)
+   - {What happens at this step}
+   - {Data or control passed}
+   - {Side effects if any}
+
+2. **{Step title}** (`{file:line}`)
+   - {What happens}
+   - Branch: {if condition} → {outcome A} | {otherwise} → {outcome B}
+
+{Continue for all steps in execution order}
+
+## Key Interfaces
+
+| Symbol | File | Role |
+|--------|------|------|
+| {class/function/module name} | {file path} | {what it does in this flow} |
+
+## Configuration and Dependencies
+
+- **Config files**: {list of config files that affect this flow}
+- **Environment variables**: {relevant env vars}
+- **External dependencies**: {APIs, databases, queues, services}
+- **Internal prerequisites**: {other modules that must be initialized first}
+
+## Inputs and Outputs
+
+- **Key inputs**: {what data enters this subsystem}
+- **Key outputs**: {what data leaves this subsystem}
+- **Side effects**: {file writes, network calls, state mutations, logs, metrics}
+
+## What Comes After
+
+{Description of downstream systems, next stages in the pipeline, or terminal state}
+
+## Operational Notes
+
+{Deployment considerations, scaling behavior, failure modes, retry logic, error handling patterns}
+
+## Confidence and Open Questions
+
+- **Confidence**: {High | Medium | Low} — {basis for confidence level}
+- **Verified claims**: {list of claims verified against source code}
+- **Inferences**: {list of claims marked as [INFERENCE] with reasoning}
+- **Open questions**: {unresolved uncertainties}
+```
+
+## Validation Report Format
+
+File: `walkthrough/validation/validation-report-{id}.md`
+
+```markdown
+# Validation Report {id}
+
+## Scope
+
+- **Sections validated**: {list of section IDs}
+- **Validator agent**: {agent ID}
+- **Source files checked**: {count and list of key files read for verification}
+
+## Corrections
+
+### Correction {n}
+
+- **Section**: {section ID}
+- **Location**: {step number or subsection}
+- **Original claim**: {what the section stated}
+- **Actual behavior**: {what the source code shows}
+- **Source evidence**: {file:line reference}
+- **Severity**: {Critical — wrong sequence or invented behavior | Major — missing prerequisite or broken reference | Minor — imprecise wording or missing detail}
+
+## Contradictions With Other Sections
+
+### Contradiction {n}
+
+- **Sections involved**: {section IDs}
+- **Nature**: {what each section claims}
+- **Resolution**: {which is correct based on source, or unresolved}
+
+## Consistency Check
+
+- **Naming consistency**: {any inconsistent use of terms across sections}
+- **Terminology alignment**: {terms used differently in different sections}
+- **System boundary clarity**: {any ambiguity about where one subsystem ends and another begins}
+
+## Confidence Assessment
+
+| Section | Confidence | Basis |
+|---------|-----------|-------|
+| {id} | {High/Medium/Low} | {reason} |
+
+## Unresolved Issues
+
+- {issue description} — {why it could not be resolved}
+```
+
+## Unified Walkthrough Format
+
+File: `walkthrough/unified-walkthrough.md`
+
+The unified walkthrough merges all validated sections into one navigable document with six major parts.
+
+### Part 1: Executive Overview
+
+```markdown
+# {Repository Name} — Codebase Walkthrough
+
+## What This Codebase Is
+
+{2-3 paragraphs describing the system's purpose, users, and scope}
+
+## Major Systems
+
+| System | Purpose | Key Files |
+|--------|---------|-----------|
+| {name} | {purpose} | {primary files} |
+
+## How The Pieces Fit Together
+
+{Narrative or diagram showing system relationships and data flow}
+```
+
+### Part 2: Entry Point Index
+
+Reproduce the entry point index from `walkthrough/entry-points.md`, enhanced with links to the corresponding walkthrough sections in this document.
+
+### Part 3: Linear Walkthrough Sections
+
+Include all validated walkthrough sections in a logical reading order. Connect them with predecessor/successor links so a reader can navigate sequentially.
+
+Each section preserves its full structure from the section format above. Add navigation at the top of each section:
+
+```markdown
+**Previous**: [Section {id}: {title}](#section-{id}-{title}) | **Next**: [Section {id}: {title}](#section-{id}-{title})
+```
+
+### Part 4: Cross-Cutting System Coverage
+
+Cover these areas as separate subsections. If the codebase does not include an area, state that explicitly rather than omitting the section.
+
+- Systems architecture
+- Project design and code organization
+- Development requirements and local setup
+- Deployment and delivery systems
+- Quality control systems (linting, formatting, type checking, static analysis)
+- Testing processes (unit, integration, e2e, smoke)
+- Review procedures
+- Documentation processes and references
+- Observability, logging, metrics, and alerting
+- Security, secrets, permissions, and environment boundaries
+- Data stores, schemas, migrations, queues, and caches
+- Runtime dependencies and external integrations
+
+### Part 5: Repository Process Coverage
+
+Document how the repo is worked on and operated:
+
+- Build and packaging flows
+- CI pipelines
+- CD and release flows
+- Branching or review practices (if discoverable)
+- Linting, formatting, type checking, static analysis
+- Unit, integration, e2e, and smoke tests
+- Documentation generation or maintenance workflows
+
+### Part 6: Validation Appendix
+
+```markdown
+## Validation Appendix
+
+### Validation Coverage
+
+| Section | Validated By | Corrections Applied | Confidence |
+|---------|-------------|-------------------|------------|
+| {id} | Validator {id} | {count} | {High/Medium/Low} |
+
+### Corrections Applied
+
+{Summary of all corrections from validation reports}
+
+### Contradictions Found and Resolved
+
+{Summary of contradictions and their resolutions}
+
+### Unresolved Uncertainties
+
+{Consolidated list from all validation reports and open-questions.md}
+```
+
+## Open Questions Format
+
+File: `walkthrough/open-questions.md`
+
+```markdown
+# Open Questions
+
+## Unresolved Uncertainties
+
+### {question title}
+
+- **Related sections**: {section IDs}
+- **Nature**: {what is uncertain}
+- **Why unresolved**: {what would be needed to resolve — access to runtime, external docs, domain expert}
+- **Impact**: {how this uncertainty affects understanding of the codebase}
+
+## Partial Coverage Areas
+
+| Area | Coverage Level | What Is Missing | Priority |
+|------|---------------|-----------------|----------|
+| {area} | {partial/none} | {description} | {high/medium/low} |
+
+## Follow-Up Suggestions
+
+- {Suggested investigation or additional walkthrough scope}
+```

--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,4 @@ tmp/
 scripts/bench-plugin/
 scripts/results/
 
-.bg-shell/*
+.bg-shell/*walkthrough/

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -63,7 +63,7 @@ Plans:
 **Depends on**: Phase 2
 **Requirements**: CFG-01, CFG-02, CFG-03, CFG-04, VAL-01, VAL-02, VAL-03, VAL-04, VAL-05, VAL-06, VAL-07, VAL-08, VAL-09, SAM-01
 **Success Criteria** (what must be TRUE):
-  1. `skilllint --fix` auto-applies safe fixes (array format, multiline normalization) and leaves unsafe violations as report-only warnings
+  1. `skilllint check --fix` auto-applies safe fixes (array format, multiline normalization) and leaves unsafe violations as report-only warnings
   2. A `[tool.skilllint]` section in `pyproject.toml` (or `linter.toml`) enables disabling individual rule codes and setting per-directory overrides — changes take effect without restarting the linter
   3. Validating one file with four validators reports "Total files: 1" (not 4); SK005 fires only on SKILL files; SK004 fires on SKILL and AGENT files but not COMMAND files
   4. Hook files (`.js` in `hooks/` and `hooks.json`) are detected, validated with HK001+ error codes, and pre-commit runs only on changed files with template directories excluded from FM003

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
 
   # Python formatting and linting
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.6
     hooks:
       - id: ruff
         name: Lint Python with ruff

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,6 +2,6 @@
   name: skilllint
   description: Validate AI agent plugins, skills, and agents
   language: python
-  entry: skilllint
+  entry: skilllint check
   types_or: [markdown, json, yaml]
   pass_filenames: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@
 - Fixtures in `tests/fixtures/`:
   - `benchmark-plugin-1000-skills.zip` — clean, no violations (no-op scan)
   - `benchmark-plugin-violations.zip` — 200 skills with fixable FM004/FM007/FM008/FM009 violations
-- `skilllint --fix` operates **in-place**, so fix benchmarks must copy the fixture to a temp dir before each timed run
+- `skilllint check --fix` operates **in-place**, so fix benchmarks must copy the fixture to a temp dir before each timed run
 
 ## Orchestrator delegation discipline
 

--- a/packages/skilllint/adapters/cursor/adapter.py
+++ b/packages/skilllint/adapters/cursor/adapter.py
@@ -9,9 +9,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import frontmatter
-
 from skilllint import load_bundled_schema
+from skilllint.frontmatter import load_frontmatter
 
 if TYPE_CHECKING:
     import pathlib
@@ -54,7 +53,7 @@ class CursorAdapter:
         if mdc_schema is None:
             return []
 
-        post = frontmatter.load(str(path))  # type: ignore[unresolved-attribute]
+        post = load_frontmatter(path)
         fm: dict = dict(post.metadata)
 
         known_fields: set[str] = set(mdc_schema.get("properties", {}).keys())

--- a/packages/skilllint/frontmatter.py
+++ b/packages/skilllint/frontmatter.py
@@ -5,14 +5,143 @@ files using memory-mapped I/O. Files that already pass linting are exited
 immediately without any write operations. Files that require fixes are rewritten
 atomically via a temporary file and ``pathlib.Path.replace``, making the processor safe
 to run across large collections of files.
+
+Also provides a fast in-memory frontmatter parser that avoids the python-frontmatter
+dependency overhead while maintaining API compatibility.
 """
 
 from __future__ import annotations
 
 import mmap
 import pathlib
+from dataclasses import dataclass
+from io import StringIO
+from typing import TypeAlias
+
+from ruamel.yaml import YAML
 
 DELIMITER = b"---\n"
+
+# Recursive type for YAML-serializable frontmatter values.
+FrontmatterValue: TypeAlias = dict[str, "FrontmatterValue"] | list["FrontmatterValue"] | str | int | float | bool | None
+
+# Shared ruamel.yaml instance (round-trip mode for formatting preservation)
+_yaml = YAML(typ="rt")
+_yaml.preserve_quotes = False
+_yaml.width = 2147483647
+
+
+@dataclass
+class Post:
+    """Simple frontmatter post object compatible with python-frontmatter API.
+
+    Attributes:
+        metadata: Parsed YAML frontmatter as a dict.
+        content: Body content after the frontmatter block.
+    """
+
+    metadata: dict[str, FrontmatterValue]
+    content: str
+
+
+def loads_frontmatter(text: str) -> Post:
+    """Parse frontmatter from a string.
+
+    Fast in-memory parser that extracts YAML frontmatter and body content
+    without the python-frontmatter dependency overhead.
+
+    Args:
+        text: Markdown string potentially containing YAML frontmatter.
+
+    Returns:
+        A Post object with metadata and content attributes.
+    """
+    # Fast path: check for opening delimiter
+    if not text.startswith("---"):
+        return Post(metadata={}, content=text)
+
+    # Find closing delimiter (must be on its own line)
+    end_match = text.find("\n---", 3)
+    if end_match == -1:
+        # Malformed: no closing delimiter
+        return Post(metadata={}, content=text)
+
+    # Extract frontmatter (between delimiters)
+    frontmatter_text = text[3:end_match]
+
+    # Find where body starts (after closing delimiter line)
+    body_start = end_match + 4  # Skip past "\n---"
+    # Skip any newlines immediately after the closing delimiter
+    while body_start < len(text) and text[body_start] == "\n":
+        body_start += 1
+    content = text[body_start:] if body_start < len(text) else ""
+    # Strip trailing newline for consistency with python-frontmatter
+    content = content.removesuffix("\n")
+
+    # Parse YAML
+    metadata: dict[str, FrontmatterValue] = {}
+    if frontmatter_text.strip():
+        try:
+            parsed = _yaml.load(frontmatter_text)
+            if isinstance(parsed, dict):
+                metadata = parsed
+        except (OSError, ValueError, KeyError, TypeError):
+            # On parse error, return empty metadata
+            pass
+
+    return Post(metadata=metadata, content=content)
+
+
+def load_frontmatter(path: str | pathlib.Path) -> Post:
+    """Load frontmatter from a file path.
+
+    Args:
+        path: Path to a markdown file with YAML frontmatter.
+
+    Returns:
+        A Post object with metadata and content attributes.
+    """
+    text = pathlib.Path(path).read_text(encoding="utf-8")
+    return loads_frontmatter(text)
+
+
+def dump_frontmatter(post: Post) -> str:
+    """Serialize a Post object to a string.
+
+    Args:
+        post: A Post object with metadata and content.
+
+    Returns:
+        Full markdown string with YAML frontmatter delimiters and body.
+    """
+    buf = StringIO()
+    _yaml.dump(post.metadata, buf)
+    yaml_str = buf.getvalue().strip()
+    return f"---\n{yaml_str}\n---\n{post.content}"
+
+
+def dumps_frontmatter(post: Post, path: str | pathlib.Path) -> None:
+    """Write a Post object to a file.
+
+    Args:
+        post: A Post object with metadata and content.
+        path: Destination file path.
+    """
+    content = dump_frontmatter(post)
+    pathlib.Path(path).write_text(content, encoding="utf-8")
+
+
+def update_field(path: str | pathlib.Path, key: str, value: FrontmatterValue) -> None:
+    """Load a file, update one key, and write back.
+
+    Args:
+        path: Path to the markdown file.
+        key: Frontmatter field name to set.
+        value: New value for the field.
+    """
+    post = load_frontmatter(path)
+    post.metadata[key] = value
+    dumps_frontmatter(post, path)
 
 
 def process_markdown_file(file_path: str) -> None:

--- a/packages/skilllint/frontmatter_utils.py
+++ b/packages/skilllint/frontmatter_utils.py
@@ -1,151 +1,27 @@
-"""Shared frontmatter utilities backed by ruamel.yaml.
+"""Frontmatter utilities (compatibility shim).
 
-Provides load/dump functions for YAML frontmatter files using
-python-frontmatter with a ruamel.yaml round-trip handler.
-The round-trip handler preserves formatting and only adds quotes
-where YAML syntax demands them (e.g. colon-space in values).
-
-Public API:
-    load_frontmatter  -- Load frontmatter from a file path.
-    loads_frontmatter -- Parse frontmatter from a string.
-    dump_frontmatter  -- Serialize a Post object to a string.
-    dumps_frontmatter -- Write a Post object to a file.
-    update_field      -- Load a file, update one key, write back.
+This module re-exports the new frontmatter API from frontmatter.py for
+backward compatibility. The implementation no longer depends on python-frontmatter.
 """
 
 from __future__ import annotations
 
-import re
-from io import StringIO
-from typing import TYPE_CHECKING, TypeAlias
+from .frontmatter import (
+    FrontmatterValue,
+    Post,
+    dump_frontmatter,
+    dumps_frontmatter,
+    load_frontmatter,
+    loads_frontmatter,
+    update_field,
+)
 
-from frontmatter import Post, dump, dumps, load, loads  # type: ignore[attr-defined]
-from frontmatter.default_handlers import BaseHandler  # type: ignore[attr-defined]
-from ruamel.yaml import YAML
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
-# Recursive type for YAML/JSON-serializable frontmatter values. More specific than Any.
-FrontmatterValue: TypeAlias = dict[str, "FrontmatterValue"] | list["FrontmatterValue"] | str | int | float | bool | None
-
-
-class RuamelYAMLHandler(BaseHandler):
-    """Frontmatter handler using ruamel.yaml in round-trip mode.
-
-    Subclasses BaseHandler directly (not YAMLHandler) to avoid an upstream
-    LSP conflict: YAMLHandler.load adds **kwargs that BaseHandler.load
-    does not declare, making it impossible for a subclass to satisfy both
-    signatures simultaneously under strict type checking.
-
-    Overrides the default pyyaml-based handler so that:
-    - Values without special YAML characters stay unquoted.
-    - Values requiring quotes (colon-space) get single-quoted.
-    - Unnecessary quotes from the source are stripped on round-trip.
-    """
-
-    FM_BOUNDARY = re.compile(r"^-{3,}\s*$", re.MULTILINE)
-    START_DELIMITER = "---"
-    END_DELIMITER = "---"
-
-    def __init__(self) -> None:
-        """Initialize handler with ruamel.yaml round-trip instance."""
-        super().__init__()
-        self._yaml = YAML(typ="rt")
-        self._yaml.preserve_quotes = False
-        # Prevent ruamel.yaml from wrapping long scalar values into block scalars.
-        # Without this, descriptions longer than ~80 chars become multi-line
-        # block scalars which break downstream validators expecting single-line strings.
-        self._yaml.width = 2147483647
-
-    @property
-    def yaml(self) -> YAML:
-        """Round-trip YAML instance for load/dump. Public for plugin_validator._dump_yaml."""
-        return self._yaml
-
-    def load(self, fm: str) -> dict[str, FrontmatterValue]:
-        """Parse YAML frontmatter string using ruamel.yaml round-trip loader.
-
-        Args:
-            fm: Raw YAML frontmatter string (without delimiters).
-
-        Returns:
-            Parsed YAML data as a CommentedMap or None for empty input.
-        """
-        return self._yaml.load(fm)
-
-    def export(self, metadata: dict[str, object], **kwargs: object) -> str:
-        """Serialize metadata dict to YAML string using ruamel.yaml.
-
-        Args:
-            metadata: Frontmatter metadata dictionary.
-            **kwargs: Accepted for API compatibility with BaseHandler; not used.
-
-        Returns:
-            YAML-formatted string without trailing newline.
-        """
-        buf = StringIO()
-        self._yaml.dump(metadata, buf)
-        return buf.getvalue().strip()
-
-
-_handler = RuamelYAMLHandler()
-
-
-def load_frontmatter(path: str | Path) -> Post:
-    """Load frontmatter from a file path.
-
-    Args:
-        path: Path to a markdown file with YAML frontmatter.
-
-    Returns:
-        A frontmatter.Post with metadata and content attributes.
-    """
-    return load(str(path), handler=_handler)
-
-
-def loads_frontmatter(text: str) -> Post:
-    """Parse frontmatter from a string.
-
-    Args:
-        text: Markdown string potentially containing YAML frontmatter.
-
-    Returns:
-        A frontmatter.Post with metadata and content attributes.
-    """
-    return loads(text, handler=_handler)
-
-
-def dump_frontmatter(post: Post) -> str:
-    """Serialize a Post object to a string.
-
-    Args:
-        post: A frontmatter.Post object.
-
-    Returns:
-        Full markdown string with YAML frontmatter delimiters and body.
-    """
-    return dumps(post, handler=_handler)
-
-
-def dumps_frontmatter(post: Post, path: str | Path) -> None:
-    """Write a Post object to a file.
-
-    Args:
-        post: A frontmatter.Post object.
-        path: Destination file path.
-    """
-    dump(post, str(path), handler=_handler)
-
-
-def update_field(path: str | Path, key: str, value: FrontmatterValue) -> None:
-    """Load a file, update one key, and write back.
-
-    Args:
-        path: Path to the markdown file.
-        key: Frontmatter field name to set.
-        value: New value for the field.
-    """
-    post = load_frontmatter(path)
-    post.metadata[key] = value
-    dumps_frontmatter(post, path)
+__all__ = [
+    "FrontmatterValue",
+    "Post",
+    "dump_frontmatter",
+    "dumps_frontmatter",
+    "load_frontmatter",
+    "loads_frontmatter",
+    "update_field",
+]

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -67,7 +67,6 @@ from .frontmatter_core import (
     fix_skill_name_field,
     get_frontmatter_model,
 )
-from .frontmatter_utils import RuamelYAMLHandler
 
 if TYPE_CHECKING:
     from pydantic_core import ErrorDetails
@@ -75,9 +74,9 @@ if TYPE_CHECKING:
 # Module-level ruamel.yaml safe-mode instance (replaces yaml.safe_load)
 _yaml_safe = YAML(typ="safe")
 
-# Round-trip YAML instance (via shared handler) for dumping with format preservation
-_rt_handler = RuamelYAMLHandler()
-_rt_yaml = _rt_handler.yaml
+# Round-trip YAML instance for dumping with format preservation
+_rt_yaml = YAML(typ="rt")
+_rt_yaml.preserve_quotes = False
 _rt_yaml.width = 10000  # prevent line wrapping
 
 # Platform adapter registry — loaded once at module level.

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -56,6 +56,7 @@ from skilllint.adapters import PlatformAdapter, load_adapters, matches_file
 from skilllint.adapters.claude_code import ClaudeCodeAdapter
 from skilllint.rules.as_series import run_as_series
 from skilllint.token_counter import TOKEN_ERROR_THRESHOLD, TOKEN_WARNING_THRESHOLD, count_tokens
+from skilllint.version import __version__
 
 from .frontmatter_core import (
     MAX_SKILL_NAME_LENGTH,
@@ -578,7 +579,7 @@ class FileType(StrEnum):
             result = FileType.COMMAND
         elif path.name == "hooks.json":
             result = FileType.HOOK_CONFIG
-        elif "hooks" in path.parts and path.suffix in {".js", ".cjs"}:
+        elif "hooks" in path.parts:
             result = FileType.HOOK_SCRIPT
         elif path.name == "CLAUDE.md":
             result = FileType.CLAUDE_MD
@@ -5260,10 +5261,21 @@ def main(
 # Create Typer app
 app = typer.Typer(help="Validate Claude Code plugins and skills", add_completion=False)
 
+# Version option handled via callback
 
-@app.callback()
-def _callback() -> None:
+
+@app.callback(invoke_without_command=True)
+def _callback(
+    ctx: typer.Context,
+    version: Annotated[bool, typer.Option("--version", "-V", help="Show version and exit", is_eager=True)] = False,
+) -> None:
     """Validate Claude Code plugins, skills, agents, and commands."""
+    if version:
+        print(f"skilllint {__version__}")
+        raise typer.Exit
+    if ctx.invoked_subcommand is None:
+        print("Use 'skilllint --help' for usage.")
+        raise typer.Exit(1)
 
 
 def _show_rules_list(platform: str | None = None, category: str | None = None, severity: str | None = None) -> None:

--- a/packages/skilllint/tests/test_hook_validator.py
+++ b/packages/skilllint/tests/test_hook_validator.py
@@ -68,12 +68,44 @@ class TestDetectFileType:
         result = FileType.detect_file_type(hook_cjs)
         assert result == FileType.HOOK_SCRIPT
 
+    def test_sh_in_hooks_dir_detected_as_hook_script(self, tmp_path: Path) -> None:
+        """Test shell script in hooks/ directory is detected as HOOK_SCRIPT.
+
+        Tests: FileType detection for non-JS hook scripts
+        How: Create hooks/my-hook.sh, call detect_file_type
+        Why: Any executable script in hooks/ should be valid HOOK_SCRIPT
+        """
+        hooks_dir = tmp_path / "hooks"
+        hooks_dir.mkdir()
+        hook_sh = hooks_dir / "my-hook.sh"
+        hook_sh.write_text("#!/bin/bash\necho 'hook'")
+        hook_sh.chmod(0o755)
+
+        result = FileType.detect_file_type(hook_sh)
+        assert result == FileType.HOOK_SCRIPT
+
+    def test_py_in_hooks_dir_detected_as_hook_script(self, tmp_path: Path) -> None:
+        """Test Python script in hooks/ directory is detected as HOOK_SCRIPT.
+
+        Tests: FileType detection for Python hook scripts
+        How: Create hooks/my-hook.py, call detect_file_type
+        Why: Any executable script in hooks/ should be valid HOOK_SCRIPT
+        """
+        hooks_dir = tmp_path / "hooks"
+        hooks_dir.mkdir()
+        hook_py = hooks_dir / "my-hook.py"
+        hook_py.write_text("#!/usr/bin/env python3\nprint('hook')")
+        hook_py.chmod(0o755)
+
+        result = FileType.detect_file_type(hook_py)
+        assert result == FileType.HOOK_SCRIPT
+
     def test_js_outside_hooks_dir_not_detected_as_hook(self, tmp_path: Path) -> None:
         """Test .js file outside hooks/ directory is detected as UNKNOWN.
 
         Tests: FileType detection scope limitation
         How: Create scripts/util.js, call detect_file_type
-        Why: Only .js/.cjs files inside a hooks/ directory are HOOK_SCRIPT
+        Why: Only files inside a hooks/ directory are HOOK_SCRIPT (any extension)
         """
         scripts_dir = tmp_path / "scripts"
         scripts_dir.mkdir()

--- a/plugins/agentskills-skilllint/README.md
+++ b/plugins/agentskills-skilllint/README.md
@@ -9,7 +9,7 @@ The skill teaches Claude how to:
 - **Install** `skilllint` via `uv`, `pipx`, or `pip`
 - **Run** validation scans on plugins, skills, agents, and commands
 - **Read** and interpret violation output (FM, SK, AS, PL, HK, LK, PD rule IDs)
-- **Fix** auto-fixable violations with `skilllint --fix`
+- **Fix** auto-fixable violations with `skilllint check --fix`
 - **Understand** any rule ID by consulting the built-in rule catalog
 - **Check for updates** and upgrade to the latest version
 

--- a/plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md
+++ b/plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md
@@ -1,6 +1,6 @@
 # skilllint Rule Catalog
 
-Complete reference for all rule IDs emitted by `skilllint`. Use `skilllint --verbose <path>` to see explanatory text alongside each violation.
+Complete reference for all rule IDs emitted by `skilllint`. Use `skilllint check --verbose <path>` to see explanatory text alongside each violation.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "gitpython>=3.1.45",
     "msgspec>=0.20.0",
     "pydantic>=2.0.0",
-    "python-frontmatter>=1.1.0",
     "ruamel-yaml>=0.18.0",
     "tiktoken>=0.8.0",
     "typer>=0.21.0",

--- a/tests/benchmarks/test_benchmark.py
+++ b/tests/benchmarks/test_benchmark.py
@@ -76,10 +76,7 @@ def test_io_scan_1000_skills_timing(extracted_plugin_dir: Path, plugin_file_coun
     """
     start = time.perf_counter()
     result = subprocess.run(
-        ["skilllint", "check", str(extracted_plugin_dir)],
-        capture_output=True,
-        text=True,
-        check=False,
+        ["skilllint", "check", str(extracted_plugin_dir)], capture_output=True, text=True, check=False
     )
     duration = time.perf_counter() - start
 

--- a/uv.lock
+++ b/uv.lock
@@ -693,73 +693,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-frontmatter"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/96/de/910fa208120314a12f9a88ea63e03707261692af782c99283f1a2c8a5e6f/python-frontmatter-1.1.0.tar.gz", hash = "sha256:7118d2bd56af9149625745c58c9b51fb67e8d1294a0c76796dafdc72c36e5f6d", size = 16256, upload-time = "2024-01-16T18:50:04.052Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/87/3c8da047b3ec5f99511d1b4d7a5bc72d4b98751c7e78492d14dc736319c5/python_frontmatter-1.1.0-py3-none-any.whl", hash = "sha256:335465556358d9d0e6c98bbeb69b1c969f2a4a21360587b9873bfc3b213407c1", size = 9834, upload-time = "2024-01-16T18:50:00.911Z" },
-]
-
-[[package]]
-name = "pyyaml"
-version = "6.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
-    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
-    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
-    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
-    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
-    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
-    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
-    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
-    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
-    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
-    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
-    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
-    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
-    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
-    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
-    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
-    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
-    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
-    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
-    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
-    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
-    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
-    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
-]
-
-[[package]]
 name = "regex"
 version = "2026.2.28"
 source = { registry = "https://pypi.org/simple" }
@@ -963,7 +896,6 @@ dependencies = [
     { name = "gitpython" },
     { name = "msgspec" },
     { name = "pydantic" },
-    { name = "python-frontmatter" },
     { name = "ruamel-yaml" },
     { name = "tiktoken" },
     { name = "typer" },
@@ -991,7 +923,6 @@ requires-dist = [
     { name = "gitpython", specifier = ">=3.1.45" },
     { name = "msgspec", specifier = ">=0.20.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
-    { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "ruamel-yaml", specifier = ">=0.18.0" },
     { name = "tiktoken", specifier = ">=0.8.0" },
     { name = "typer", specifier = ">=0.21.0" },


### PR DESCRIPTION
## Summary

Replaces the `python-frontmatter` dependency with a native implementation in `frontmatter.py`.

## Changes

- **New implementation**: `packages/skilllint/frontmatter.py` provides complete frontmatter API (load, loads, dump, dumps, update)
- **Backward compatibility**: `frontmatter_utils.py` re-exports from new module
- **Dependency removed**: `python-frontmatter>=1.1.0` no longer required
- **Adapters updated**: Cursor adapter uses new frontmatter module
- **Simplified**: Creates ruamel.yaml instance directly in plugin_validator.py

## Performance

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Scan (1001 files) | 6466ms | 5596ms | **-13.5%** |

## Test plan

- [x] All existing tests pass (`packages/skilllint/tests/test_frontmatter_utils.py`)
- [x] I/O benchmark shows performance improvement
- [x] Fix benchmark works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the external python-frontmatter dependency.

* **New Features**
  * Added a native frontmatter API for reading, updating, and writing markdown frontmatter.
  * CLI gains a --version flag to print the tool version.

* **Refactor**
  * Consolidated frontmatter utilities behind a single implementation and simplified hook detection to include any file in hooks/ directories.

* **Tests**
  * Added tests covering hook-file detection behavior.

* **Documentation**
  * Added a multi-agent "linear walkthrough" skill with templates, instructions, and output formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->