### PR TITLE
refactor(rules): route rule references through rule_reference, drop dead RuleEntry.fn

### DIFF
--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -1205,7 +1205,7 @@ class Validator(Protocol):
 # ============================================================================
 
 
-def generate_docs_url(error_code: ErrorCode) -> str:
+def generate_docs_url(error_code: ErrorCode | str) -> str:
     """Generate documentation URL for error code.
 
     Args:

--- a/packages/skilllint/rule_registry.py
+++ b/packages/skilllint/rule_registry.py
@@ -25,10 +25,10 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Annotated, Any, Literal
+from typing import TYPE_CHECKING, Annotated, Literal
 from urllib.parse import urljoin
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -67,10 +67,7 @@ class RuleAuthority(BaseModel):
 class RuleEntry(BaseModel):
     """Registry entry for a single validation rule."""
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
     id: Annotated[str, Field(pattern=r"^[A-Z]{2}\d{3}$")]
-    fn: Any  # Callable — not validatable by Pydantic, stored as Any
     severity: Literal["error", "warning", "info"]
     category: str  # "frontmatter", "skill", "plugin", "hook", etc.
     platforms: list[str]  # ["agentskills"] = all platforms, or specific like ["claude-code"]
@@ -129,7 +126,6 @@ def skilllint_rule(
     def decorator(fn: Callable) -> Callable:
         entry = RuleEntry(
             id=rule_id.upper(),
-            fn=fn,
             severity=severity,
             category=category,
             platforms=platforms,

--- a/packages/skilllint/rules/cu_series.py
+++ b/packages/skilllint/rules/cu_series.py
@@ -44,18 +44,6 @@ if TYPE_CHECKING:
 _CURSOR_DOCS_URL = "https://docs.cursor.com/context/rules-for-ai"
 
 
-def _docs_url(code: str) -> str:
-    """Return the documentation URL for a CU rule code.
-
-    Args:
-        code: Rule code string (e.g., "CU001").
-
-    Returns:
-        Full URL with anchor for the error code documentation.
-    """
-    return rule_reference(code)
-
-
 # ---------------------------------------------------------------------------
 # CU001 — Required field missing from .mdc frontmatter
 # ---------------------------------------------------------------------------
@@ -108,7 +96,7 @@ def check_cu001(frontmatter: dict[str, object], mdc_schema: dict[str, object]) -
             severity="error",
             message=f"Required field '{field}' is missing from .mdc frontmatter",
             code="CU001",
-            docs_url=_docs_url("CU001"),
+            docs_url=rule_reference("CU001"),
         )
         for field in required_fields
         if field not in frontmatter
@@ -178,7 +166,7 @@ def check_cu002(frontmatter: dict[str, object], mdc_schema: dict[str, object]) -
             severity="error",
             message=f"Unknown field '{field}' in .mdc frontmatter (additionalProperties is false)",
             code="CU002",
-            docs_url=_docs_url("CU002"),
+            docs_url=rule_reference("CU002"),
         )
         for field in frontmatter
         if field not in known_fields

--- a/packages/skilllint/rules/cx_series.py
+++ b/packages/skilllint/rules/cx_series.py
@@ -57,18 +57,6 @@ _PREFIX_RULE_RE = re.compile(r"prefix_rule\s*\(([^)]*)\)", re.DOTALL)
 _FIELD_RE = re.compile(r"^\s*(\w+)\s*=", re.MULTILINE)
 
 
-def _docs_url(code: str) -> str:
-    """Return the documentation URL for a CX rule code.
-
-    Args:
-        code: Rule code string (e.g., "CX001").
-
-    Returns:
-        Full URL with anchor for the error code documentation.
-    """
-    return rule_reference(code)
-
-
 # ---------------------------------------------------------------------------
 # CX001 — AGENTS.md content is empty
 # ---------------------------------------------------------------------------
@@ -117,7 +105,7 @@ def check_cx001(content: str) -> list[ValidationIssue]:
                 severity="error",
                 message="AGENTS.md is empty",
                 code="CX001",
-                docs_url=_docs_url("CX001"),
+                docs_url=rule_reference("CX001"),
             )
         ]
     return []
@@ -189,7 +177,7 @@ def check_cx002(content: str, schema: dict[str, object]) -> list[ValidationIssue
                         severity="error",
                         message=f"Unknown field '{field}' in prefix_rule() (known fields: {sorted(known_fields)})",
                         code="CX002",
-                        docs_url=_docs_url("CX002"),
+                        docs_url=rule_reference("CX002"),
                     )
                 )
     return issues

--- a/packages/skilllint/rules/fm_series.py
+++ b/packages/skilllint/rules/fm_series.py
@@ -45,18 +45,6 @@ _CONSECUTIVE_HYPHENS_RE = re.compile(r"--")
 _MAX_NAME_LENGTH = 64
 
 
-def _docs_url(code: str) -> str:
-    """Return the documentation URL for an FM rule code.
-
-    Args:
-        code: Rule code string (e.g., "FM001").
-
-    Returns:
-        Full URL with anchor for the error code documentation.
-    """
-    return rule_reference(code)
-
-
 def _make_issue(
     *,
     field: str,
@@ -88,7 +76,7 @@ def _make_issue(
         severity=severity,
         message=message,
         code=code,
-        docs_url=_docs_url(code),
+        docs_url=rule_reference(code),
         suggestion=suggestion,
         line=line,
     )

--- a/packages/skilllint/rules/hk_series.py
+++ b/packages/skilllint/rules/hk_series.py
@@ -33,29 +33,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from skilllint.rule_registry import rule_reference, skilllint_rule
+from skilllint.rule_registry import skilllint_rule
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from skilllint.plugin_validator import ValidationIssue
-
-# ---------------------------------------------------------------------------
-# Spec sources
-# ---------------------------------------------------------------------------
-
-
-def _docs_url(code: str) -> str:
-    """Return the documentation URL for an HK rule code.
-
-    Args:
-        code: Rule code string (e.g., "HK001").
-
-    Returns:
-        Full URL with anchor for the error code documentation.
-    """
-    return rule_reference(code)
-
 
 # ---------------------------------------------------------------------------
 # HK001 — Invalid hooks.json structure

--- a/packages/skilllint/rules/lk_series.py
+++ b/packages/skilllint/rules/lk_series.py
@@ -35,29 +35,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from skilllint.rule_registry import rule_reference, skilllint_rule
+from skilllint.rule_registry import skilllint_rule
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from skilllint.plugin_validator import ValidationIssue
-
-# ---------------------------------------------------------------------------
-# Spec sources
-# ---------------------------------------------------------------------------
-
-
-def _docs_url(code: str) -> str:
-    """Return the documentation URL for an LK rule code.
-
-    Args:
-        code: Rule code string (e.g., "LK001").
-
-    Returns:
-        Full URL with anchor for the error code documentation.
-    """
-    return rule_reference(code)
-
 
 # ---------------------------------------------------------------------------
 # LK001 — Broken internal link (file does not exist)

--- a/packages/skilllint/rules/nr_series.py
+++ b/packages/skilllint/rules/nr_series.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from skilllint.rule_registry import rule_reference, skilllint_rule
+from skilllint.rule_registry import skilllint_rule
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -53,18 +53,6 @@ if TYPE_CHECKING:
 # which says nothing about traversal, boundaries, escaping, or symlinks —
 # verified via `grep -ci` returning 0 for those terms against the cached spec.)
 _NR002_PATH_TRAVERSAL_URL = "https://code.claude.com/docs/en/plugins-reference.md#path-traversal-limitations"
-
-
-def _docs_url(code: str) -> str:
-    """Return the documentation URL for an NR rule code.
-
-    Args:
-        code: Rule code string (e.g., "NR001").
-
-    Returns:
-        Full URL with anchor for the error code documentation.
-    """
-    return rule_reference(code)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/skilllint/rules/pd_series.py
+++ b/packages/skilllint/rules/pd_series.py
@@ -29,29 +29,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from skilllint.rule_registry import rule_reference, skilllint_rule
+from skilllint.rule_registry import skilllint_rule
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from skilllint.plugin_validator import ValidationIssue
-
-# ---------------------------------------------------------------------------
-# Spec sources
-# ---------------------------------------------------------------------------
-
-
-def _docs_url(code: str) -> str:
-    """Return the documentation URL for a PD rule code.
-
-    Args:
-        code: Rule code string (e.g., "PD001").
-
-    Returns:
-        Full URL with anchor for the error code documentation.
-    """
-    return rule_reference(code)
-
 
 # ---------------------------------------------------------------------------
 # PD001 — No references/ directory found

--- a/packages/skilllint/rules/pl_series.py
+++ b/packages/skilllint/rules/pl_series.py
@@ -36,29 +36,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from skilllint.rule_registry import rule_reference, skilllint_rule
+from skilllint.rule_registry import skilllint_rule
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from skilllint.plugin_validator import ValidationIssue
-
-# ---------------------------------------------------------------------------
-# Spec sources
-# ---------------------------------------------------------------------------
-
-
-def _docs_url(code: str) -> str:
-    """Return the documentation URL for a PL rule code.
-
-    Args:
-        code: Rule code string (e.g., "PL001").
-
-    Returns:
-        Full URL with anchor for the error code documentation.
-    """
-    return rule_reference(code)
-
 
 # ---------------------------------------------------------------------------
 # PL001 — Missing plugin.json file

--- a/packages/skilllint/rules/pr_series.py
+++ b/packages/skilllint/rules/pr_series.py
@@ -33,29 +33,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from skilllint.rule_registry import rule_reference, skilllint_rule
+from skilllint.rule_registry import skilllint_rule
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from skilllint.plugin_validator import ValidationIssue
-
-# ---------------------------------------------------------------------------
-# Spec sources
-# ---------------------------------------------------------------------------
-
-
-def _docs_url(code: str) -> str:
-    """Return the documentation URL for a PR rule code.
-
-    Args:
-        code: Rule code string (e.g., "PR001").
-
-    Returns:
-        Full URL with anchor for the error code documentation.
-    """
-    return rule_reference(code)
-
 
 # ---------------------------------------------------------------------------
 # PR001 — Capability exists but not explicitly registered in plugin.json

--- a/packages/skilllint/rules/sk_series.py
+++ b/packages/skilllint/rules/sk_series.py
@@ -50,18 +50,6 @@ _NAME_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 _DIR_CONVENTION_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 
 
-def _docs_url(code: str) -> str:
-    """Return the documentation URL for an SK rule code.
-
-    Args:
-        code: Rule code string (e.g., "SK001").
-
-    Returns:
-        Full URL with anchor for the error code documentation.
-    """
-    return rule_reference(code)
-
-
 # ---------------------------------------------------------------------------
 # SK001 — Name contains uppercase characters
 # ---------------------------------------------------------------------------
@@ -114,7 +102,7 @@ def check_sk001(frontmatter: dict[str, object], path: Path, file_type: str) -> l
                 severity="error",
                 message="Name contains uppercase characters",
                 code="SK001",
-                docs_url=_docs_url("SK001"),
+                docs_url=rule_reference("SK001"),
                 suggestion=f"Use lowercase only (e.g., '{name_val.lower()}' not '{name_val}')",
             )
         ]
@@ -173,7 +161,7 @@ def check_sk002(frontmatter: dict[str, object], path: Path, file_type: str) -> l
                 severity="error",
                 message="Name contains underscores (use hyphens instead)",
                 code="SK002",
-                docs_url=_docs_url("SK002"),
+                docs_url=rule_reference("SK002"),
                 suggestion=f"Replace underscores with hyphens: '{name_val.replace('_', '-')}'",
             )
         ]
@@ -236,7 +224,7 @@ def check_sk003(frontmatter: dict[str, object], path: Path, file_type: str) -> l
                 severity="error",
                 message="Name field is empty",
                 code="SK003",
-                docs_url=_docs_url("SK003"),
+                docs_url=rule_reference("SK003"),
                 suggestion="Provide a non-empty name using lowercase letters, numbers, and hyphens",
             )
         )
@@ -251,7 +239,7 @@ def check_sk003(frontmatter: dict[str, object], path: Path, file_type: str) -> l
                 severity="error",
                 message=f"Name exceeds maximum length of {MAX_NAME_LENGTH} characters (got {len(name_val)})",
                 code="SK003",
-                docs_url=_docs_url("SK003"),
+                docs_url=rule_reference("SK003"),
                 suggestion=f"Shorten the name to {MAX_NAME_LENGTH} characters or less",
             )
         )
@@ -264,7 +252,7 @@ def check_sk003(frontmatter: dict[str, object], path: Path, file_type: str) -> l
                 severity="error",
                 message="Name has leading hyphen",
                 code="SK003",
-                docs_url=_docs_url("SK003"),
+                docs_url=rule_reference("SK003"),
                 suggestion=f"Remove leading hyphen: '{name_val.lstrip('-')}'",
             )
         )
@@ -276,7 +264,7 @@ def check_sk003(frontmatter: dict[str, object], path: Path, file_type: str) -> l
                 severity="error",
                 message="Name has trailing hyphen",
                 code="SK003",
-                docs_url=_docs_url("SK003"),
+                docs_url=rule_reference("SK003"),
                 suggestion=f"Remove trailing hyphen: '{name_val.rstrip('-')}'",
             )
         )
@@ -288,7 +276,7 @@ def check_sk003(frontmatter: dict[str, object], path: Path, file_type: str) -> l
                 severity="error",
                 message="Name has consecutive hyphens",
                 code="SK003",
-                docs_url=_docs_url("SK003"),
+                docs_url=rule_reference("SK003"),
                 suggestion="Use single hyphens only (e.g., 'test-skill' not 'test--skill')",
             )
         )
@@ -300,7 +288,7 @@ def check_sk003(frontmatter: dict[str, object], path: Path, file_type: str) -> l
                 severity="error",
                 message="Name format invalid",
                 code="SK003",
-                docs_url=_docs_url("SK003"),
+                docs_url=rule_reference("SK003"),
                 suggestion="Use lowercase letters, numbers, and hyphens only (e.g., 'my-skill-name')",
             )
         )
@@ -372,7 +360,7 @@ def check_sk004(frontmatter: dict[str, object], path: Path, file_type: str) -> l
                 severity="warning",
                 message=f"Description too short (minimum {_MIN_DESCRIPTION_LENGTH} characters, got {desc_len})",
                 code="SK004",
-                docs_url=_docs_url("SK004"),
+                docs_url=rule_reference("SK004"),
                 suggestion="Run /plugin-creator:write-frontmatter-description to generate an optimized description",
             )
         )
@@ -383,7 +371,7 @@ def check_sk004(frontmatter: dict[str, object], path: Path, file_type: str) -> l
                 severity="warning",
                 message=f"Exceeds recommended length of {RECOMMENDED_DESCRIPTION_LENGTH} characters (got {desc_len})",
                 code="SK004",
-                docs_url=_docs_url("SK004"),
+                docs_url=rule_reference("SK004"),
                 suggestion=f"Front-load critical information in first {RECOMMENDED_DESCRIPTION_LENGTH} characters. Run /plugin-creator:write-frontmatter-description to generate an optimized description",
             )
         )
@@ -470,7 +458,7 @@ def check_sk005(frontmatter: dict[str, object], path: Path, file_type: str) -> l
             severity="warning",
             message="Description missing trigger phrases",
             code="SK005",
-            docs_url=_docs_url("SK005"),
+            docs_url=rule_reference("SK005"),
             suggestion=f"Required trigger phrases: {', '.join(_REQUIRED_TRIGGER_PHRASES)}. Run /plugin-creator:write-frontmatter-description to generate a compliant description",
         )
     ]

--- a/packages/skilllint/rules/sl_series.py
+++ b/packages/skilllint/rules/sl_series.py
@@ -29,29 +29,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from skilllint.rule_registry import rule_reference, skilllint_rule
+from skilllint.rule_registry import skilllint_rule
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from skilllint.plugin_validator import ValidationIssue
-
-# ---------------------------------------------------------------------------
-# Spec sources
-# ---------------------------------------------------------------------------
-
-
-def _docs_url(code: str) -> str:
-    """Return the documentation URL for an SL rule code.
-
-    Args:
-        code: Rule code string (e.g., "SL001").
-
-    Returns:
-        Full URL with anchor for the error code documentation.
-    """
-    return rule_reference(code)
-
 
 # ---------------------------------------------------------------------------
 # SL001 — Symlink target has trailing whitespace/newlines

--- a/packages/skilllint/rules/tc_series.py
+++ b/packages/skilllint/rules/tc_series.py
@@ -28,29 +28,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from skilllint.rule_registry import rule_reference, skilllint_rule
+from skilllint.rule_registry import skilllint_rule
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from skilllint.plugin_validator import ValidationIssue
-
-# ---------------------------------------------------------------------------
-# Spec sources
-# ---------------------------------------------------------------------------
-
-
-def _docs_url(code: str) -> str:
-    """Return the documentation URL for a TC rule code.
-
-    Args:
-        code: Rule code string (e.g., "TC001").
-
-    Returns:
-        Full URL with anchor for the error code documentation.
-    """
-    return rule_reference(code)
-
 
 # ---------------------------------------------------------------------------
 # TC001 — Token count info (total, frontmatter, body)

--- a/packages/skilllint/tests/test_docs_url_parity.py
+++ b/packages/skilllint/tests/test_docs_url_parity.py
@@ -1,0 +1,29 @@
+"""Parity tests binding rule documentation references to a single source.
+
+Every rule code must resolve to the same documentation reference no matter
+which entry point produces it, so that a finding emitted by a rule module and
+the same finding emitted by the validator never disagree.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from skilllint.plugin_validator import ErrorCode, generate_docs_url
+from skilllint.rule_registry import rule_reference
+
+
+@pytest.mark.parametrize("code", list(ErrorCode), ids=str)
+def test_generate_docs_url_matches_rule_reference_for_every_error_code(code: ErrorCode) -> None:
+    """generate_docs_url delegates to rule_reference for every ErrorCode member."""
+    assert generate_docs_url(code) == rule_reference(code.value)
+
+
+def test_generate_docs_url_accepts_bare_code_strings() -> None:
+    """Rule modules pass literal codes, so strings must resolve identically to enum members."""
+    assert generate_docs_url("FM007") == generate_docs_url(ErrorCode.FM007)
+
+
+def test_rule_reference_normalises_case() -> None:
+    """A lowercase code resolves to the same reference as its canonical uppercase form."""
+    assert rule_reference("fm007") == rule_reference("FM007")

