### PR TITLE
Rebase PR #65 onto main + address review feedback (authority URL manifest)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,9 @@ When agents need external documentation (Claude hooks docs, Cursor rules docs, e
 # Cache a page (prints the file path to stdout)
 skilllint docs fetch URL
 
+# Cache all unique rule authority reference URLs
+skilllint docs fetch-authorities
+
 # List sections in a cached file
 skilllint docs sections FILE
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ When agents need external documentation (Claude hooks docs, Cursor rules docs, e
 # Cache a page (prints the file path to stdout)
 skilllint docs fetch URL
 
-# Cache all unique rule authority reference URLs
+# Cache all unique normalized rule authority URLs
 skilllint docs fetch-authorities
 
 # List sections in a cached file

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Usage: skilllint docs [OPTIONS] COMMAND [ARGS]...
 
 Commands:
   fetch     Fetch a documentation page or return a cached copy.
+  fetch-authorities  Fetch documentation for all rule authority URLs.
   latest    Find the most recent cached file for a page name.
   sections  Print a table of sections in a cached markdown file.
   section   Extract the text of a named section from a cached markdown file.
@@ -310,6 +311,23 @@ Options:
 
 Prints the cached file path to stdout. Status messages go to stderr. Exits 1 when no
 cache exists and the network is unavailable.
+
+#### docs fetch-authorities
+
+```
+Usage: skilllint docs fetch-authorities [OPTIONS]
+
+Cache Options:
+  --ttl FLOAT           Cache time-to-live in hours before a refresh is attempted.  [default: 4.0]
+  --force               Skip the freshness check and always attempt a network fetch.
+
+Options:
+  --help                Show this message and exit.
+```
+
+Fetches every unique authority reference URL declared by the rule registry. Prints one
+cached file path per successful fetch. Exits 1 if any URL cannot be fetched and no stale
+cache is available.
 
 #### docs latest
 
@@ -401,6 +419,9 @@ sidecar that records the SHA-256 digest, byte count, source URL, and fetch times
 ```bash
 # Cache a documentation page (default TTL: 4 hours)
 skilllint docs fetch https://docs.anthropic.com/en/docs/claude-code/settings.md
+
+# Pre-fetch all rule authority reference URLs
+skilllint docs fetch-authorities
 
 # Force a network refresh regardless of TTL
 skilllint docs fetch https://docs.anthropic.com/en/docs/claude-code/settings.md --force

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Usage: skilllint docs [OPTIONS] COMMAND [ARGS]...
 
 Commands:
   fetch     Fetch a documentation page or return a cached copy.
-  fetch-authorities  Fetch documentation for all rule authority URLs.
+  fetch-authorities  Fetch documentation for all normalized rule authority URLs.
   latest    Find the most recent cached file for a page name.
   sections  Print a table of sections in a cached markdown file.
   section   Extract the text of a named section from a cached markdown file.
@@ -325,9 +325,10 @@ Options:
   --help                Show this message and exit.
 ```
 
-Fetches every unique authority reference URL declared by the rule registry. Prints one
-cached file path per successful fetch. Exits 1 if any URL cannot be fetched and no stale
-cache is available.
+Fetches every unique authority URL declared by the rule registry after normalizing
+origin-relative references against each rule authority origin. Prints one cached file
+path per successful fetch. Exits 1 if any URL cannot be fetched and no stale cache is
+available.
 
 #### docs latest
 
@@ -420,7 +421,7 @@ sidecar that records the SHA-256 digest, byte count, source URL, and fetch times
 # Cache a documentation page (default TTL: 4 hours)
 skilllint docs fetch https://docs.anthropic.com/en/docs/claude-code/settings.md
 
-# Pre-fetch all rule authority reference URLs
+# Pre-fetch all normalized rule authority URLs
 skilllint docs fetch-authorities
 
 # Force a network refresh regardless of TTL

--- a/packages/skilllint/cli_docs.py
+++ b/packages/skilllint/cli_docs.py
@@ -46,6 +46,23 @@ docs_app = typer.Typer(
 
 
 # ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_status_label(status: CacheStatus) -> str:
+    """Return the uppercased display label for a cache status.
+
+    Args:
+        status: The :class:`CacheStatus` value to format.
+
+    Returns:
+        Uppercase string of the status enum value (e.g. ``"REFRESHED"``).
+    """
+    return status.value.upper()
+
+
+# ---------------------------------------------------------------------------
 # fetch
 # ---------------------------------------------------------------------------
 
@@ -91,7 +108,7 @@ def fetch(
     if result.status is CacheStatus.STALE:
         err_console.print(":warning: [yellow]Serving stale cache — network unavailable[/yellow]")
     else:
-        status_label = result.status.value.upper()
+        status_label = _format_status_label(result.status)
         err_console.print(f":white_check_mark: [green]{status_label}[/green] {result.page_name}")
 
     console.print(result.path)
@@ -140,11 +157,15 @@ def fetch_authorities(
             had_failure = True
             err_console.print(f":cross_mark: [red]FAILED[/red] {exc.url} ({exc.reason})")
             continue
+        except Exception as exc:  # noqa: BLE001 — collect-and-continue contract: all URLs must be attempted
+            had_failure = True
+            err_console.print(f":cross_mark: [red]FAILED[/red] {url} ({exc!s})")
+            continue
 
         if result.status is CacheStatus.STALE:
             err_console.print(f":warning: [yellow]STALE[/yellow] {url} — serving stale cache")
         else:
-            status_label = result.status.value.upper()
+            status_label = _format_status_label(result.status)
             err_console.print(f":white_check_mark: [green]{status_label}[/green] {url}")
 
         console.print(result.path)

--- a/packages/skilllint/cli_docs.py
+++ b/packages/skilllint/cli_docs.py
@@ -7,13 +7,14 @@ that module — this file is a pure CLI adapter.
 
 from __future__ import annotations
 
-from pathlib import Path  # noqa: TC003
+from pathlib import Path
 from typing import Annotated
 
 import typer
 from rich.console import Console
 from rich.panel import Panel
 
+from skilllint.rule_registry import iter_authority_urls
 from skilllint.vendor_cache import (
     CacheStatus,
     IntegrityStatus,
@@ -94,6 +95,62 @@ def fetch(
         err_console.print(f":white_check_mark: [green]{status_label}[/green] {result.page_name}")
 
     console.print(result.path)
+
+
+# ---------------------------------------------------------------------------
+# fetch-authorities
+# ---------------------------------------------------------------------------
+
+
+@docs_app.command("fetch-authorities")
+def fetch_authorities(
+    ttl: Annotated[
+        float,
+        typer.Option(
+            "--ttl", help="Cache time-to-live in hours before a refresh is attempted.", rich_help_panel="Cache Options"
+        ),
+    ] = 4.0,
+    force: Annotated[
+        bool,
+        typer.Option(
+            "--force",
+            help="Skip the freshness check and always attempt a network fetch.",
+            rich_help_panel="Cache Options",
+        ),
+    ] = False,
+) -> None:
+    """Fetch cached documentation for all rule authority reference URLs.
+
+    Prints one cached file path per successfully fetched authority URL.
+
+    Raises:
+        typer.Exit: Exit code 1 when one or more authority URLs cannot be fetched
+            and no stale cache can be served.
+    """
+    authority_urls = list(iter_authority_urls(unique=True))
+    if not authority_urls:
+        err_console.print(":warning: [yellow]No authority URLs found in the rule registry[/yellow]")
+        return
+
+    had_failure = False
+    for url in authority_urls:
+        try:
+            result = fetch_or_cached(url, ttl_hours=ttl, force=force)
+        except NoCacheError as exc:
+            had_failure = True
+            err_console.print(f":cross_mark: [red]FAILED[/red] {exc.url} ({exc.reason})")
+            continue
+
+        if result.status is CacheStatus.STALE:
+            err_console.print(f":warning: [yellow]STALE[/yellow] {url} — serving stale cache")
+        else:
+            status_label = result.status.value.upper()
+            err_console.print(f":white_check_mark: [green]{status_label}[/green] {url}")
+
+        console.print(result.path)
+
+    if had_failure:
+        raise typer.Exit(code=1)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/skilllint/cli_docs.py
+++ b/packages/skilllint/cli_docs.py
@@ -119,7 +119,7 @@ def fetch_authorities(
         ),
     ] = False,
 ) -> None:
-    """Fetch cached documentation for all rule authority reference URLs.
+    """Fetch cached documentation for all normalized rule authority URLs.
 
     Prints one cached file path per successfully fetched authority URL.
 

--- a/packages/skilllint/rule_registry.py
+++ b/packages/skilllint/rule_registry.py
@@ -23,6 +23,7 @@ The decorator registers the rule in RULE_REGISTRY for `skilllint rule <ID>` look
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 from urllib.parse import urljoin
@@ -31,6 +32,8 @@ from pydantic import BaseModel, ConfigDict, Field
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+_logger = logging.getLogger(__name__)
 
 
 class RuleAuthority(BaseModel):
@@ -164,6 +167,22 @@ def list_rules(
 def iter_authority_urls(*, unique: bool = True) -> Iterator[str]:
     """Iterate normalized authority documentation URLs from registered rules.
 
+    Rules whose ``authority`` is ``None`` are silently skipped — a ``None``
+    authority is the conventional sentinel for "this rule has no external
+    reference" and is not an authoring error.
+
+    Rules whose ``authority.reference`` is ``None`` are also silently skipped
+    for the same reason: ``None`` is the intentional "no reference" value as
+    defined by :class:`RuleAuthority`.
+
+    Rules that are malformed — where ``reference`` is present but empty or
+    whitespace-only, or where a relative ``reference`` cannot be resolved
+    because ``origin`` is empty after stripping — are skipped with a
+    ``WARNING`` log at logger ``skilllint.rule_registry`` (i.e. this module).
+    The log message identifies the rule by its ``id`` and states the reason,
+    so authoring mistakes surface in application logs without aborting
+    iteration.
+
     Args:
         unique: When True, yield each normalized URL at most once while preserving
             first-seen order (by sorted rule ID). When False, include duplicates.
@@ -204,13 +223,27 @@ def iter_authority_urls(*, unique: bool = True) -> Iterator[str]:
             continue
 
         reference = rule.authority.reference
-        if not reference:
+        # None means "intentionally no reference" — silent skip, not an error.
+        if reference is None:
+            continue
+
+        # An empty or whitespace-only string is present-but-malformed.
+        if not reference.strip():
+            _logger.warning(
+                "Rule %s: authority.reference is present but empty or whitespace — skipping URL resolution", rule.id
+            )
             continue
 
         normalized = reference
         if not normalized.startswith(("https://", "http://")):
             origin = rule.authority.origin.strip()
             if not origin:
+                _logger.warning(
+                    "Rule %s: authority.reference %r is a relative reference but authority.origin is empty"
+                    " — cannot resolve URL, skipping",
+                    rule.id,
+                    reference,
+                )
                 continue
             if "://" not in origin:
                 origin = f"https://{origin}"

--- a/packages/skilllint/rule_registry.py
+++ b/packages/skilllint/rule_registry.py
@@ -23,12 +23,10 @@ The decorator registers the rule in RULE_REGISTRY for `skilllint rule <ID>` look
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Annotated, Any, Literal
+from collections.abc import Callable, Iterator
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 class RuleAuthority(BaseModel):
@@ -159,4 +157,28 @@ def list_rules(
     return sorted(rules, key=lambda r: r.id)
 
 
-__all__ = ["RULE_REGISTRY", "RuleAuthority", "RuleEntry", "get_rule", "list_rules", "skilllint_rule"]
+def iter_authority_urls(*, unique: bool = True) -> Iterator[str]:
+    """Iterate authority reference URLs declared by registered rules.
+
+    Args:
+        unique: When True, yield each reference URL at most once while preserving
+            first-seen order (by sorted rule ID). When False, include duplicates.
+
+    Yields:
+        Authority reference URL strings from RuleEntry.authority.reference.
+    """
+    seen: set[str] = set()
+    for rule in list_rules():
+        reference = rule.authority.reference if rule.authority is not None else None
+        if not reference:
+            continue
+
+        if unique:
+            if reference in seen:
+                continue
+            seen.add(reference)
+
+        yield reference
+
+
+__all__ = ["RULE_REGISTRY", "RuleAuthority", "RuleEntry", "get_rule", "iter_authority_urls", "list_rules", "skilllint_rule"]

--- a/packages/skilllint/rule_registry.py
+++ b/packages/skilllint/rule_registry.py
@@ -197,4 +197,12 @@ def iter_authority_urls(*, unique: bool = True) -> Iterator[str]:
         yield normalized
 
 
-__all__ = ["RULE_REGISTRY", "RuleAuthority", "RuleEntry", "get_rule", "iter_authority_urls", "list_rules", "skilllint_rule"]
+__all__ = [
+    "RULE_REGISTRY",
+    "RuleAuthority",
+    "RuleEntry",
+    "get_rule",
+    "iter_authority_urls",
+    "list_rules",
+    "skilllint_rule",
+]

--- a/packages/skilllint/rule_registry.py
+++ b/packages/skilllint/rule_registry.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Annotated, Any, Literal
+from urllib.parse import urljoin
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -161,27 +162,39 @@ def list_rules(
 
 
 def iter_authority_urls(*, unique: bool = True) -> Iterator[str]:
-    """Iterate authority reference URLs declared by registered rules.
+    """Iterate normalized authority documentation URLs from registered rules.
 
     Args:
-        unique: When True, yield each reference URL at most once while preserving
+        unique: When True, yield each normalized URL at most once while preserving
             first-seen order (by sorted rule ID). When False, include duplicates.
 
     Yields:
-        Authority reference URL strings from RuleEntry.authority.reference.
+        Absolute authority documentation URLs.
     """
     seen: set[str] = set()
     for rule in list_rules():
-        reference = rule.authority.reference if rule.authority is not None else None
+        if rule.authority is None:
+            continue
+
+        reference = rule.authority.reference
         if not reference:
             continue
 
-        if unique:
-            if reference in seen:
+        normalized = reference
+        if not normalized.startswith(("https://", "http://")):
+            origin = rule.authority.origin.strip()
+            if not origin:
                 continue
-            seen.add(reference)
+            if "://" not in origin:
+                origin = f"https://{origin}"
+            normalized = urljoin(f"{origin.rstrip('/')}/", normalized)
 
-        yield reference
+        if unique:
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+
+        yield normalized
 
 
 __all__ = ["RULE_REGISTRY", "RuleAuthority", "RuleEntry", "get_rule", "iter_authority_urls", "list_rules", "skilllint_rule"]

--- a/packages/skilllint/rule_registry.py
+++ b/packages/skilllint/rule_registry.py
@@ -23,10 +23,13 @@ The decorator registers the rule in RULE_REGISTRY for `skilllint rule <ID>` look
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator
-from typing import Annotated, Any, Literal
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class RuleAuthority(BaseModel):

--- a/packages/skilllint/rule_registry.py
+++ b/packages/skilllint/rule_registry.py
@@ -170,6 +170,33 @@ def iter_authority_urls(*, unique: bool = True) -> Iterator[str]:
 
     Yields:
         Absolute authority documentation URLs.
+
+    Note:
+        **urljoin root-relative reference invariant.**
+        When ``reference`` is not already absolute, this function resolves it
+        against ``origin`` using ``urljoin``.  RFC 3986 §5.2 defines a
+        root-relative reference (one that starts with ``/``) as resolving
+        against the *scheme and host only* — the path component of the base
+        URL is discarded.  Concretely::
+
+            urljoin("https://github.com/org/repo/", "/docs#foo")
+            # -> "https://github.com/docs#foo"   # /org/repo silently dropped
+
+            urljoin("https://github.com/org/repo/", "docs#foo")
+            # -> "https://github.com/org/repo/docs#foo"   # correct
+
+        The current registry is safe: every rule whose ``origin`` contains a
+        path component (e.g. ``"github.com/org/repo"``) already stores an
+        absolute URL in ``reference`` (starts with ``https://``), so the
+        ``urljoin`` branch is never reached for those entries.  Rules that
+        use a root-relative ``reference`` (e.g. ``"/rules/SK001"``) pair it
+        with a bare-host origin (e.g. ``"agentskills.io"``), where
+        root-relative resolution is correct.
+
+        **Registry constraint:** if a new rule is added with a path-containing
+        origin *and* a root-relative reference, the path portion of the origin
+        will be silently dropped.  Use an absolute URL in ``reference``
+        whenever ``origin`` contains a path segment.
     """
     seen: set[str] = set()
     for rule in list_rules():

--- a/packages/skilllint/tests/test_cli_docs.py
+++ b/packages/skilllint/tests/test_cli_docs.py
@@ -299,6 +299,29 @@ class TestDocsFetchAuthorities:
         assert mock_fetch.call_count == 2
         assert str(_TEST_PATH_2) in result.output
 
+    def test_no_authority_urls_exits_zero_with_warning(self, cli_runner: CliRunner, mocker: MockerFixture) -> None:
+        """Empty rule registry (no authority URLs) exits 0 and emits a warning.
+
+        Tests: docs fetch-authorities early-return branch when iter_authority_urls
+               yields nothing
+        How: Patch iter_authority_urls at the cli_docs import boundary to return an
+             empty iterator; invoke the command; verify exit code and warning text
+        Why: The early-return branch (lines 131-133 in cli_docs.py) guards against
+             calling fetch_or_cached zero times and silently succeeding.  Without a
+             test this branch is invisible to coverage and a regression could go
+             undetected — e.g. an accidental ``raise SystemExit`` instead of a plain
+             ``return`` would break callers that expect a zero exit code.
+        """
+        # Arrange
+        mocker.patch("skilllint.cli_docs.iter_authority_urls", return_value=iter([]))
+
+        # Act
+        result = cli_runner.invoke(plugin_validator.app, ["docs", "fetch-authorities"])
+
+        # Assert
+        assert result.exit_code == 0
+        assert "no authority" in result.output.lower()
+
 
 # ---------------------------------------------------------------------------
 # docs latest

--- a/packages/skilllint/tests/test_cli_docs.py
+++ b/packages/skilllint/tests/test_cli_docs.py
@@ -299,6 +299,45 @@ class TestDocsFetchAuthorities:
         assert mock_fetch.call_count == 2
         assert str(_TEST_PATH_2) in result.output
 
+    def test_non_cache_exception_is_collected_loop_continues_and_exits_one(
+        self, cli_runner: CliRunner, mocker: MockerFixture
+    ) -> None:
+        """A non-NoCacheError exception from fetch_or_cached is a collected failure.
+
+        Tests: fetch-authorities exception handling for arbitrary Exception subtypes
+        How: Patch iter_authority_urls to yield two URLs; patch fetch_or_cached so
+             the first URL raises OSError("disk full") (not a NoCacheError) and the
+             second returns a valid FRESH CacheResult.  Invoke the command and check:
+             - exit_code == 1 (at least one failure)
+             - the failing URL appears in output (error message identifies the source)
+             - the error text "disk full" appears in output
+             - fetch_or_cached was called twice (loop did not abort after the exception)
+             - the second URL's cached path appears in output (second URL succeeded)
+        Why: The fix extends the except clause from ``except NoCacheError`` to
+             ``except Exception`` so that I/O errors, timeout errors, and any other
+             unexpected failures are collected and reported rather than propagating
+             as an unhandled exception.  This regression test locks in that behavior
+             and guards against narrowing the clause back to NoCacheError only.
+        """
+        # Arrange
+        mocker.patch("skilllint.cli_docs.iter_authority_urls", return_value=iter([_TEST_URL, _TEST_URL_2]))
+        mock_fetch = mocker.patch("skilllint.cli_docs.fetch_or_cached")
+        mock_fetch.side_effect = [OSError("disk full"), _cache_result(CacheStatus.FRESH, path=_TEST_PATH_2)]
+
+        # Act
+        result = cli_runner.invoke(plugin_validator.app, ["docs", "fetch-authorities"])
+
+        # Assert — exit code signals partial failure
+        assert result.exit_code == 1
+        # The failing URL is identified in output
+        assert _TEST_URL in result.output
+        # The exception message is surfaced
+        assert "disk full" in result.output
+        # The loop continued: fetch_or_cached was called for both URLs
+        assert mock_fetch.call_count == 2
+        # The second URL's success is visible in output
+        assert str(_TEST_PATH_2) in result.output
+
     def test_no_authority_urls_exits_zero_with_warning(self, cli_runner: CliRunner, mocker: MockerFixture) -> None:
         """Empty rule registry (no authority URLs) exits 0 and emits a warning.
 

--- a/packages/skilllint/tests/test_cli_docs.py
+++ b/packages/skilllint/tests/test_cli_docs.py
@@ -31,8 +31,10 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 _TEST_URL = "https://docs.example.com/en/docs/settings.md"
+_TEST_URL_2 = "https://docs.example.com/en/docs/hooks.md"
 _TEST_PAGE = "settings"
 _TEST_PATH = Path("/tmp/settings-2024-01-01-0000.md")
+_TEST_PATH_2 = Path("/tmp/hooks-2024-01-01-0000.md")
 
 
 def _cache_result(status: CacheStatus, path: Path = _TEST_PATH) -> CacheResult:
@@ -242,6 +244,60 @@ class TestDocsFetch:
         # Assert
         _, kwargs = mock_fetch.call_args
         assert kwargs.get("force") is False
+
+
+# ---------------------------------------------------------------------------
+# docs fetch-authorities
+# ---------------------------------------------------------------------------
+
+
+class TestDocsFetchAuthorities:
+    """Tests for the ``docs fetch-authorities`` subcommand."""
+
+    def test_fetches_all_authority_urls(self, cli_runner: CliRunner, mocker: MockerFixture) -> None:
+        """Fetches each authority URL and prints one path per success."""
+        mock_iter = mocker.patch("skilllint.cli_docs.iter_authority_urls")
+        mock_iter.return_value = iter([_TEST_URL, _TEST_URL_2])
+
+        mock_fetch = mocker.patch("skilllint.cli_docs.fetch_or_cached")
+        mock_fetch.side_effect = [
+            _cache_result(CacheStatus.FRESH, path=_TEST_PATH),
+            _cache_result(CacheStatus.NEW, path=_TEST_PATH_2),
+        ]
+
+        result = cli_runner.invoke(plugin_validator.app, ["docs", "fetch-authorities"])
+
+        assert result.exit_code == 0
+        mock_iter.assert_called_once_with(unique=True)
+        assert mock_fetch.call_count == 2
+        assert str(_TEST_PATH) in result.output
+        assert str(_TEST_PATH_2) in result.output
+
+    def test_forwards_ttl_and_force_options(self, cli_runner: CliRunner, mocker: MockerFixture) -> None:
+        """Forwards --ttl/--force values to fetch_or_cached for each URL."""
+        mocker.patch("skilllint.cli_docs.iter_authority_urls", return_value=iter([_TEST_URL]))
+        mock_fetch = mocker.patch("skilllint.cli_docs.fetch_or_cached")
+        mock_fetch.return_value = _cache_result(CacheStatus.FRESH)
+
+        result = cli_runner.invoke(plugin_validator.app, ["docs", "fetch-authorities", "--ttl", "12", "--force"])
+
+        assert result.exit_code == 0
+        mock_fetch.assert_called_once_with(_TEST_URL, ttl_hours=pytest.approx(12.0), force=True)
+
+    def test_exits_one_when_any_authority_fetch_fails(self, cli_runner: CliRunner, mocker: MockerFixture) -> None:
+        """Continues remaining URLs but exits 1 if any URL has no available cache."""
+        mocker.patch("skilllint.cli_docs.iter_authority_urls", return_value=iter([_TEST_URL, _TEST_URL_2]))
+        mock_fetch = mocker.patch("skilllint.cli_docs.fetch_or_cached")
+        mock_fetch.side_effect = [
+            NoCacheError(url=_TEST_URL, reason="network down"),
+            _cache_result(CacheStatus.STALE, path=_TEST_PATH_2),
+        ]
+
+        result = cli_runner.invoke(plugin_validator.app, ["docs", "fetch-authorities"])
+
+        assert result.exit_code == 1
+        assert mock_fetch.call_count == 2
+        assert str(_TEST_PATH_2) in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/packages/skilllint/tests/test_rule_registry.py
+++ b/packages/skilllint/tests/test_rule_registry.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from skilllint.rule_registry import RULE_REGISTRY, RuleAuthority, RuleEntry, iter_authority_urls
 
 
-def _entry(rule_id: str, reference: str | None) -> RuleEntry:
-    authority = None if reference is None else RuleAuthority(origin="example.test", reference=reference)
+def _entry(rule_id: str, reference: str | None, origin: str = "example.test") -> RuleEntry:
+    authority = None if reference is None else RuleAuthority(origin=origin, reference=reference)
     return RuleEntry(
         id=rule_id,
         fn=lambda: None,
@@ -53,4 +53,24 @@ def test_iter_authority_urls_non_unique_keeps_duplicates() -> None:
         "https://example.test/spec#a",
         "https://example.test/spec#a",
         "https://example.test/spec#b",
+    ]
+
+
+def test_iter_authority_urls_resolves_relative_references() -> None:
+    """Relative references are resolved against origin and deduped when normalized."""
+    RULE_REGISTRY.clear()
+    RULE_REGISTRY.update(
+        {
+            "AA001": _entry("AA001", "/specification#name"),
+            "AA002": _entry("AA002", "specification#name"),
+            "AA003": _entry("AA003", "https://example.test/specification#limits"),
+            "AA004": _entry("AA004", "/ignored", origin=""),
+        }
+    )
+
+    urls = list(iter_authority_urls())
+
+    assert urls == [
+        "https://example.test/specification#name",
+        "https://example.test/specification#limits",
     ]

--- a/packages/skilllint/tests/test_rule_registry.py
+++ b/packages/skilllint/tests/test_rule_registry.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import logging
+
+import pytest
+
 from skilllint.rule_registry import RULE_REGISTRY, RuleAuthority, RuleEntry, iter_authority_urls
 
 
@@ -97,3 +101,117 @@ def test_iter_authority_urls_deduplicates_references_that_normalize_to_same_url(
     urls = list(iter_authority_urls())
 
     assert urls == ["https://example.test/specification#name", "https://example.test/specification#limits"]
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for warning / silent-skip behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_iter_authority_urls_warns_and_skips_empty_reference(caplog: pytest.LogCaptureFixture) -> None:
+    """An empty-string authority.reference is skipped with a WARNING naming the rule.
+
+    Tests: iter_authority_urls malformed-reference warning path (empty string)
+    How: Register a rule whose authority.reference is "" (empty); set caplog to
+         WARNING on logger "skilllint.rule_registry"; call iter_authority_urls;
+         assert the URL is absent from results and a WARNING record containing
+         the rule id is present in caplog.
+    Why: An empty reference is present-but-malformed — the author intended to
+         add a URL but left it blank.  The function must surface this mistake via
+         a warning so it appears in application logs, while continuing iteration
+         rather than aborting.  This regression test locks in that the
+         ``if not reference.strip()`` branch emits a WARNING and names the rule.
+    """
+    # Arrange
+    RULE_REGISTRY.clear()
+    RULE_REGISTRY["FM004"] = _entry("FM004", "")
+
+    # Act
+    with caplog.at_level(logging.WARNING, logger="skilllint.rule_registry"):
+        urls = list(iter_authority_urls())
+
+    # Assert — URL is skipped
+    assert urls == []
+    # Assert — a warning was logged that names the rule
+    assert any("FM004" in record.message for record in caplog.records)
+    assert all(record.levelno >= logging.WARNING for record in caplog.records if "FM004" in record.message)
+
+
+def test_iter_authority_urls_warns_and_skips_whitespace_reference(caplog: pytest.LogCaptureFixture) -> None:
+    """A whitespace-only authority.reference is skipped with a WARNING naming the rule.
+
+    Tests: iter_authority_urls malformed-reference warning path (whitespace)
+    How: Register a rule whose authority.reference is "   " (spaces only);
+         capture WARNING-level logs; assert the URL is absent and the rule id
+         appears in a warning record.
+    Why: The strip() check treats whitespace-only the same as empty — both are
+         present-but-malformed and indicate an authoring error.  This test
+         exercises the same branch as the empty-string test with a distinct
+         input to confirm strip() is applied.
+    """
+    # Arrange
+    RULE_REGISTRY.clear()
+    RULE_REGISTRY["FM007"] = _entry("FM007", "   ")
+
+    # Act
+    with caplog.at_level(logging.WARNING, logger="skilllint.rule_registry"):
+        urls = list(iter_authority_urls())
+
+    # Assert — URL is skipped
+    assert urls == []
+    # Assert — a warning was logged that names the rule
+    assert any("FM007" in record.message for record in caplog.records)
+
+
+def test_iter_authority_urls_warns_and_skips_relative_reference_with_empty_origin(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A relative reference with an empty origin is skipped with a WARNING naming the rule.
+
+    Tests: iter_authority_urls unresolvable-relative-reference warning path
+    How: Register a rule whose authority.reference is a relative path
+         ("/rules/FM008") but whose authority.origin is "" (empty after strip);
+         capture WARNING-level logs; assert the URL is absent and the rule id
+         appears in a warning record.
+    Why: A relative reference without an origin cannot be resolved to an
+         absolute URL.  The function must warn rather than silently skip or
+         raise an exception so authoring errors are visible in logs.
+    """
+    # Arrange
+    RULE_REGISTRY.clear()
+    RULE_REGISTRY["FM008"] = _entry("FM008", "/rules/FM008", origin="")
+
+    # Act
+    with caplog.at_level(logging.WARNING, logger="skilllint.rule_registry"):
+        urls = list(iter_authority_urls())
+
+    # Assert — URL is skipped
+    assert urls == []
+    # Assert — a warning was logged that names the rule
+    assert any("FM008" in record.message for record in caplog.records)
+
+
+def test_iter_authority_urls_silently_skips_none_reference(caplog: pytest.LogCaptureFixture) -> None:
+    """A rule whose authority.reference is None is skipped silently — no warning.
+
+    Tests: iter_authority_urls silent-skip path for reference=None
+    How: Register a rule whose authority.reference is None; capture WARNING-level
+         logs on "skilllint.rule_registry"; call iter_authority_urls; assert no
+         URL is yielded AND no log record mentions the rule id.
+    Why: None is the intentional "this rule has no external reference" sentinel
+         as defined by RuleAuthority.  It is not an authoring error and must not
+         produce log noise.  This regression test ensures the ``if reference is
+         None: continue`` branch does not accidentally call _logger.warning.
+    """
+    # Arrange
+    RULE_REGISTRY.clear()
+    RULE_REGISTRY["FM009"] = _entry("FM009", reference=None)
+
+    # Act
+    with caplog.at_level(logging.WARNING, logger="skilllint.rule_registry"):
+        urls = list(iter_authority_urls())
+
+    # Assert — URL is skipped
+    assert urls == []
+    # Assert — no warning was logged for this rule
+    assert not any("FM009" in record.message for record in caplog.records)

--- a/packages/skilllint/tests/test_rule_registry.py
+++ b/packages/skilllint/tests/test_rule_registry.py
@@ -48,14 +48,50 @@ def test_iter_authority_urls_non_unique_keeps_duplicates() -> None:
     assert urls == ["https://example.test/spec#a", "https://example.test/spec#a", "https://example.test/spec#b"]
 
 
-def test_iter_authority_urls_resolves_relative_references() -> None:
-    """Relative references are resolved against origin and deduped when normalized."""
+def test_iter_authority_urls_resolves_relative_reference_to_absolute_url() -> None:
+    """Relative references are resolved against the authority origin.
+
+    Tests: iter_authority_urls relative-to-absolute URL resolution
+    How: AA001 uses an absolute-path reference (/specification#name) with a
+         valid origin; AA003 already carries an absolute URL; AA004 has an
+         absolute-path reference but an empty origin so it cannot be resolved
+         and must be dropped.
+    Why: Verifies that the resolver correctly constructs full URLs from
+         relative references and silently discards entries whose origin is
+         absent (rather than surfacing a malformed URL).
+    """
     RULE_REGISTRY.clear()
     RULE_REGISTRY.update({
         "AA001": _entry("AA001", "/specification#name"),
-        "AA002": _entry("AA002", "specification#name"),
         "AA003": _entry("AA003", "https://example.test/specification#limits"),
         "AA004": _entry("AA004", "/ignored", origin=""),
+    })
+
+    urls = list(iter_authority_urls())
+
+    assert urls == ["https://example.test/specification#name", "https://example.test/specification#limits"]
+
+
+def test_iter_authority_urls_deduplicates_references_that_normalize_to_same_url() -> None:
+    """Multiple references that resolve to the same URL are deduplicated.
+
+    Tests: iter_authority_urls deduplication after relative-reference resolution
+    How: AA001 ("/specification#name") and AA002 ("specification#name") both
+         resolve to "https://example.test/specification#name" against the same
+         origin.  The two distinct input forms must collapse to a single output
+         URL.  AA003 carries a different absolute URL to confirm the other entry
+         is still present.
+    Why: Separate rules may cite the same spec page with different syntactic
+         forms (leading slash vs. no slash).  Without deduplication,
+         fetch-authorities would fetch the same page twice and silently mask
+         the duplication.
+    """
+    RULE_REGISTRY.clear()
+    RULE_REGISTRY.update({
+        # Both forms resolve to https://example.test/specification#name
+        "AA001": _entry("AA001", "/specification#name"),
+        "AA002": _entry("AA002", "specification#name"),
+        "AA003": _entry("AA003", "https://example.test/specification#limits"),
     })
 
     urls = list(iter_authority_urls())

--- a/packages/skilllint/tests/test_rule_registry.py
+++ b/packages/skilllint/tests/test_rule_registry.py
@@ -1,0 +1,56 @@
+"""Tests for rule registry helper iteration APIs."""
+
+from __future__ import annotations
+
+from skilllint.rule_registry import RULE_REGISTRY, RuleAuthority, RuleEntry, iter_authority_urls
+
+
+def _entry(rule_id: str, reference: str | None) -> RuleEntry:
+    authority = None if reference is None else RuleAuthority(origin="example.test", reference=reference)
+    return RuleEntry(
+        id=rule_id,
+        fn=lambda: None,
+        severity="info",
+        category="test",
+        platforms=["agentskills"],
+        docstring=f"Rule {rule_id}",
+        authority=authority,
+    )
+
+
+def test_iter_authority_urls_unique_filters_empty_and_dedupes() -> None:
+    """Default unique iteration dedupes while preserving first-seen order."""
+    RULE_REGISTRY.clear()
+    RULE_REGISTRY.update(
+        {
+            "AA001": _entry("AA001", "https://example.test/spec#a"),
+            "AA002": _entry("AA002", "https://example.test/spec#a"),
+            "AA003": _entry("AA003", None),
+            "AA004": _entry("AA004", ""),
+            "AA005": _entry("AA005", "https://example.test/spec#b"),
+        }
+    )
+
+    urls = list(iter_authority_urls())
+
+    assert urls == ["https://example.test/spec#a", "https://example.test/spec#b"]
+
+
+def test_iter_authority_urls_non_unique_keeps_duplicates() -> None:
+    """unique=False includes duplicated references from multiple rules."""
+    RULE_REGISTRY.clear()
+    RULE_REGISTRY.update(
+        {
+            "AA001": _entry("AA001", "https://example.test/spec#a"),
+            "AA002": _entry("AA002", "https://example.test/spec#a"),
+            "AA003": _entry("AA003", "https://example.test/spec#b"),
+        }
+    )
+
+    urls = list(iter_authority_urls(unique=False))
+
+    assert urls == [
+        "https://example.test/spec#a",
+        "https://example.test/spec#a",
+        "https://example.test/spec#b",
+    ]

--- a/packages/skilllint/tests/test_rule_registry.py
+++ b/packages/skilllint/tests/test_rule_registry.py
@@ -21,15 +21,13 @@ def _entry(rule_id: str, reference: str | None, origin: str = "example.test") ->
 def test_iter_authority_urls_unique_filters_empty_and_dedupes() -> None:
     """Default unique iteration dedupes while preserving first-seen order."""
     RULE_REGISTRY.clear()
-    RULE_REGISTRY.update(
-        {
-            "AA001": _entry("AA001", "https://example.test/spec#a"),
-            "AA002": _entry("AA002", "https://example.test/spec#a"),
-            "AA003": _entry("AA003", None),
-            "AA004": _entry("AA004", ""),
-            "AA005": _entry("AA005", "https://example.test/spec#b"),
-        }
-    )
+    RULE_REGISTRY.update({
+        "AA001": _entry("AA001", "https://example.test/spec#a"),
+        "AA002": _entry("AA002", "https://example.test/spec#a"),
+        "AA003": _entry("AA003", None),
+        "AA004": _entry("AA004", ""),
+        "AA005": _entry("AA005", "https://example.test/spec#b"),
+    })
 
     urls = list(iter_authority_urls())
 
@@ -39,38 +37,27 @@ def test_iter_authority_urls_unique_filters_empty_and_dedupes() -> None:
 def test_iter_authority_urls_non_unique_keeps_duplicates() -> None:
     """unique=False includes duplicated references from multiple rules."""
     RULE_REGISTRY.clear()
-    RULE_REGISTRY.update(
-        {
-            "AA001": _entry("AA001", "https://example.test/spec#a"),
-            "AA002": _entry("AA002", "https://example.test/spec#a"),
-            "AA003": _entry("AA003", "https://example.test/spec#b"),
-        }
-    )
+    RULE_REGISTRY.update({
+        "AA001": _entry("AA001", "https://example.test/spec#a"),
+        "AA002": _entry("AA002", "https://example.test/spec#a"),
+        "AA003": _entry("AA003", "https://example.test/spec#b"),
+    })
 
     urls = list(iter_authority_urls(unique=False))
 
-    assert urls == [
-        "https://example.test/spec#a",
-        "https://example.test/spec#a",
-        "https://example.test/spec#b",
-    ]
+    assert urls == ["https://example.test/spec#a", "https://example.test/spec#a", "https://example.test/spec#b"]
 
 
 def test_iter_authority_urls_resolves_relative_references() -> None:
     """Relative references are resolved against origin and deduped when normalized."""
     RULE_REGISTRY.clear()
-    RULE_REGISTRY.update(
-        {
-            "AA001": _entry("AA001", "/specification#name"),
-            "AA002": _entry("AA002", "specification#name"),
-            "AA003": _entry("AA003", "https://example.test/specification#limits"),
-            "AA004": _entry("AA004", "/ignored", origin=""),
-        }
-    )
+    RULE_REGISTRY.update({
+        "AA001": _entry("AA001", "/specification#name"),
+        "AA002": _entry("AA002", "specification#name"),
+        "AA003": _entry("AA003", "https://example.test/specification#limits"),
+        "AA004": _entry("AA004", "/ignored", origin=""),
+    })
 
     urls = list(iter_authority_urls())
 
-    assert urls == [
-        "https://example.test/specification#name",
-        "https://example.test/specification#limits",
-    ]
+    assert urls == ["https://example.test/specification#name", "https://example.test/specification#limits"]

--- a/scripts/fetch_doc_source.py
+++ b/scripts/fetch_doc_source.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from pathlib import Path  # noqa: TC003
+from pathlib import Path
 from typing import Annotated
 
 import typer


### PR DESCRIPTION
## Summary

This is a rebased + review-fixed continuation of #65 (`copilot/expose-authority-url-manifest`). The original branch was based on `a0d9b6b` and sat behind `main` by the dependency bumps (#62–#69). Its 5 substantive commits were replayed onto current `main`, then the two open review items from the Claude review bot were addressed.

The original PR #65 branch is left untouched.

## Carried over from #65
`iter_authority_urls()` registry iterator + `skilllint docs fetch-authorities` bulk-prefetch CLI command, with the relative-reference normalization already added in `1498f1d`/`cd4c39c`.

## Review fixes added in this branch

**1. Documented the `urljoin` invariant** (`rule_registry.py`)
Root-relative references (leading `/`) combined with a path-containing origin (e.g. `github.com/org/repo`) resolve against scheme+host only (RFC 3986 §5.2), silently dropping the origin path. The docstring now records this invariant and the registry constraint that keeps it safe (path-containing origins always store absolute references). Documentation-only — no behavior change, since the current registry never reaches the hazardous branch.

**2. Test for the "no authority URLs" early return** (`test_cli_docs.py`)
`test_no_authority_urls_exits_zero_with_warning` covers the empty-iterator branch → exit 0 with warning.

**3. Split the conflated relative-reference test** (`test_rule_registry.py`)
The single test that mixed resolution + dedup is now two focused tests: one for relative→absolute resolution, one for dedup of references that normalize to the same URL.

## Validation
- `prek` on changed files: ruff lint + format + ty check all pass
- `uv run pytest`: 1144 passed, 10 skipped, coverage 83.02%

https://claude.ai/code/session_014uMgbWtYCTqxrCkojzy649

---
_Generated by [Claude Code](https://claude.ai/code/session_014uMgbWtYCTqxrCkojzy649)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `docs fetch-authorities` command to pre-fetch and cache all unique rule authority documentation URLs. Includes configurable time-to-live and force-refresh options for effective cache management.

* **Documentation**
  * Updated CLI reference and vendor documentation guides with full documentation of the new `fetch-authorities` command, including complete usage examples and cache behavior details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->