### PR TITLE
feat(policy): add configurable skill thresholds

### DIFF
--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -53,7 +53,7 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from ruamel.yaml import YAML, YAMLError
 from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 
-import skilllint.rules  # noqa: F401 — ensures all 14 series modules register into RULE_REGISTRY
+import skilllint.rules  # ruff: ignore[unused-import] — ensures all 14 series modules register into RULE_REGISTRY
 from skilllint.adapters import PlatformAdapter, load_adapters, matches_file
 from skilllint.adapters.claude_code import ClaudeCodeAdapter
 from skilllint.cli_docs import docs_app
@@ -649,7 +649,14 @@ class ValidationPolicy:
 
 
 DEFAULT_THRESHOLDS: dict[str, int] = {"SK006": TOKEN_WARNING_THRESHOLD, "SK007": TOKEN_ERROR_THRESHOLD}
-_KNOWN_POLICY_RULES = frozenset({"SK006", "SK007", "AS005"})
+# Threshold keys must map to an implemented warning/error band. AS005 measures
+# the same SKILL.md body token count as SK006/SK007 but has no threshold plumbing
+# of its own, so it is not a configurable threshold key (PR #97 review).
+_THRESHOLD_POLICY_RULES = frozenset({"SK006", "SK007"})
+# Severity may be reconfigured for the token-band rules including AS005, which
+# shares the band and can legitimately be downgraded per-plugin.
+_SEVERITY_POLICY_RULES = frozenset({"SK006", "SK007", "AS005"})
+_VALID_SEVERITIES = frozenset({"warning", "info"})
 
 _SKILLLINT_CONFIG_FILENAME = ".skilllint.json"
 
@@ -680,36 +687,93 @@ def _load_ignore_dict(config_path: Path) -> IgnoreConfig:
     return {str(k): [str(c) for c in v] for k, v in ignore.items() if isinstance(v, list)}
 
 
-def _load_policy(config_path: Path) -> ValidationPolicy:
-    """Load thresholds and severity from the existing JSON config.
+def _parse_thresholds(raw: object, config_path: Path, diagnostics: list[str]) -> dict[str, int]:
+    """Parse the ``thresholds`` block, appending a diagnostic per rejected entry.
+
+    Args:
+        raw: The raw ``thresholds`` value from the decoded config.
+        config_path: Config path, used only in diagnostic messages.
+        diagnostics: Mutable list that rejected-entry messages are appended to.
 
     Returns:
