### PR TITLE
refactor: extract inline JS to post_coverage_summary.mjs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,14 +147,14 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Download coverage artifacts
         uses: actions/download-artifact@v8.0.1
         with:
           name: coverage-xml
           path: coverage-reports
-
-      - name: Checkout code
-        uses: actions/checkout@v4
 
       - name: Comment PR with coverage
         uses: actions/github-script@v9.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Comment PR with coverage
         uses: actions/github-script@v9.0.0
         with:
-          script: (await import('./scripts/post_coverage_summary.mjs')).default({ github, context })
+          script: (await import(`${process.env.GITHUB_WORKSPACE}/scripts/post_coverage_summary.mjs`)).default({ github, context })
 
   release:
     name: Tag and Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,7 +148,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.3
+        with:
+          # Job needs no git operations after checkout; do not leave the token in .git/config
+          persist-credentials: false
 
       - name: Download coverage artifacts
         uses: actions/download-artifact@v8.0.1
@@ -159,7 +162,7 @@ jobs:
       - name: Comment PR with coverage
         uses: actions/github-script@v9.0.0
         with:
-          script: (await import(`${process.env.GITHUB_WORKSPACE}/scripts/post_coverage_summary.mjs`)).default({ github, context })
+          script: await (await import(`${process.env.GITHUB_WORKSPACE}/scripts/post_coverage_summary.mjs`)).default({ github, context })
 
   release:
     name: Tag and Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,41 +153,13 @@ jobs:
           name: coverage-xml
           path: coverage-reports
 
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Comment PR with coverage
         uses: actions/github-script@v9.0.0
         with:
-          script: |
-            const fs = require('fs');
-            const xml = fs.readFileSync('coverage-reports/coverage.xml', 'utf8');
-            const match = xml.match(/line-rate="([^"]+)"/);
-            const coverage = match ? (parseFloat(match[1]) * 100).toFixed(2) + '%' : 'N/A';
-
-            const comments = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.data.find(c =>
-              c.user.type === 'Bot' && c.body.includes('📊 Test Coverage')
-            );
-
-            const body = `## 📊 Test Coverage Report\n\n**Coverage:** ${coverage}\n\n📥 Coverage XML available as artifact: \`coverage-xml\``;
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body: body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: body
-              });
-            }
+          script: (await import('./scripts/post_coverage_summary.mjs')).default({ github, context })
 
   release:
     name: Tag and Release

--- a/scripts/post_coverage_summary.mjs
+++ b/scripts/post_coverage_summary.mjs
@@ -1,0 +1,47 @@
+// scripts/post_coverage_summary.mjs
+// Extracted from .github/workflows/test.yml coverage-summary job (issue #42).
+// No npm deps — stdlib only. Node 24 floor (matches actions/github-script@v9 runner).
+
+import { readFileSync } from 'node:fs';
+
+/**
+ * Read coverage.xml, compute line-rate %, upsert a sticky PR comment.
+ *
+ * @param {{ github: object, context: object }} deps — injected by github-script
+ */
+export default async function postCoverageSummary({ github, context }) {
+  const xml = readFileSync('coverage-reports/coverage.xml', 'utf8');
+  const match = xml.match(/line-rate="([^"]+)"/);
+  const coverage = match ? `${(parseFloat(match[1]) * 100).toFixed(2)}%` : 'N/A';
+
+  const comments = await github.rest.issues.listComments({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: context.issue.number,
+  });
+
+  const existing = comments.data.find(
+    (c) => c.user.type === 'Bot' && c.body.includes('📊 Test Coverage'),
+  );
+
+  const body =
+    `## 📊 Test Coverage Report\n\n` +
+    `**Coverage:** ${coverage}\n\n` +
+    `📥 Coverage XML available as artifact: \`coverage-xml\``;
+
+  if (existing) {
+    await github.rest.issues.updateComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      comment_id: existing.id,
+      body,
+    });
+  } else {
+    await github.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: context.issue.number,
+      body,
+    });
+  }
+}