--- a/packages/skilllint/tests/test_provider_contracts.py
+++ b/packages/skilllint/tests/test_provider_contracts.py
@@ -95,15 +95,10 @@ class TestRuleAuthority:
     def test_rule_entry_authority_structured(self) -> None:
         """RuleEntry should accept and expose structured authority."""
 
-        # Create a test function
-        def test_validator(frontmatter: dict) -> list:
-            return []
-
         # Create a RuleEntry with authority
         authority = RuleAuthority(origin="test-origin", reference="https://example.com/rules/TE001")
         entry = RuleEntry(
             id="TE001",
-            fn=test_validator,
             severity="error",
             category="test",
             platforms=["agentskills"],
@@ -118,14 +113,9 @@ class TestRuleAuthority:
     def test_rule_entry_authority_optional(self) -> None:
         """RuleEntry.authority should be optional (default None)."""
 
-        # Create a test function
-        def test_validator(frontmatter: dict) -> list:
-            return []
-
         # Create a RuleEntry without authority
         entry = RuleEntry(
             id="TE002",
-            fn=test_validator,
             severity="warning",
             category="test",
             platforms=["agentskills"],

--- a/packages/skilllint/tests/test_rule_registry.py
+++ b/packages/skilllint/tests/test_rule_registry.py
@@ -13,7 +13,6 @@ def _entry(rule_id: str, reference: str | None, origin: str = "example.test") ->
     authority = None if reference is None else RuleAuthority(origin=origin, reference=reference)
     return RuleEntry(
         id=rule_id,
-        fn=lambda: None,
         severity="info",
         category="test",
         platforms=["agentskills"],


### PR DESCRIPTION
Issue #41. Rebased onto current `main`.

## What changed

**One source of truth for rule documentation references.** Every `rules/*_series.py` module carried a private `_docs_url(code)` wrapper. #108 removed the per-series `_XX_DOCS_BASE` constants and reduced each wrapper to a one-line pass-through to `rule_registry.rule_reference`, leaving **eight of the twelve with zero call sites** — the leftover recorded in #123. All twelve are now gone; the live call sites in `cu`, `cx`, `fm` and `sk` call `rule_reference` directly, which is already imported at module level and needs no deferred import to dodge the `plugin_validator` circular dependency. Where that left an empty `# Spec sources` banner, the banner went too.

**`generate_docs_url` signature matches its docstring.** It documented "ErrorCode enum or string like `FM001`, `SK006`" while annotating `ErrorCode`. Widened to `ErrorCode | str`. This is what lets a rule module emit a finding for a code that has no `ErrorCode` member.

**`RuleEntry.fn` removed.** The decorator stored the validator function and nothing ever read it back. Gone, along with its `Any` import and the `arbitrary_types_allowed` model config that existed only to carry it. Three test call sites passed `fn=` into a model whose default `extra="ignore"` would have swallowed it silently — those kwargs and the stub functions that existed only to fill them are removed too.

## FM008 hunks dropped

The original branch added `ErrorCode.FM008` and a test asserting it exists. Those hunks are **not** in the rebased commit, per the verdict recorded in [this comment](https://github.com/bitflight-devops/skilllint/pull/103#issuecomment-5466464445): `skills` is not one of the six `SKILL.md` frontmatter fields in the AgentSkills spec, the `ErrorCode.FM008` gap is deliberate rather than a bug, and `main` already ruled on this shape when #108 rescoped the AS family. The alias tuple keeps its nine names with the `FM008` gap intact on both sides. The parity test now asserts the actual contract — `generate_docs_url` delegating to `rule_reference` for every `ErrorCode` member, plus string and case handling — instead of asserting one enum member's existence.

## Verification

- `uv run pytest packages/skilllint/tests/ -q` — 1199 passed, 10 skipped, 83% coverage
- `uv run ruff format --check .` — 376 files already formatted
- `uv run ruff check --no-fix .` — all checks passed
- `uv run ty check packages/` — all checks passed
- No conflict markers repo-wide

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)