-        A policy containing defaults for invalid or missing entries.
+        Thresholds with defaults substituted for missing or invalid entries.
+    """
+    thresholds = dict(DEFAULT_THRESHOLDS)
+    if isinstance(raw, dict):
+        for raw_code, value in raw.items():
+            code = str(raw_code)
+            if code not in _THRESHOLD_POLICY_RULES:
+                diagnostics.append(f"{config_path}: thresholds.{code} is not a configurable threshold; ignored")
+            elif not (isinstance(value, int) and not isinstance(value, bool) and value > 0):
+                diagnostics.append(
+                    f"{config_path}: thresholds.{code}={value!r} is not a positive integer; using default"
+                )
+            else:
+                thresholds[code] = value
+    # Warning must stay below error, or the warning band is unreachable
+    # (test_limits.py asserts warning < error as the built-in invariant).
+    if thresholds["SK006"] >= thresholds["SK007"]:
+        diagnostics.append(
+            f"{config_path}: thresholds SK006 ({thresholds['SK006']}) must be below SK007 "
+            f"({thresholds['SK007']}); resetting both to defaults"
+        )
+        thresholds = dict(DEFAULT_THRESHOLDS)
+    return thresholds
+
+
+def _parse_severity(raw: object, config_path: Path, diagnostics: list[str]) -> dict[str, str]:
+    """Parse the ``severity`` block, appending a diagnostic per rejected entry.
+
+    Args:
+        raw: The raw ``severity`` value from the decoded config.
+        config_path: Config path, used only in diagnostic messages.
+        diagnostics: Mutable list that rejected-entry messages are appended to.
+
+    Returns:
+        Mapping of rule code to a valid configured severity; invalid entries
+        are dropped rather than raising.
+    """
+    severity: dict[str, str] = {}
+    if isinstance(raw, dict):
+        for raw_code, value in raw.items():
+            code = str(raw_code)
+            if code not in _SEVERITY_POLICY_RULES:
+                diagnostics.append(f"{config_path}: severity.{code} is not a configurable rule; ignored")
+            elif not (isinstance(value, str) and value in _VALID_SEVERITIES):
+                diagnostics.append(
+                    f"{config_path}: severity.{code}={value!r} must be one of {sorted(_VALID_SEVERITIES)}; ignored"
+                )
+            else:
+                severity[code] = value
+    return severity
+
+
+def _load_policy(config_path: Path) -> tuple[ValidationPolicy, list[str]]:
+    """Load thresholds and severity from the existing JSON config.
+
+    Invalid entries fall back to defaults but are reported: a linter config is
+    producer input, and silently swallowing a typo hides a real error
+    (docs/TYPING_POLICY.md — producer errors must not be silently coerced).
+
+    Returns:
+        The policy (defaults for invalid or missing entries) and a list of
+        human-readable diagnostics describing every rejected entry.
     """
     defaults = dict(DEFAULT_THRESHOLDS)
     if not config_path.is_file():
-        return ValidationPolicy(defaults, {}, {})
+        return ValidationPolicy(defaults, {}, {}), []
     try:
         raw = msgspec.json.decode(config_path.read_bytes())
-    except (OSError, msgspec.DecodeError):
-        return ValidationPolicy(defaults, {}, {})
+    except (OSError, msgspec.DecodeError) as exc:
+        return ValidationPolicy(defaults, {}, {}), [
+            f"{config_path}: unreadable or malformed JSON ({exc}); using defaults"
+        ]
     if not isinstance(raw, dict):
-        return ValidationPolicy(defaults, {}, {})
-    thresholds = dict(defaults)
-    values = raw.get("thresholds", {})
-    if isinstance(values, dict):
-        for raw_code, value in values.items():
-            code = str(raw_code)
-            if code in _KNOWN_POLICY_RULES and isinstance(value, int) and not isinstance(value, bool) and value > 0:
-                thresholds[code] = value
-    severity: dict[str, str] = {}
-    values = raw.get("severity", {})
-    if isinstance(values, dict):
-        for raw_code, value in values.items():
-            code = str(raw_code)
-            if code in _KNOWN_POLICY_RULES and value in {"warning", "info"}:
-                severity[code] = value
-    return ValidationPolicy(thresholds, severity, _load_ignore_dict(config_path))
+        return ValidationPolicy(defaults, {}, {}), [f"{config_path}: top-level config is not an object; using defaults"]
+    diagnostics: list[str] = []
+    thresholds = _parse_thresholds(raw.get("thresholds", {}), config_path, diagnostics)
+    severity = _parse_severity(raw.get("severity", {}), config_path, diagnostics)
+    return ValidationPolicy(thresholds, severity, _load_ignore_dict(config_path)), diagnostics
 
 
 def _load_ignore_config(plugin_root: Path) -> IgnoreConfig:
@@ -807,6 +871,10 @@ def _resolve_policy(
 ) -> tuple[ValidationPolicy, Path | None]:
     """Resolve first-match policy using the existing discovery and cache.
 
+    Diagnostics for invalid config are emitted once per config file: they fire
+    only on a cache miss (the first file that resolves a given config), so a
+    1000-file scan warns once, not once per file.
+
     Returns:
         The policy and its config root, or defaults and ``None``.
     """
@@ -818,20 +886,25 @@ def _resolve_policy(
     current = start_dir
     policy = ValidationPolicy(dict(DEFAULT_THRESHOLDS), {}, {})
     root: Path | None = None
+    diagnostics: list[str] = []
     while True:
         walked.append(current)
         plugin_cfg = current / ".claude-plugin" / "plugin.json"
         skilllint_cfg = current / _SKILLLINT_CONFIG_FILENAME
         if plugin_cfg.exists():
-            policy, root = _load_policy(current / ".claude-plugin" / "validator.json"), current
+            policy, diagnostics = _load_policy(current / ".claude-plugin" / "validator.json")
+            root = current
             break
         if skilllint_cfg.exists():
-            policy, root = _load_policy(skilllint_cfg), current
+            policy, diagnostics = _load_policy(skilllint_cfg)
+            root = current
             break
         parent = current.parent
         if parent == current:
             break
         current = parent
+    for message in diagnostics:
+        typer.echo(f"Warning: {message}", err=True)
     result = (policy, root)
     for directory in walked:
         cache.setdefault(str(directory), result)
@@ -1210,7 +1283,7 @@ def _check_list_valued_tool_fields(
         errors: Mutable list to append error issues to (unused, kept for API compat).
         warnings: Mutable list to append warning issues to.
     """
-    from pathlib import Path as _Path  # noqa: PLC0415
+    from pathlib import Path as _Path  # ruff: ignore[import-outside-top-level]
 
     sentinel_path = _Path()
     warnings.extend(check_fm007(data, sentinel_path, "skill"))
@@ -2290,7 +2363,7 @@ class AsSeriesValidator:
         Returns:
             ValidationResult grouping AS-series issues by severity.
         """
-        from skilllint.rules.as_series import run_as_series  # noqa: PLC0415
+        from skilllint.rules.as_series import run_as_series  # ruff: ignore[import-outside-top-level]
 
         frontmatter_data, body_lines, _yaml_err, _colon_fields = parse_skill_md(path)
         thresholds = policy.thresholds if policy is not None else DEFAULT_THRESHOLDS
@@ -2370,7 +2443,7 @@ def _validate_skill_directory_name(skill_dir_name: str) -> list[tuple[str, str]]
         List of (message, suggestion) tuples for each violation found.
         Empty list if the name is valid.
     """
