### PR TITLE
feat(scan): support skill-folder scanning

### DIFF
--- a/.hermes/plans/reference/pr-95-actionable-fixes/index.md
+++ b/.hermes/plans/reference/pr-95-actionable-fixes/index.md
@@ -1,0 +1,28 @@
+# PR #95 actionable fixes
+
+- **Status:** PASS
+- **Result:** Fixed both current-head actionable findings with the existing `_ignore_path` normalization helper: platform validation now receives `SKILL.md` for folder targets, and manifest skill declarations deduplicate folder/file aliases while preserving the first declared target.
+- **Scope / changed paths:**
+  - `packages/skilllint/scan_runtime.py`
+  - `packages/skilllint/tests/test_scan_runtime.py`
+
+## Validation
+
+- `uv run --project /tmp/skilllint-slice2-20260806 pytest --no-cov packages/skilllint/tests/test_scan_runtime.py packages/skilllint/tests/test_cli.py packages/skilllint/tests/test_markdown_token_counter.py -q` — **104 passed, 1 skipped**.
+- `uv run --project /tmp/skilllint-slice2-20260806 pytest --no-cov packages/skilllint/tests/test_scan_runtime.py -q` — **29 passed**.
+- Ruff check — **passed**.
+- Ty check — **passed**.
+- `prek run --files packages/skilllint/scan_runtime.py packages/skilllint/tests/test_scan_runtime.py` — **passed**.
+- `git diff --check` — **passed**.
+
+## Decisions / follow-ups
+
+No compatibility shim, new abstraction, or unrelated change added. The pre-existing `claude-review` infrastructure failure remains classified as expected and was not retried.
+
+Links: none.
+
+Commit and push are recorded after this report is created.
+
+## Evidence
+
+The focused regression covers platform callback normalization and duplicate manifest declarations (`skills/foo` plus `skills/foo/SKILL.md`).

--- a/.hermes/plans/reference/pr-95-ignore-path-fix.md
+++ b/.hermes/plans/reference/pr-95-ignore-path-fix.md
@@ -1,0 +1,30 @@
+# PR #95: normalized ignore-path fix
+
+## Finding
+`run_validation_loop` passed folder targets to `_build_gitignore_set` but checked the concrete `SKILL.md` path via `_ignore_path`, so gitignored skill folders could be validated instead of skipped.
+
+## Fix
+Build the ignored set from `_ignore_path(path)` for every expanded target. This preserves direct-file targets and keeps folder targets represented by their direct `SKILL.md`; validation still receives the original folder path.
+
+## Call flow
+`plugin_validator` expands targets and calls `run_validation_loop`; its local `_should_skip` performs pattern/gitignore checks, and the loop passes `_ignore_path(path)` into it.
+
+## Verification
+- `uv run pytest packages/skilllint/tests/test_scan_runtime.py -q --no-cov` — 28 passed
+- `uv run ruff check ...` and `uv run ruff format --check ...` — passed
+- `uv run ty check packages/skilllint/scan_runtime.py packages/skilllint/tests/test_scan_runtime.py` — passed
+- `prek run --files packages/skilllint/scan_runtime.py packages/skilllint/tests/test_scan_runtime.py` — passed
+- `git diff --check` — passed
+
+## Commit
+The final commit is available from `git rev-parse HEAD` in this worktree.
+
+## Changed paths
+- `packages/skilllint/scan_runtime.py`
+- `packages/skilllint/tests/test_scan_runtime.py`
+
+## Scope
+No merge performed; only the bounded ignore-path fix and its focused regression test were changed.
+
+## Durable index
+This file is the durable report index for the fix and verification evidence.