--- a/scripts/post_coverage_summary.test.mjs
+++ b/scripts/post_coverage_summary.test.mjs
@@ -1,0 +1,106 @@
+// scripts/post_coverage_summary.test.mjs
+// Run: node --test scripts/post_coverage_summary.test.mjs
+
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import postCoverageSummary from './post_coverage_summary.mjs';
+
+function mockGithub() {
+  // ponytail: mutable holder object, not closures that reassign local vars
+  const state = { updated: null, created: null, comments: [] };
+
+  return {
+    rest: {
+      issues: {
+        listComments: async () => ({ data: state.comments }),
+        updateComment: async (params) => {
+          state.updated = params;
+          return { status: 200 };
+        },
+        createComment: async (params) => {
+          state.created = params;
+          return { status: 201 };
+        },
+      },
+    },
+    _state: state,
+  };
+}
+
+function mockContext() {
+  return {
+    repo: { owner: 'bitflight-devops', repo: 'skilllint' },
+    issue: { number: 42 },
+  };
+}
+
+function withTempCoverageDir(testFn) {
+  return async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cov-'));
+    mkdirSync(join(dir, 'coverage-reports'), { recursive: true });
+    const origCwd = process.cwd();
+    process.chdir(dir);
+    try {
+      await testFn(dir);
+    } finally {
+      process.chdir(origCwd);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  };
+}
+
+describe('postCoverageSummary', () => {
+  it(
+    'creates comment when none exists (line-rate 0.85 → 85.00%)',
+    withTempCoverageDir(async () => {
+      writeFileSync(
+        'coverage-reports/coverage.xml',
+        `<coverage line-rate="0.85" branch-rate="0.7"/>`,
+      );
+
+      const gh = mockGithub();
+      await postCoverageSummary({ github: gh, context: mockContext() });
+
+      assert.equal(
+        gh._state.created.body,
+        '## 📊 Test Coverage Report\n\n**Coverage:** 85.00%\n\n📥 Coverage XML available as artifact: `coverage-xml`',
+      );
+      assert.equal(gh._state.updated, null);
+    }),
+  );
+
+  it(
+    'updates existing sticky comment (preserves first-match predicate)',
+    withTempCoverageDir(async () => {
+      writeFileSync('coverage-reports/coverage.xml', `<coverage line-rate="1.0"/>`);
+
+      const gh = mockGithub();
+      gh._state.comments.push({
+        id: 999,
+        user: { type: 'Bot' },
+        body: '## 📊 Test Coverage Report\n\n**Coverage:** 50.00%\n\n...',
+      });
+
+      await postCoverageSummary({ github: gh, context: mockContext() });
+
+      assert.equal(gh._state.updated.comment_id, 999);
+      assert.equal(gh._state.created, null);
+    }),
+  );
+
+  it(
+    'returns N/A when line-rate attribute missing',
+    withTempCoverageDir(async () => {
+      writeFileSync('coverage-reports/coverage.xml', `<coverage branch-rate="0.5"/>`);
+
+      const gh = mockGithub();
+      await postCoverageSummary({ github: gh, context: mockContext() });
+
+      assert.ok(gh._state.created.body.includes('N/A'));
+    }),
+  );
+});

--- a/scripts/post_coverage_summary.test.mjs
+++ b/scripts/post_coverage_summary.test.mjs
@@ -1,11 +1,11 @@
 // scripts/post_coverage_summary.test.mjs
 // Run: node --test scripts/post_coverage_summary.test.mjs
 
-import { describe, it } from 'node:test';
 import { strict as assert } from 'node:assert';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
 
 import postCoverageSummary from './post_coverage_summary.mjs';
 


### PR DESCRIPTION
Issue #42. Extract 31 lines of inline JavaScript from .github/workflows/test.yml to scripts/post_coverage_summary.mjs (async default export, stdlib only, no npm deps). Adds node --test (3 cases). Full checkout@v4 + one-liner github-script call. CLAUDE.md no-inline-CI compliance. Biome covers .mjs.