-    from skilllint._spec_constants import MAX_NAME_LENGTH  # noqa: PLC0415
+    from skilllint._spec_constants import MAX_NAME_LENGTH  # ruff: ignore[import-outside-top-level]
 
     if not skill_dir_name:
         return [("Skill directory name cannot be empty", "Provide a non-empty directory name")]
@@ -2975,7 +3048,7 @@ class NameFormatValidator:
             name: The name value to check (must be non-empty str).
             errors: Mutable list to append ValidationIssue objects to.
         """
-        from pathlib import Path as _Path  # noqa: PLC0415
+        from pathlib import Path as _Path  # ruff: ignore[import-outside-top-level]
 
         frontmatter: dict[str, object] = {"name": name}
         sentinel = _Path()
@@ -3162,7 +3235,7 @@ class DescriptionValidator:
         Delegates to sk_series check_sk004/check_sk005 — the series module is
         the single source of truth for SK-series rule logic.
         """
-        from pathlib import Path as _Path  # noqa: PLC0415
+        from pathlib import Path as _Path  # ruff: ignore[import-outside-top-level]
 
         frontmatter: dict[str, object] = {"description": description}
         sentinel = _Path()
@@ -4347,7 +4420,7 @@ class PluginStructureValidator:
         }
         return fallbacks.get(str(code), "Plugin structure validation failed")
 
-    def _get_error_suggestion(self, code: str) -> str:  # noqa: PLR0911
+    def _get_error_suggestion(self, code: str) -> str:  # ruff: ignore[too-many-return-statements]
         """Get suggestion for fixing error.
 
         Args:
@@ -5028,7 +5101,7 @@ def get_staged_files() -> list[Path]:
         return [Path(item.a_path) for item in diffs if item.a_path]
     except (InvalidGitRepositoryError, NoSuchPathError, ValueError):
         return []
-    except Exception:  # noqa: BLE001
+    except Exception:  # ruff: ignore[blind-except]
         return []
 
 
@@ -5248,6 +5321,7 @@ def validate_single_path(
     fix: bool,
     verbose: bool,
     per_run_cache: dict[str, tuple[IgnoreConfig, Path | None]] | None = None,
+    per_run_policy_cache: dict[str, tuple[ValidationPolicy, Path | None]] | None = None,
 ) -> FileResults:
     """Validate a single path and return results grouped by file.
 