--- a/.hermes/plans/reference/pr-95-slice2-review-fixes.md
+++ b/.hermes/plans/reference/pr-95-slice2-review-fixes.md
@@ -1,0 +1,21 @@
+# PR #95 review-fix report
+
+- Branch: `feat/issue-88-skill-folder-scanning`
+- Scope: `scan_runtime.py`, `plugin_validator.py`, `test_cli.py`, `test_markdown_token_counter.py`
+- Codex P1 fixes: skill-folder ignore matching now uses concrete `SKILL.md`; `--platform` normalizes skill-folder targets before adapter validation.
+- CodeRabbit fixes: plugin test drives plugin-root manifest discovery and asserts `SKILL.md`; missing-link regression asserts failure and one target; token test includes nested markdown and asserts exact complete output.
+- Validation: `uv run pytest --no-cov packages/skilllint/tests/test_cli.py packages/skilllint/tests/test_markdown_token_counter.py packages/skilllint/tests/test_scan_context.py` — 139 passed, 1 skipped.
+- Focused platform/regression tests: 11 passed.
+- Lint/format: targeted Ruff check passed; targeted Ruff format check passed; `git diff --check` passed.
+- Skipped findings: none.
+- Commit: recorded in the delivery summary; verify with `git rev-parse HEAD`.
+
+## Review-finding index
+
+| Finding | Status | Evidence |
+|---|---|---|
+| Codex P1: ignore matching loses concrete SKILL.md | Fixed | `_ignore_path()` in `scan_runtime.py` |
+| Codex P1: platform path bypasses folder normalization | Fixed | platform branch in `plugin_validator.py` |
+| CodeRabbit: plugin-contained test bypasses discovery | Fixed | `test_plugin_contained_skill_folder_validates` |
+| CodeRabbit: valid-link test is vacuous | Fixed | missing-link regression in `test_cli.py` |
+| CodeRabbit: token test truncates tabbed output | Fixed | exact output assertion with nested resource |

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -5523,6 +5523,8 @@ def main(
 
     def _run_validation_command() -> None:
         expanded_paths, is_batch = _resolve_filter_and_expand_paths(paths, filter_glob, filter_type)
+        if platform_override is not None:
+            expanded_paths = [_normalize_skill_folder(path) for path in expanded_paths]
 
         if tokens_only:
             _handle_tokens_only(expanded_paths, batch=is_batch)

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -5096,6 +5096,16 @@ def _collect_validator_results(
     return results
 
 
+def _normalize_skill_folder(path: Path) -> Path:
+    """Map a skill folder entrypoint to its direct ``SKILL.md`` file.
+
+    Returns:
+        The direct skill file for a skill folder, otherwise the original path.
+    """
+    skill_file = path / "SKILL.md"
+    return skill_file if path.is_dir() and skill_file.is_file() else path
+
+
 def validate_single_path(
     path: Path,
     *,
@@ -5126,6 +5136,8 @@ def validate_single_path(
     if not path.exists():
         typer.echo(f"Error: Path does not exist: {path}", err=True)
         raise typer.Exit(2) from None
+
+    path = _normalize_skill_folder(path)
 
     validators = _get_validators_for_path(path)
     if not validators:
@@ -5194,12 +5206,13 @@ def _handle_tokens_only(paths: list[Path], *, batch: bool = False) -> None:
         if not path.exists():
             typer.echo(f"Error: Path does not exist: {path}", err=True)
             raise typer.Exit(2) from None
+        normalized_path = _normalize_skill_folder(path)
         # Always count body-only so output matches ComplexityValidator thresholds
-        token_count = counter.count_file_tokens(path, body_only=True)
+        token_count = counter.count_file_tokens(normalized_path, body_only=True)
         if token_count is None:
-            typer.echo(f"Error: Could not count tokens for: {path}", err=True)
+            typer.echo(f"Error: Could not count tokens for: {normalized_path}", err=True)
             raise typer.Exit(2) from None
-        entries.append((token_count, path))
+        entries.append((token_count, normalized_path))
 
     if batch:
         for count, path in entries:

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -158,17 +158,12 @@ def _discover_plugin_paths(manifest: PluginManifest) -> list[Path]:
     if manifest.is_manifest_driven:
         # Intentionally no existence check — missing declared paths are a lint error.
         # Skills entries may be directories (e.g. "./skills/my-skill/") or
-        # direct SKILL.md paths. Use the path name to distinguish: a path whose
-        # final component is "SKILL.md" is a direct file reference; anything else
-        # is treated as a skill directory and resolved to its SKILL.md child.
-        # This avoids an is_dir() check that would silently drop non-existent dirs.
+        # direct SKILL.md paths. Preserve direct files; folder declarations are
+        # folder-backed targets so the validator bridge can resolve SKILL.md.
         if manifest.skills is not None:
             for rel in manifest.skills:
                 resolved = root / rel
-                if resolved.name == "SKILL.md":
-                    discovered.add(resolved)
-                else:
-                    discovered.add(resolved / "SKILL.md")
+                discovered.add(resolved)
         # Agents and commands entries should be direct file paths.
         for path_list in (manifest.agents, manifest.commands):
             if path_list is not None:
@@ -176,7 +171,7 @@ def _discover_plugin_paths(manifest: PluginManifest) -> list[Path]:
     else:
         discovered.update(root.glob("agents/*.md"))
         discovered.update(root.glob("commands/*.md"))
-        discovered.update(root.glob("skills/*/SKILL.md"))
+        discovered.update(path.parent for path in root.glob("skills/*/SKILL.md"))
 
     discovered.add(root)
 
@@ -216,6 +211,11 @@ def detect_scan_context(directory: Path) -> ScanContext:
     if directory.name in KNOWN_PROVIDER_DIRS:
         return ScanContext.PROVIDER
     return ScanContext.BARE
+
+
+def _is_skill_folder(path: Path) -> bool:
+    """Return whether *path* is a standalone folder-backed skill target."""
+    return path.is_dir() and (path / "SKILL.md").is_file()
 
 
 def _discover_provider_paths(directory: Path) -> list[Path]:
@@ -265,6 +265,9 @@ def _discover_validatable_paths(directory: Path) -> list[Path]:
     if context == ScanContext.PROVIDER:
         return _discover_provider_paths(directory)
 
+    if _is_skill_folder(directory):
+        return [directory]
+
     # BARE context: find nested plugins and providers, then apply DEFAULT_SCAN_PATTERNS
     discovered: set[Path] = set()
     plugin_roots: set[Path] = set()
@@ -294,7 +297,12 @@ def _discover_validatable_paths(directory: Path) -> list[Path]:
     for pattern in DEFAULT_SCAN_PATTERNS:
         for match in directory.glob(pattern):
             # For plugin.json matches, add the plugin root (grandparent)
-            candidate = match.parent.parent if pattern.endswith("plugin.json") else match
+            if pattern.endswith("plugin.json"):
+                candidate = match.parent.parent
+            elif pattern.endswith("skills/*/SKILL.md"):
+                candidate = match.parent
+            else:
+                candidate = match
             # Only add if not already inside a discovered plugin/provider tree
             if not any(candidate.is_relative_to(root) for root in covered_roots):
                 discovered.add(candidate)
@@ -339,6 +347,8 @@ def _resolve_filter_and_expand_paths(
             resolved_glob = filter_glob
         if resolved_glob is not None and path.is_dir():
             matched = sorted(path.glob(resolved_glob))
+            if filter_type == "skills":
+                matched = [match.parent for match in matched]
             expanded_paths.extend(matched)
             is_batch = True
         elif resolved_glob is None and path.is_dir():

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -235,6 +235,41 @@ def _discover_provider_paths(directory: Path) -> list[Path]:
     return sorted(set(directory.glob("agents/**/*.md")))
 
 
+def _discover_bare_paths(directory: Path) -> list[Path]:
+    """Discover paths in a bare directory outside plugin/provider subtrees.
+
+    Returns:
+        Sorted validatable paths discovered outside nested plugin/provider roots.
+    """
+    discovered: set[Path] = set()
+    plugin_roots: set[Path] = set()
+    for plugin_json in directory.glob("**/.claude-plugin/plugin.json"):
+        plugin_root = plugin_json.parent.parent
+        plugin_roots.add(plugin_root)
+        discovered.update(_discover_plugin_paths(_parse_plugin_manifest(plugin_root)))
+
+    provider_roots: set[Path] = set()
+    for provider_name in KNOWN_PROVIDER_DIRS:
+        for provider_dir in directory.glob(f"**/{provider_name}"):
+            if not provider_dir.is_dir() or any(provider_dir.is_relative_to(root) for root in plugin_roots):
+                continue
+            provider_roots.add(provider_dir)
+            discovered.update(_discover_provider_paths(provider_dir))
+
+    covered_roots = plugin_roots | provider_roots
+    for pattern in DEFAULT_SCAN_PATTERNS:
+        for match in directory.glob(pattern):
+            if pattern.endswith("plugin.json"):
+                candidate = match.parent.parent
+            elif pattern.endswith("skills/*/SKILL.md"):
+                candidate = match.parent
+            else:
+                candidate = match
+            if not any(candidate.is_relative_to(root) for root in covered_roots):
+                discovered.add(candidate)
+    return sorted(discovered)
+
+
 # ---------------------------------------------------------------------------
 # Path discovery and filtering
 # ---------------------------------------------------------------------------
@@ -268,46 +303,7 @@ def _discover_validatable_paths(directory: Path) -> list[Path]:
     if _is_skill_folder(directory):
         return [directory]
 
-    # BARE context: find nested plugins and providers, then apply DEFAULT_SCAN_PATTERNS
-    discovered: set[Path] = set()
-    plugin_roots: set[Path] = set()
-
-    # Find nested plugin roots
-    for plugin_json in directory.glob("**/.claude-plugin/plugin.json"):
-        plugin_root = plugin_json.parent.parent
-        plugin_roots.add(plugin_root)
-        manifest = _parse_plugin_manifest(plugin_root)
-        discovered.update(_discover_plugin_paths(manifest))
-
-    # Find nested provider directories (skip those inside plugin trees)
-    provider_roots: set[Path] = set()
-    for provider_name in KNOWN_PROVIDER_DIRS:
-        for provider_dir in directory.glob(f"**/{provider_name}"):
-            if not provider_dir.is_dir():
-                continue
-            # Plugin takes precedence: skip providers inside plugin trees
-            if any(provider_dir.is_relative_to(pr) for pr in plugin_roots):
-                continue
-            provider_roots.add(provider_dir)
-            discovered.update(_discover_provider_paths(provider_dir))
-
-    # Files outside any plugin/provider subtree: use DEFAULT_SCAN_PATTERNS
-    covered_roots = plugin_roots | provider_roots
-
-    for pattern in DEFAULT_SCAN_PATTERNS:
-        for match in directory.glob(pattern):
-            # For plugin.json matches, add the plugin root (grandparent)
-            if pattern.endswith("plugin.json"):
-                candidate = match.parent.parent
-            elif pattern.endswith("skills/*/SKILL.md"):
-                candidate = match.parent
-            else:
-                candidate = match
-            # Only add if not already inside a discovered plugin/provider tree
-            if not any(candidate.is_relative_to(root) for root in covered_roots):
-                discovered.add(candidate)
-
-    return sorted(discovered)
+    return _discover_bare_paths(directory)
 
 
 def _resolve_filter_and_expand_paths(

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -161,9 +161,11 @@ def _discover_plugin_paths(manifest: PluginManifest) -> list[Path]:
         # direct SKILL.md paths. Preserve direct files; folder declarations are
         # folder-backed targets so the validator bridge can resolve SKILL.md.
         if manifest.skills is not None:
+            skill_paths: dict[Path, Path] = {}
             for rel in manifest.skills:
                 resolved = root / rel
-                discovered.add(resolved)
+                skill_paths.setdefault(_ignore_path(resolved), resolved)
+            discovered.update(skill_paths.values())
         # Agents and commands entries should be direct file paths.
         for path_list in (manifest.agents, manifest.commands):
             if path_list is not None:
@@ -571,7 +573,7 @@ def run_validation_loop(
         if _should_skip(_ignore_path(path)):
             continue
         if platform_override is not None:
-            violations = validate_file(path, adapters, platform_override)
+            violations = validate_file(_ignore_path(path), adapters, platform_override)
             all_results[path] = [("platform", violations_to_result(violations))]
         else:
             file_results = validate_single_path(path, check=check, fix=fix, verbose=verbose)

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -556,7 +556,9 @@ def run_validation_loop(
     scan_base = _compute_scan_base(expanded_paths)
 
     ignored_set: frozenset[str] = (
-        _build_gitignore_set(expanded_paths, scan_base) if not include_gitignore else frozenset()
+        _build_gitignore_set([_ignore_path(path) for path in expanded_paths], scan_base)
+        if not include_gitignore
+        else frozenset()
     )
 
     def _should_skip(p: Path) -> bool:

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -502,6 +502,12 @@ ValidateFileFn = Callable[[Path, dict[str, object], str | None], list[dict]]
 ViolationsToResultFn = Callable[[list[dict]], Any]
 
 
+def _ignore_path(path: Path) -> Path:
+    """Return the concrete skill file for ignore matching when applicable."""
+    skill_file = path / "SKILL.md"
+    return skill_file if path.is_dir() and skill_file.is_file() else path
+
+
 def run_validation_loop(
     *,
     expanded_paths: list[Path],
@@ -560,7 +566,7 @@ def run_validation_loop(
 
     all_results: FileResults = {}
     for path in expanded_paths:
-        if _should_skip(path):
+        if _should_skip(_ignore_path(path)):
             continue
         if platform_override is not None:
             violations = validate_file(path, adapters, platform_override)

--- a/packages/skilllint/tests/test_cli.py
+++ b/packages/skilllint/tests/test_cli.py
@@ -432,10 +432,26 @@ class TestPathArguments:
         self, cli_runner: CliRunner, sample_plugin_dir: Path, no_color_env: None
     ) -> None:
         """Plugin-discovered skill folders use the same file validator bridge."""
-        skill_dir = sample_plugin_dir / "skills" / "test-skill"
-        result = cli_runner.invoke(plugin_validator.app, ["check", "--no-color", str(skill_dir)])
+        result = cli_runner.invoke(plugin_validator.app, ["check", "--no-color", "--verbose", str(sample_plugin_dir)])
 
         assert result.exit_code == 0, result.stdout
+        assert "SKILL.md" in result.stdout
+
+    def test_skill_folder_reports_missing_link_without_nested_targets(
+        self, cli_runner: CliRunner, tmp_path: Path, no_color_env: None
+    ) -> None:
+        """A missing skill link fails while the folder remains one target."""
+        skill_dir = tmp_path / "broken-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: broken-skill\ndescription: Test missing links\n---\n\n"
+            "See [the missing guide](./references/missing.md).\n"
+        )
+
+        result = cli_runner.invoke(plugin_validator.app, ["check", "--no-color", "--show-summary", str(skill_dir)])
+
+        assert result.exit_code == 1, result.stdout
+        assert "Total files: 1" in result.stdout
 
 
 class TestErrorMessages:

--- a/packages/skilllint/tests/test_cli.py
+++ b/packages/skilllint/tests/test_cli.py
@@ -399,6 +399,44 @@ class TestPathArguments:
         # This test just verifies CLI doesn't crash on relative paths
         assert result.exit_code in {0, 1, 2}
 
+    def test_accepts_skill_folder_and_validates_its_skill_file(
+        self, cli_runner: CliRunner, sample_skill_dir: Path, no_color_env: None
+    ) -> None:
+        """A direct skill folder reaches the existing SKILL.md validators once."""
+        result = cli_runner.invoke(
+            plugin_validator.app, ["check", "--no-color", "--show-summary", str(sample_skill_dir)]
+        )
+
+        assert result.exit_code == 0, result.stdout
+        assert "Total files: 1" in result.stdout
+
+    def test_skill_folder_preserves_link_validation_without_nested_targets(
+        self, cli_runner: CliRunner, tmp_path: Path, no_color_env: None
+    ) -> None:
+        """Folder validation checks SKILL.md links, not nested files as targets."""
+        skill_dir = tmp_path / "linked-skill"
+        skill_dir.mkdir()
+        (skill_dir / "references").mkdir()
+        (skill_dir / "references" / "guide.md").write_text("# Guide\n")
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: linked-skill\ndescription: Use this skill when checking folder links\n---\n\n"
+            "See [the guide](./references/guide.md).\n"
+        )
+
+        result = cli_runner.invoke(plugin_validator.app, ["check", "--no-color", "--show-summary", str(skill_dir)])
+
+        assert result.exit_code == 0, result.stdout
+        assert "Total files: 1" in result.stdout
+
+    def test_plugin_contained_skill_folder_validates(
+        self, cli_runner: CliRunner, sample_plugin_dir: Path, no_color_env: None
+    ) -> None:
+        """Plugin-discovered skill folders use the same file validator bridge."""
+        skill_dir = sample_plugin_dir / "skills" / "test-skill"
+        result = cli_runner.invoke(plugin_validator.app, ["check", "--no-color", str(skill_dir)])
+
+        assert result.exit_code == 0, result.stdout
+
 
 class TestErrorMessages:
     """Test error message clarity and actionability."""

--- a/packages/skilllint/tests/test_markdown_token_counter.py
+++ b/packages/skilllint/tests/test_markdown_token_counter.py
@@ -375,6 +375,18 @@ class TestTokensOnlyCLIFlag:
         assert result.exit_code == 0
         assert "--tokens-only" in result.stdout
 
+    def test_tokens_only_folder_matches_direct_skill_file(
+        self, cli_runner: CliRunner, sample_skill_dir: Path, no_color_env: None
+    ) -> None:
+        """A skill-folder entrypoint counts only its direct SKILL.md body."""
+        skill_file = sample_skill_dir / "SKILL.md"
+        folder = cli_runner.invoke(plugin_validator.app, ["check", "--tokens-only", str(sample_skill_dir)])
+        direct = cli_runner.invoke(plugin_validator.app, ["check", "--tokens-only", str(skill_file)])
+
+        assert folder.exit_code == 0, folder.stdout
+        assert direct.exit_code == 0, direct.stdout
+        assert folder.stdout.strip().split("\t", 1)[0] == direct.stdout.strip()
+
 
 class TestCLIMarkdownValidation:
     """Test CLI integration for general markdown file validation."""

--- a/packages/skilllint/tests/test_markdown_token_counter.py
+++ b/packages/skilllint/tests/test_markdown_token_counter.py
@@ -380,12 +380,18 @@ class TestTokensOnlyCLIFlag:
     ) -> None:
         """A skill-folder entrypoint counts only its direct SKILL.md body."""
         skill_file = sample_skill_dir / "SKILL.md"
+        references = sample_skill_dir / "references"
+        references.mkdir()
+        (references / "guide.md").write_text("# Nested guide\n\nThis must not be counted as a target.\n")
         folder = cli_runner.invoke(plugin_validator.app, ["check", "--tokens-only", str(sample_skill_dir)])
         direct = cli_runner.invoke(plugin_validator.app, ["check", "--tokens-only", str(skill_file)])
 
         assert folder.exit_code == 0, folder.stdout
         assert direct.exit_code == 0, direct.stdout
-        assert folder.stdout.strip().split("\t", 1)[0] == direct.stdout.strip()
+        expected = plugin_validator.MarkdownTokenCounter().count_file_tokens(skill_file, body_only=True)
+        assert expected is not None
+        assert folder.stdout.strip() == f"{expected}\t{skill_file}"
+        assert direct.stdout.strip() == str(expected)
 
 
 class TestCLIMarkdownValidation:

--- a/packages/skilllint/tests/test_scan_context.py
+++ b/packages/skilllint/tests/test_scan_context.py
@@ -702,7 +702,7 @@ class TestDiscoverPluginPaths:
         result = _discover_plugin_paths(manifest)
 
         # Assert
-        assert tmp_path / "skills" / "my-skill" / "SKILL.md" in result
+        assert tmp_path / "skills" / "my-skill" in result
 
     def test_convention_driven_excludes_skill_internal_agents(self, tmp_path: Path) -> None:
         """Core false-positive scenario: skills/*/agents/ must never be discovered.
@@ -842,7 +842,7 @@ class TestDiscoverPluginPaths:
         result = _discover_plugin_paths(manifest)
 
         # Assert
-        assert tmp_path / "skills" / "review" / "SKILL.md" in result
+        assert tmp_path / "skills" / "review" in result
 
     def test_manifest_driven_always_includes_plugin_root(self, tmp_path: Path) -> None:
         """Manifest mode always includes the plugin root directory.
@@ -880,7 +880,7 @@ class TestDiscoverPluginPaths:
         result = _discover_plugin_paths(manifest)
 
         # Assert — path present despite not existing on disk
-        assert tmp_path / "skills" / "ghost-skill" / "SKILL.md" in result
+        assert tmp_path / "skills" / "ghost-skill" in result
 
     def test_manifest_driven_includes_declared_agent_even_when_file_missing(self, tmp_path: Path) -> None:
         """Declared agent file is included even when it does not exist on disk.
@@ -957,7 +957,7 @@ class TestIntegrationContextAwareDiscovery:
 
         # Assert
         assert tmp_path / "agents" / "main.md" in result
-        assert tmp_path / "skills" / "my-skill" / "SKILL.md" in result
+        assert tmp_path / "skills" / "my-skill" in result
         assert tmp_path / "skills" / "my-skill" / "agents" / "helper.md" not in result
 
     def test_filter_type_agents_on_plugin_uses_root_only_glob(self, tmp_path: Path) -> None:
@@ -1188,13 +1188,13 @@ class TestBareDirectoryRegressionCompatibility:
         result = _discover_validatable_paths(tmp_path)
 
         # Assert — every file created must appear in the result
-        assert tmp_path / "skills" / "my-skill" / "SKILL.md" in result
+        assert tmp_path / "skills" / "my-skill" in result
         assert tmp_path / "agents" / "helper.md" in result
         assert tmp_path / "commands" / "run.md" in result
         assert tmp_path / "hooks" / "hooks.json" in result
         assert tmp_path / "CLAUDE.md" in result
         assert tmp_path / "subdir" / "agents" / "nested-agent.md" in result
-        assert tmp_path / "subdir" / "skills" / "other-skill" / "SKILL.md" in result
+        assert tmp_path / "subdir" / "skills" / "other-skill" in result
 
     def test_bare_directory_with_plugin_json_includes_plugin_root(self, tmp_path: Path) -> None:
         """Directory with .claude-plugin/plugin.json routes through PLUGIN context.

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -281,17 +281,53 @@ class TestResolveFilterAndExpandPaths:
         plugin_dir = tmp_path / "my-plugin"
         (plugin_dir / ".claude-plugin").mkdir(parents=True)
         (plugin_dir / "skills" / "folder").mkdir(parents=True)
+        (plugin_dir / "skills" / "folder" / "SKILL.md").write_text("---\ndescription: folder\n---\n# Folder\n")
         direct = plugin_dir / "skills" / "direct" / "SKILL.md"
         direct.parent.mkdir()
         direct.write_text("---\ndescription: direct\n---\n# Direct\n")
         (plugin_dir / ".claude-plugin" / "plugin.json").write_text(
-            '{"name": "my-plugin", "skills": ["skills/folder", "skills/direct/SKILL.md"]}'
+            '{"name": "my-plugin", "skills": ["skills/folder", "skills/folder/SKILL.md", "skills/direct/SKILL.md"]}'
         )
 
         discovered = _discover_validatable_paths(plugin_dir)
 
         assert plugin_dir / "skills" / "folder" in discovered
+        assert plugin_dir / "skills" / "folder/SKILL.md" not in discovered
         assert direct in discovered
+
+    def test_platform_validation_normalizes_skill_folder(self, tmp_path: Path) -> None:
+        import typer
+
+        from skilllint.plugin_validator import ValidationResult
+
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        skill_file = skill_dir / "SKILL.md"
+        skill_file.write_text("---\ndescription: Test\n---\n# Test\n")
+        seen: list[Path] = []
+
+        def validate_file(path: Path, _adapters: dict, _platform: str | None) -> list[dict]:
+            seen.append(path)
+            return []
+
+        with pytest.raises(typer.Exit) as exc_info:
+            run_validation_loop(
+                expanded_paths=[skill_dir],
+                check=True,
+                fix=False,
+                verbose=False,
+                no_color=True,
+                show_progress=False,
+                show_summary=False,
+                platform_override="claude",
+                validate_single_path=lambda **_kwargs: pytest.fail("platform path used default validation"),
+                validate_file=validate_file,
+                violations_to_result=lambda _violations: ValidationResult(passed=True, errors=[], warnings=[], info=[]),
+                adapters={},
+            )
+
+        assert exc_info.value.exit_code == 0
+        assert seen == [skill_file]
 
     def test_gitignore_matching_uses_skill_file_for_folder_targets(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -24,6 +24,7 @@ from skilllint.scan_runtime import (
     _compute_summary,
     _discover_validatable_paths,
     _resolve_filter_and_expand_paths,
+    run_validation_loop,
 )
 
 if TYPE_CHECKING:
@@ -291,6 +292,44 @@ class TestResolveFilterAndExpandPaths:
 
         assert plugin_dir / "skills" / "folder" in discovered
         assert direct in discovered
+
+    def test_gitignore_matching_uses_skill_file_for_folder_targets(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Gitignore evaluation uses the concrete SKILL.md for folder targets."""
+        import typer
+
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        skill_file = skill_dir / "SKILL.md"
+        skill_file.write_text("---\ndescription: Test\n---\n# Test\n")
+        seen: list[Path] = []
+
+        def build_gitignore_set(paths: list[Path], _scan_base: Path | None) -> frozenset[str]:
+            seen.extend(paths)
+            return frozenset(str(path.resolve()) for path in paths)
+
+        monkeypatch.setattr("skilllint.scan_runtime._load_ignore_patterns", list)
+        monkeypatch.setattr("skilllint.scan_runtime._build_gitignore_set", build_gitignore_set)
+
+        with pytest.raises(typer.Exit) as exc_info:
+            run_validation_loop(
+                expanded_paths=[skill_dir],
+                check=True,
+                fix=False,
+                verbose=False,
+                no_color=True,
+                show_progress=False,
+                show_summary=False,
+                platform_override=None,
+                validate_single_path=lambda **_kwargs: pytest.fail("ignored skill was validated"),
+                validate_file=lambda *_args: pytest.fail("ignored skill was validated"),
+                violations_to_result=lambda violations: violations,
+                adapters={},
+            )
+
+        assert exc_info.value.exit_code == 0
+        assert seen == [skill_file]
 
 
 class TestComputeSummary:

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -49,8 +49,7 @@ class TestDiscoverValidatablePaths:
 
         discovered = _discover_validatable_paths(tmp_path)
 
-        skill_file = skill_dir / "SKILL.md"
-        assert skill_file in discovered, f"Expected {skill_file} in discovered paths: {discovered}"
+        assert discovered == [skill_dir], f"Expected folder-backed target: {discovered}"
 
     def test_discovers_agent_files(self, tmp_path: Path) -> None:
         """_discover_validatable_paths finds agent .md files.
@@ -129,6 +128,19 @@ class TestDiscoverValidatablePaths:
         discovered = _discover_validatable_paths(tmp_path)
         assert discovered == []
 
+    def test_direct_skill_folder_is_one_target(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("---\ndescription: Test\n---\n# Test\n")
+        (skill_dir / "references").mkdir()
+        (skill_dir / "references" / "rule-catalog.md").write_text("# Rules\n")
+        (skill_dir / "agents").mkdir()
+        (skill_dir / "agents" / "nested.md").write_text("# Nested\n")
+        (skill_dir / "commands").mkdir()
+        (skill_dir / "commands" / "nested.md").write_text("# Nested\n")
+
+        assert _discover_validatable_paths(skill_dir) == [skill_dir]
+
 
 class TestResolveFilterAndExpandPaths:
     """Tests for _resolve_filter_and_expand_paths seam."""
@@ -147,8 +159,7 @@ class TestResolveFilterAndExpandPaths:
 
         expanded, is_batch = _resolve_filter_and_expand_paths([tmp_path], None, None)
 
-        skill_file = skill_dir / "SKILL.md"
-        assert skill_file in expanded, f"Expected {skill_file} in expanded: {expanded}"
+        assert expanded == [skill_dir], f"Expected folder-backed target: {expanded}"
         assert is_batch is True, "Expected is_batch=True for directory expansion"
 
     def test_passes_through_files(self, tmp_path: Path) -> None:
@@ -185,9 +196,8 @@ class TestResolveFilterAndExpandPaths:
 
         expanded, is_batch = _resolve_filter_and_expand_paths([tmp_path], None, "skills")
 
-        skill_file = skill_dir / "SKILL.md"
         agent_file = agents_dir / "agent.md"
-        assert skill_file in expanded, f"Expected {skill_file} in expanded"
+        assert skill_dir in expanded, f"Expected {skill_dir} in expanded"
         assert agent_file not in expanded, f"Did not expect {agent_file} when filtering for skills"
         assert is_batch is True
 
@@ -252,6 +262,35 @@ class TestResolveFilterAndExpandPaths:
 
         # Plugin dir should be in expanded (as-is, not expanded)
         assert plugin_dir in expanded, f"Expected {plugin_dir} in expanded: {expanded}"
+
+    def test_plugin_discovers_skill_folders_and_root(self, tmp_path: Path) -> None:
+        plugin_dir = tmp_path / "my-plugin"
+        (plugin_dir / ".claude-plugin").mkdir(parents=True)
+        (plugin_dir / ".claude-plugin" / "plugin.json").write_text('{"name": "my-plugin"}')
+        for name in ("alpha", "beta"):
+            skill_dir = plugin_dir / "skills" / name
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(f"---\ndescription: {name}\n---\n# {name}\n")
+
+        discovered = _discover_validatable_paths(plugin_dir)
+
+        assert discovered == sorted([plugin_dir, plugin_dir / "skills" / "alpha", plugin_dir / "skills" / "beta"])
+
+    def test_manifest_preserves_direct_skill_file_and_folder_entry(self, tmp_path: Path) -> None:
+        plugin_dir = tmp_path / "my-plugin"
+        (plugin_dir / ".claude-plugin").mkdir(parents=True)
+        (plugin_dir / "skills" / "folder").mkdir(parents=True)
+        direct = plugin_dir / "skills" / "direct" / "SKILL.md"
+        direct.parent.mkdir()
+        direct.write_text("---\ndescription: direct\n---\n# Direct\n")
+        (plugin_dir / ".claude-plugin" / "plugin.json").write_text(
+            '{"name": "my-plugin", "skills": ["skills/folder", "skills/direct/SKILL.md"]}'
+        )
+
+        discovered = _discover_validatable_paths(plugin_dir)
+
+        assert plugin_dir / "skills" / "folder" in discovered
+        assert direct in discovered
 
 
 class TestComputeSummary:


### PR DESCRIPTION
## Summary

- discover standalone skill folders through their direct `SKILL.md` entrypoint
- preserve direct-file compatibility and plugin scanning semantics
- validate folder inputs and keep `--tokens-only` scoped to `SKILL.md`
- retain nested resources as existence/link inputs rather than validation targets

Closes #88

## Validation

- Focused issue-88 suite: 165 passed, 1 skipped
- Full suite: 1166 passed
- Ruff, Ty, Prek, `git diff --check`: passed
- Neutral-CWD CLI probes: passed
- Folder/direct-file token counts: both 1638

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Skill folders can now be scanned, validated, and token-counted directly.
  - Plugin discovery recognizes both skill directories and direct `SKILL.md` files.
  - Scan results consistently report the relevant skill folder or file path.

- **Bug Fixes**
  - Improved handling of nested skills and linked files to prevent duplicate validation targets.
  - Preserved declared plugin paths during discovery and validation.
  - Improved ignore-path and platform validation for skill folders.

- **Tests**
  - Added coverage for skill-folder validation, discovery, linking, filtering, and token counting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->