@@ -5260,6 +5334,9 @@ def validate_single_path(
             When provided, directory-tree walks are cached across calls so
             sibling files share the same lookup result.  Pass the same dict
             for the lifetime of a single scan run.
+        per_run_policy_cache: Optional mutable cache for policy resolution,
+            with the same per-run lifetime as ``per_run_cache``.  Sharing it
+            avoids re-walking and re-reading config for every sibling file.
 
     Returns:
         Mapping of file path to list of (validator_class_name, result) tuples.
@@ -5289,7 +5366,10 @@ def validate_single_path(
 
     cache: dict[str, tuple[IgnoreConfig, Path | None]] = per_run_cache if per_run_cache is not None else {}
     ignore_config, config_root = _resolve_ignore_config(path, cache)
-    policy, _policy_root = _resolve_policy(path, {})
+    policy_cache: dict[str, tuple[ValidationPolicy, Path | None]] = (
+        per_run_policy_cache if per_run_policy_cache is not None else {}
+    )
+    policy, _policy_root = _resolve_policy(path, policy_cache)
     policy = ValidationPolicy(policy.thresholds, policy.severity, ignore_config)
 
     validator_results = _collect_validator_results(
@@ -5508,7 +5588,19 @@ def validate_file(path: Path, adapters: dict, platform_override: str | None = No
                 "severity": "error",
                 "message": f"Invalid YAML frontmatter: {yaml_err}",
             })
-        violations.extend(run_as_series(path, frontmatter_data, body_lines))
+        # Resolve per-plugin policy so --platform validation honors the same
+        # configured thresholds as the default path (PR #97 review: the two
+        # paths must not lint the same skill differently).
+        policy, _policy_root = _resolve_policy(path, {})
+        violations.extend(
+            run_as_series(
+                path,
+                frontmatter_data,
+                body_lines,
+                warning_threshold=policy.thresholds.get("SK006", TOKEN_WARNING_THRESHOLD),
+                error_threshold=policy.thresholds.get("SK007", TOKEN_ERROR_THRESHOLD),
+            )
+        )
 
     if not matching:
         return violations
@@ -5674,9 +5766,17 @@ def main(
         # One shared cache per scan run — prevents re-walking the directory
         # tree for every file when many files share the same config root.
         per_run_cache: dict[str, tuple[IgnoreConfig, Path | None]] = {}
+        per_run_policy_cache: dict[str, tuple[ValidationPolicy, Path | None]] = {}
 
         def _validate_with_cache(p: Path, *, check: bool, fix: bool, verbose: bool) -> FileResults:
-            return validate_single_path(p, check=check, fix=fix, verbose=verbose, per_run_cache=per_run_cache)
+            return validate_single_path(
+                p,
+                check=check,
+                fix=fix,
+                verbose=verbose,
+                per_run_cache=per_run_cache,
+                per_run_policy_cache=per_run_policy_cache,
+            )
 
         run_validation_loop(
             expanded_paths=expanded_paths,

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -888,6 +888,12 @@ def _resolve_policy(
     root: Path | None = None
     diagnostics: list[str] = []
     while True:
+        ancestor_key = str(current)
+        # A sibling file already cached this ancestor: reuse it instead of
+        # re-walking and re-emitting diagnostics once per sibling skill.
+        if ancestor_key in cache:
+            policy, root = cache[ancestor_key]
+            break
         walked.append(current)
         plugin_cfg = current / ".claude-plugin" / "plugin.json"
         skilllint_cfg = current / _SKILLLINT_CONFIG_FILENAME
@@ -5589,8 +5595,8 @@ def validate_file(path: Path, adapters: dict, platform_override: str | None = No
                 "message": f"Invalid YAML frontmatter: {yaml_err}",
             })
         # Resolve per-plugin policy so --platform validation honors the same
-        # configured thresholds as the default path (PR #97 review: the two
-        # paths must not lint the same skill differently).
+        # configured thresholds AND severity as the default path (PR #97 review:
+        # the two paths must not lint the same skill differently).
         policy, _policy_root = _resolve_policy(path, {})
         violations.extend(
             run_as_series(
@@ -5601,6 +5607,17 @@ def validate_file(path: Path, adapters: dict, platform_override: str | None = No
                 error_threshold=policy.thresholds.get("SK007", TOKEN_ERROR_THRESHOLD),
             )
         )
+        if policy.severity:
+            # Apply configured severity downgrades to the AS-series dict
+            # violations so --platform matches the default-path remap.
+            remapped: list[dict[str, object]] = []
+            for violation in violations:
+                configured = policy.severity.get(str(violation.get("code")))
+                if configured in {"warning", "info"}:
+                    remapped.append({**violation, "severity": configured})
+                else:
+                    remapped.append(violation)
+            violations = remapped
 
     if not matching:
         return violations

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -5509,7 +5509,9 @@ def parse_skill_md(path: Path) -> tuple[dict, list[str], str | None, list[str]]:
     return frontmatter_dict, body_lines, yaml_err, colon_fields
 
 
-def run_platform_checks(path: Path, adapter: PlatformAdapter) -> list[dict]:
+def run_platform_checks(
+    path: Path, adapter: PlatformAdapter, *, policy_cache: dict[str, tuple[ValidationPolicy, Path | None]] | None = None
+) -> list[dict]:
     """Run platform-specific validation for a single adapter.
 
     Dispatches to adapter.validate(path) for all adapter types.
@@ -5518,6 +5520,9 @@ def run_platform_checks(path: Path, adapter: PlatformAdapter) -> list[dict]:
     Args:
         path: File path to validate.
         adapter: PlatformAdapter instance for constraint scope filtering.
+        policy_cache: Optional mutable per-run policy cache, forwarded to the
+            nested Claude pipeline so a multi-file scan reads each config —
+            and emits its diagnostics — once rather than once per file.
 
     Returns:
         List of violation dicts with keys: code, severity, message.
@@ -5534,7 +5539,9 @@ def run_platform_checks(path: Path, adapter: PlatformAdapter) -> list[dict]:
         if not sk_validators:
             return list(adapter.validate(path))
 
-        file_results = validate_single_path(path, check=True, fix=False, verbose=False)
+        file_results = validate_single_path(
+            path, check=True, fix=False, verbose=False, per_run_policy_cache=policy_cache
+        )
 
         violations: list[dict] = []
         for validator_results in file_results.values():
@@ -5580,6 +5587,9 @@ def validate_file(
         May include 'authority' key with origin and reference when the rule
         has authority metadata.
     """
+    resolved_policy_cache: dict[str, tuple[ValidationPolicy, Path | None]] = (
+        policy_cache if policy_cache is not None else {}
+    )
     pure = PurePath(path)
     if platform_override:
         matching = [adapters[platform_override]]
@@ -5610,7 +5620,7 @@ def validate_file(
         # configured thresholds AND severity as the default path (PR #97 review:
         # the two paths must not lint the same skill differently). Reuse a shared
         # per-run cache so a 1000-file platform scan reads each config once.
-        policy, _policy_root = _resolve_policy(path, policy_cache if policy_cache is not None else {})
+        policy, _policy_root = _resolve_policy(path, resolved_policy_cache)
         violations.extend(
             run_as_series(
                 path,
@@ -5626,7 +5636,7 @@ def validate_file(
             remapped: list[dict[str, object]] = []
             for violation in violations:
                 configured = policy.severity.get(str(violation.get("code")))
-                if configured in {"warning", "info"}:
+                if configured in _VALID_SEVERITIES:
                     remapped.append({**violation, "severity": configured})
                 else:
                     remapped.append(violation)
@@ -5646,7 +5656,7 @@ def validate_file(
     sk_validators = filter_validators_by_constraint_scopes(sk_validators, constraint_scopes)
 
     for adapter in matching:
-        violations.extend(run_platform_checks(path, adapter))
+        violations.extend(run_platform_checks(path, adapter, policy_cache=resolved_policy_cache))
 
     return violations
 

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -710,6 +710,8 @@ def _parse_thresholds(raw: object, config_path: Path, diagnostics: list[str]) ->
                 )
             else:
                 thresholds[code] = value
+    else:
+        diagnostics.append(f"{config_path}: thresholds is not an object; using defaults")
     # Warning must stay below error, or the warning band is unreachable
     # (test_limits.py asserts warning < error as the built-in invariant).
     if thresholds["SK006"] >= thresholds["SK007"]:
@@ -745,6 +747,8 @@ def _parse_severity(raw: object, config_path: Path, diagnostics: list[str]) -> d
                 )
             else:
                 severity[code] = value
+    else:
+        diagnostics.append(f"{config_path}: severity is not an object; using defaults")
     return severity
 
 
@@ -5551,7 +5555,12 @@ def run_platform_checks(path: Path, adapter: PlatformAdapter) -> list[dict]:
     return list(adapter.validate(path))
 
 
-def validate_file(path: Path, adapters: dict, platform_override: str | None = None) -> list[dict]:
+def validate_file(
+    path: Path,
+    adapters: dict,
+    platform_override: str | None = None,
+    policy_cache: dict[str, tuple[ValidationPolicy, Path | None]] | None = None,
+) -> list[dict]:
     """Dispatch validation for a single file using the adapter registry.
 
     AS-series fires ONCE per file (before per-adapter loop) — structural dedup.
@@ -5562,6 +5571,9 @@ def validate_file(path: Path, adapters: dict, platform_override: str | None = No
         platform_override: If set, restrict to this adapter ID. The selected
             adapter's constraint_scopes() will be used to filter rules by
             provider relevance (shared vs provider_specific).
+        policy_cache: Optional mutable per-run policy cache. Sharing it across
+            a scan prevents re-reading config and re-emitting diagnostics once
+            per file.
 
     Returns:
         List of violation dicts with keys: code, severity, message.
@@ -5596,8 +5608,9 @@ def validate_file(path: Path, adapters: dict, platform_override: str | None = No
             })
         # Resolve per-plugin policy so --platform validation honors the same
         # configured thresholds AND severity as the default path (PR #97 review:
-        # the two paths must not lint the same skill differently).
-        policy, _policy_root = _resolve_policy(path, {})
+        # the two paths must not lint the same skill differently). Reuse a shared
+        # per-run cache so a 1000-file platform scan reads each config once.
+        policy, _policy_root = _resolve_policy(path, policy_cache if policy_cache is not None else {})
         violations.extend(
             run_as_series(
                 path,
@@ -5805,7 +5818,7 @@ def main(
             show_summary=show_summary,
             platform_override=platform_override,
             validate_single_path=_validate_with_cache,
-            validate_file=validate_file,
+            validate_file=lambda p, a, o: validate_file(p, a, o, policy_cache=per_run_policy_cache),
             violations_to_result=violations_to_result,
             adapters=ADAPTERS,
             record_console=record_console,

--- a/packages/skilllint/tests/test_policy_config.py
+++ b/packages/skilllint/tests/test_policy_config.py
@@ -1,4 +1,14 @@
-"""Focused coverage for Issue #5's bounded JSON policy contract."""
+"""Focused coverage for Issue #5's bounded JSON policy contract.
+
+Threshold literals in these tests are chosen to exercise specific branches, not
+to model real skills:
+  - ``0`` and negative values exercise the positive-integer guard.
+  - Distinct positive values (e.g. 12, 34, 99) exercise first-match precedence
+    and cache stability; the exact numbers are arbitrary and unrelated to the
+    real DEFAULT_THRESHOLDS (SK006=4400, SK007=8800).
+  - ``1`` exercises unknown-rule filtering.
+  - Reversed/equal pairs (9000 vs default SK007=8800) exercise the ordering guard.
+"""
 
 from __future__ import annotations
 
@@ -8,12 +18,14 @@ from pathlib import Path
 from skilllint.plugin_validator import DEFAULT_THRESHOLDS, ValidationPolicy, _load_policy, _resolve_policy
 
 
-def test_policy_defaults_and_invalid_values_fail_open(tmp_path: Path) -> None:
+def test_policy_defaults_and_invalid_values_report_and_default(tmp_path: Path) -> None:
     cfg = tmp_path / ".skilllint.json"
     cfg.write_text(json.dumps({"thresholds": {"SK006": 0, "SK007": "bad"}, "severity": {"SK007": "error"}}))
-    policy = _load_policy(cfg)
+    policy, diagnostics = _load_policy(cfg)
     assert policy.thresholds == DEFAULT_THRESHOLDS
     assert policy.severity == {}
+    # Every rejected entry is surfaced, not silently swallowed.
+    assert len(diagnostics) == 3  # SK006=0, SK007="bad", severity SK007="error"
 
 
 def test_policy_first_match_and_cache(tmp_path: Path) -> None:
@@ -31,36 +43,88 @@ def test_policy_first_match_and_cache(tmp_path: Path) -> None:
 
 
 def test_policy_plugin_precedes_project_without_merge(tmp_path: Path) -> None:
+    # Project sets SK006=12; plugin sets a full valid pair. Precedence (no merge)
+    # is proven by the project's SK006=12 NOT leaking into the plugin-resolved
+    # policy — SK006 must be the plugin's value, not the project's.
     (tmp_path / ".skilllint.json").write_text(json.dumps({"thresholds": {"SK006": 12}}))
     root = tmp_path / "plugin"
     (root / ".claude-plugin").mkdir(parents=True)
     (root / ".claude-plugin" / "plugin.json").write_text("{}")
-    (root / ".claude-plugin" / "validator.json").write_text(json.dumps({"thresholds": {"SK007": 34}}))
+    (root / ".claude-plugin" / "validator.json").write_text(json.dumps({"thresholds": {"SK006": 34, "SK007": 56}}))
     skill = root / "SKILL.md"
     skill.write_text("body")
     policy, config_root = _resolve_policy(skill, {})
-    assert policy.thresholds["SK006"] == DEFAULT_THRESHOLDS["SK006"]
-    assert policy.thresholds["SK007"] == 34
+    assert policy.thresholds["SK006"] == 34  # plugin value, not project's 12 (no merge)
+    assert policy.thresholds["SK007"] == 56
     assert config_root == root
 
 
 def test_policy_ignore_retains_existing_shape(tmp_path: Path) -> None:
     cfg = tmp_path / ".skilllint.json"
     cfg.write_text(json.dumps({"ignore": {"skills/demo": ["SK006"], "bad": "skip"}}))
-    assert _load_policy(cfg).ignore == {"skills/demo": ["SK006"]}
+    policy, _diagnostics = _load_policy(cfg)
+    assert policy.ignore == {"skills/demo": ["SK006"]}
 
 
 def test_unknown_policy_rules_are_ignored(tmp_path: Path) -> None:
     cfg = tmp_path / ".skilllint.json"
     cfg.write_text(json.dumps({"thresholds": {"NOPE": 1}, "severity": {"NOPE": "info"}}))
-    policy = _load_policy(cfg)
+    policy, diagnostics = _load_policy(cfg)
     assert "NOPE" not in policy.thresholds
     assert "NOPE" not in policy.severity
+    assert len(diagnostics) == 2
 
 
-def test_malformed_policy_fails_open(tmp_path: Path) -> None:
+def test_malformed_policy_reports_and_defaults(tmp_path: Path) -> None:
     cfg = tmp_path / ".skilllint.json"
     cfg.write_text("not json")
-    policy = _load_policy(cfg)
+    policy, diagnostics = _load_policy(cfg)
     assert policy.thresholds == DEFAULT_THRESHOLDS
     assert policy.ignore == {}
+    assert len(diagnostics) == 1
+
+
+def test_as005_is_not_a_configurable_threshold(tmp_path: Path) -> None:
+    # AS005 shares the SK006/SK007 token band and has no threshold plumbing of
+    # its own, so an AS005 threshold key is rejected (PR #97 review finding #1).
+    cfg = tmp_path / ".skilllint.json"
+    cfg.write_text(json.dumps({"thresholds": {"AS005": 1000}}))
+    policy, diagnostics = _load_policy(cfg)
+    assert "AS005" not in policy.thresholds
+    assert policy.thresholds == DEFAULT_THRESHOLDS
+    assert len(diagnostics) == 1
+
+
+def test_as005_severity_is_configurable(tmp_path: Path) -> None:
+    cfg = tmp_path / ".skilllint.json"
+    cfg.write_text(json.dumps({"severity": {"AS005": "info"}}))
+    policy, diagnostics = _load_policy(cfg)
+    assert policy.severity == {"AS005": "info"}
+    assert diagnostics == []
+
+
+def test_inverted_thresholds_reset_to_defaults(tmp_path: Path) -> None:
+    # SK006 >= SK007 makes the warning band unreachable; reset both (finding #2).
+    cfg = tmp_path / ".skilllint.json"
+    cfg.write_text(json.dumps({"thresholds": {"SK006": 9000}}))  # >= default SK007 (8800)
+    policy, diagnostics = _load_policy(cfg)
+    assert policy.thresholds == DEFAULT_THRESHOLDS
+    assert any("must be below SK007" in d for d in diagnostics)
+
+
+def test_equal_thresholds_reset_to_defaults(tmp_path: Path) -> None:
+    cfg = tmp_path / ".skilllint.json"
+    cfg.write_text(json.dumps({"thresholds": {"SK006": 5000, "SK007": 5000}}))
+    policy, diagnostics = _load_policy(cfg)
+    assert policy.thresholds == DEFAULT_THRESHOLDS
+    assert any("must be below SK007" in d for d in diagnostics)
+
+
+def test_composite_severity_value_does_not_crash(tmp_path: Path) -> None:
+    # A list/dict severity value must be rejected, not raise TypeError on the
+    # set membership check (finding #3 — trust-boundary crash).
+    cfg = tmp_path / ".skilllint.json"
+    cfg.write_text(json.dumps({"severity": {"SK006": [], "SK007": {"nested": 1}}}))
+    policy, diagnostics = _load_policy(cfg)
+    assert policy.severity == {}
+    assert len(diagnostics) == 2

--- a/packages/skilllint/tests/test_policy_config.py
+++ b/packages/skilllint/tests/test_policy_config.py
@@ -152,3 +152,44 @@ def test_policy_cache_reuses_ancestor_across_siblings(tmp_path: Path) -> None:
     # The only cached ancestor (the shared "skills" dir + config root) is reused,
     # so no config re-read and no second diagnostic emission on stderr.
     assert "AS005 is not a configurable threshold" not in buf.getvalue()
+
+
+def test_non_object_thresholds_section_is_reported(tmp_path: Path) -> None:
+    # Codex re-review #1 (4a33171): a mistyped section like "thresholds": []
+    # must produce a diagnostic, not silently default.
+    cfg = tmp_path / ".skilllint.json"
+    cfg.write_text(json.dumps({"thresholds": []}))
+    policy, diagnostics = _load_policy(cfg)
+    assert policy.thresholds == DEFAULT_THRESHOLDS
+    assert any("thresholds is not an object" in d for d in diagnostics)
+
+
+def test_non_object_severity_section_is_reported(tmp_path: Path) -> None:
+    cfg = tmp_path / ".skilllint.json"
+    cfg.write_text(json.dumps({"severity": "info"}))
+    policy, diagnostics = _load_policy(cfg)
+    assert policy.severity == {}
+    assert any("severity is not an object" in d for d in diagnostics)
+
+
+def test_platform_path_reuses_policy_cache_across_files(tmp_path: Path) -> None:
+    # Codex re-review #2 (4a33171): --platform scans must reuse the per-run
+    # cache so a 1000-file scan doesn't re-read config / re-emit per file.
+    import contextlib
+    import io
+
+    from skilllint.plugin_validator import validate_file
+
+    (tmp_path / ".skilllint.json").write_text(json.dumps({"thresholds": {"AS005": 1000}}))
+    a = tmp_path / "skills" / "a" / "SKILL.md"
+    b = tmp_path / "skills" / "b" / "SKILL.md"
+    a.parent.mkdir(parents=True)
+    b.parent.mkdir(parents=True, exist_ok=True)
+    for f in (a, b):
+        f.write_text("---\nname: x\ndescription: y\n---\nbody")
+    cache: dict[str, tuple[ValidationPolicy, Path | None]] = {}
+    validate_file(a, {}, policy_cache=cache)
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        validate_file(b, {}, policy_cache=cache)
+    assert "AS005 is not a configurable threshold" not in buf.getvalue()

--- a/packages/skilllint/tests/test_policy_config.py
+++ b/packages/skilllint/tests/test_policy_config.py
@@ -128,3 +128,27 @@ def test_composite_severity_value_does_not_crash(tmp_path: Path) -> None:
     policy, diagnostics = _load_policy(cfg)
     assert policy.severity == {}
     assert len(diagnostics) == 2
+
+
+def test_policy_cache_reuses_ancestor_across_siblings(tmp_path: Path) -> None:
+    # Codex re-review #1: a sibling skill must reuse an already-cached ancestor
+    # instead of re-walking, re-reading config, and re-emitting diagnostics.
+    # Config is deliberately invalid so diagnostics are observable.
+    import contextlib
+    import io
+
+    (tmp_path / ".skilllint.json").write_text(json.dumps({"thresholds": {"AS005": 1000}}))
+    a = tmp_path / "skills" / "a" / "SKILL.md"
+    b = tmp_path / "skills" / "b" / "SKILL.md"
+    b.parent.mkdir(parents=True, exist_ok=False)
+    a.parent.mkdir(parents=True, exist_ok=True)
+    a.write_text("body")
+    b.write_text("body")
+    cache: dict[str, tuple[ValidationPolicy, Path | None]] = {}
+    _resolve_policy(a, cache)
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        _resolve_policy(b, cache)  # second sibling — must NOT re-emit
+    # The only cached ancestor (the shared "skills" dir + config root) is reused,
+    # so no config re-read and no second diagnostic emission on stderr.
+    assert "AS005 is not a configurable threshold" not in buf.getvalue()

--- a/packages/skilllint/tests/test_policy_config.py
+++ b/packages/skilllint/tests/test_policy_config.py
@@ -193,3 +193,37 @@ def test_platform_path_reuses_policy_cache_across_files(tmp_path: Path) -> None:
     with contextlib.redirect_stderr(buf):
         validate_file(b, {}, policy_cache=cache)
     assert "AS005 is not a configurable threshold" not in buf.getvalue()
+
+
+def test_nested_claude_platform_path_reuses_policy_cache(tmp_path: Path) -> None:
+    # Codex re-review #3 (268a8d9): validate_file() shared the per-run cache with
+    # its own _resolve_policy() but not with the nested Claude pipeline, so
+    # run_platform_checks() -> validate_single_path() re-read the config and
+    # re-emitted its diagnostics for every scanned file.
+    import contextlib
+    import io
+
+    from skilllint.plugin_validator import ADAPTERS, validate_file
+
+    (tmp_path / ".skilllint.json").write_text(json.dumps({"thresholds": {"AS005": 1000}}))
+    first = tmp_path / "skills" / "a" / "SKILL.md"
+    second = tmp_path / "skills" / "b" / "SKILL.md"
+    first.parent.mkdir(parents=True)
+    second.parent.mkdir(parents=True)
+    for skill in (first, second):
+        skill.write_text(f"---\nname: {skill.parent.name}\ndescription: demo skill\n---\nbody")
+
+    cache: dict[str, tuple[ValidationPolicy, Path | None]] = {}
+    marker = "AS005 is not a configurable threshold"
+
+    first_buf = io.StringIO()
+    with contextlib.redirect_stderr(first_buf):
+        validate_file(first, ADAPTERS, "claude_code", policy_cache=cache)
+    # Outer resolve and the nested Claude pipeline must share one cache entry,
+    # so the config is read — and reported — exactly once for the whole run.
+    assert first_buf.getvalue().count(marker) == 1
+
+    second_buf = io.StringIO()
+    with contextlib.redirect_stderr(second_buf):
+        validate_file(second, ADAPTERS, "claude_code", policy_cache=cache)
+    assert marker not in second_buf.getvalue()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,8 +71,8 @@ dev = [
     "pytest-xdist>=3.8.0",
     "pytest>=9.0.2",
     "rich>=14.3.3",
-    "ruff>=0.15.8",
-    "ty>=0.0.26",
+    "ruff>=0.16.2",
+    "ty>=0.0.69",
 ]
 
 [tool.hatch.build.targets.sdist]

--- a/uv.lock
+++ b/uv.lock
@@ -1004,8 +1004,8 @@ dev = [
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "rich", specifier = ">=14.3.3" },
-    { name = "ruff", specifier = ">=0.15.8" },
-    { name = "ty", specifier = ">=0.0.26" },
+    { name = "ruff", specifier = ">=0.16.2" },
+    { name = "ty", specifier = ">=0.0.69" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements Issue #5 progressive lint ratcheting.

- Reuses existing JSON config discovery and precedence.
- Adds positive threshold overrides for known token rules.
- Adds warning/info severity remapping and preserves ignore configuration.
- Keeps legacy defaults and direct validator behavior.

Validation: 75 focused tests passed; 1174 full-suite passed, 1 skipped; Ruff, Ty, and git diff checks passed.

Closes #5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-plugin validation policies through `.validator.json` and `.skilllint.json`.
  * Configure rule thresholds, warning or info severities, and ignored rules.
  * AS005 token thresholds can now be customized.
  * Policies are discovered from parent directories and support plugin-specific overrides.
* **Bug Fixes**
  * Invalid or malformed policy settings safely preserve default validation behavior.
  * Validation policies apply consistently during initial checks and after automatic fixes.
  * Policy settings and diagnostics are reused efficiently across related validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->