### PR TITLE
fix(rules): derive finding references from rule codes; correct AS001/AS007

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ skilllint check --platform claude-code plugins/my-plugin
 |---|---|---|
 | FM001–FM010 | Frontmatter | Required fields, valid values, schema compliance |
 | SK001–SK009 | Skill | Description quality, token limits, complexity, internal links |
-| AS001–AS009 | AgentSkills | Cross-platform open standard compliance |
+| AS001–AS009 | AgentSkills | SKILL.md conformance with the AgentSkills open standard (AS007 removed) |
 | LK001–LK002 | Links | Markdown link validity and broken reference detection |
 | PD001–PD003 | Progressive disclosure | Directory structure for references/, examples/, scripts/ |
 | PL001–PL006 | Plugin | Structure, manifest correctness, marketplace layout, subprocess safety |

--- a/docs/registry-schema-examples.md
+++ b/docs/registry-schema-examples.md
@@ -221,7 +221,9 @@ These go in `opinion-catalog.json`, not in the provenance registry.
 }
 ```
 
-### AS007 -- wildcard tool detection
+### AS007 -- wildcard tool detection (REMOVED)
+
+Kept here as a worked example of what an empty `references` list predicts.
 
 ```json
 {
@@ -232,6 +234,20 @@ These go in `opinion-catalog.json`, not in the provenance registry.
   "references": []
 }
 ```
+
+AS007 was deleted in PR #108. Its declared authority was
+`agentskills.io /specification#tools-field` -- an anchor that does not exist,
+for a field that specification does not define. The spec covers `SKILL.md` and
+describes only `allowed-tools`, whose own example is itself a wildcard
+(`allowed-tools: Bash(git:*) Bash(jq:*) Read`). The rule's stated runtime
+consequence was also false: `mcp__<server>__*` is a documented group grant that
+resolves to every tool the named server exposes.
+
+`"references": []` was the signal, five months before anyone checked. A rule
+that cannot cite a source is asserting an opinion; this one asserted an opinion
+that turned out to contradict the runtime. That is the case for the provenance
+registry rather than an argument against recording opinions -- but an opinion
+must be labelled as one, not shipped as an error with a spec anchor attached.
 
 ### AS001.name_pattern (partial opinion)
 

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -62,6 +62,7 @@ from skilllint.record_export import (
     export_recording as _export_recording,
     make_recording_console as _make_recording_console,
 )
+from skilllint.rule_registry import rule_reference
 from skilllint.rules.as_series import run_as_series
 from skilllint.rules.fm_series import check_fm004, check_fm007, check_fm008, check_fm010
 from skilllint.rules.sk_series import check_sk001, check_sk002, check_sk003, check_sk004, check_sk005
@@ -234,11 +235,6 @@ def safe_load_yaml_with_colon_fix(fm_text: str) -> tuple[dict | None, str | None
         parsed = dict(data) if isinstance(data, dict) else None
         return parsed, None, [], fm_text
 
-
-# Error code base URL for documentation links
-ERROR_CODE_BASE_URL = (
-    "https://github.com/jamie-bitflight/claude_skills/blob/main/plugins/plugin-creator/docs/ERROR_CODES.md"
-)
 
 # Official plugin.json schema (plugin manifest)
 PLUGIN_MANIFEST_SCHEMA_URL = "https://code.claude.com/docs/en/plugins-reference.md#plugin-manifest-schema"
@@ -1134,9 +1130,9 @@ def generate_docs_url(error_code: ErrorCode) -> str:
         error_code: Error code (ErrorCode enum or string like "FM001", "SK006").
 
     Returns:
-        Full URL to error code documentation with anchor
+        The ``skilllint rule <CODE>`` invocation that renders the rule docs.
     """
-    return f"{ERROR_CODE_BASE_URL}#{str(error_code).lower()}"
+    return rule_reference(str(error_code))
 
 
 # extract_frontmatter imported from frontmatter_core

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -2268,12 +2268,16 @@ class SymlinkTargetValidator:
 
 
 class AsSeriesValidator:
-    """Runs AS001-AS008 rules on SKILL.md and agent .md files.
+    """Runs AS001-AS009 rules on SKILL.md files.
 
-    AS-series rules are cross-platform quality checks that apply to any file
-    carrying skill or agent frontmatter, regardless of which platform adapter
-    is active. This validator integrates them into the default
-    ``validate_single_path`` code path so they fire without ``--platform``.
+    AS-series rules enforce the AgentSkills specification, which is a
+    cross-harness baseline for skills. It defines ``SKILL.md`` and does not
+    describe agent files at all, so this validator is wired only to
+    ``FileType.SKILL``. A check on agent frontmatter belongs to a series that
+    governs agent files, cited to the harness documentation defining them.
+
+    These are platform-independent, so this validator integrates into the
+    default ``validate_single_path`` code path and fires without ``--platform``.
     """
 
     def validate(self, path: Path, policy: ValidationPolicy | None = None) -> ValidationResult:
@@ -5140,7 +5144,11 @@ def _get_validators_for_path(path: Path) -> list[Validator]:
         if fm_req == _FrontmatterRequirement.REQUIRED or _file_has_frontmatter(path):
             validators.extend([NameFormatValidator(), DescriptionValidator(file_type=file_type)])
         validators.append(NamespaceReferenceValidator())
-        if file_type in {FileType.SKILL, FileType.AGENT}:
+        # AS-series rules enforce the AgentSkills specification, which governs
+        # SKILL.md and nothing else. Agent files are a harness extension the
+        # spec does not define, so running AS rules on them is a category error
+        # regardless of what an individual rule happens to check.
+        if file_type == FileType.SKILL:
             validators.append(AsSeriesValidator())
         if file_type == FileType.SKILL:
             validators.extend([ComplexityValidator(), InternalLinkValidator(), ProgressiveDisclosureValidator()])
@@ -5483,9 +5491,10 @@ def validate_file(path: Path, adapters: dict, platform_override: str | None = No
     violations: list[dict] = []
 
     # AS-series rules are cross-platform — they run before the adapter matching
-    # guard so that agent files outside a recognised plugin structure still get
-    # AS007/AS008 checks even when no platform adapter claims the file.
-    if is_skill_md(path) or "agents" in path.parts:
+    # guard so that a SKILL.md outside a recognised plugin structure is still
+    # checked even when no platform adapter claims the file. They do not extend
+    # to agent files: the AgentSkills specification defines SKILL.md only.
+    if is_skill_md(path):
         frontmatter_data, body_lines, yaml_err, colon_fields = parse_skill_md(path)
         if colon_fields:
             violations.append({

--- a/packages/skilllint/reporting.py
+++ b/packages/skilllint/reporting.py
@@ -76,7 +76,7 @@ class ConsoleReporter:
             self.console.print(f"      [dim]→[/dim] {issue.suggestion}", crop=False, overflow="ignore")
 
         if issue.docs_url:
-            self.console.print(f"      [dim]→[/dim] [link]{issue.docs_url}[/link]", crop=False, overflow="ignore")
+            self.console.print(f"      [dim]→[/dim] [cyan]{issue.docs_url}[/cyan]", crop=False, overflow="ignore")
 
     def report(self, file_results: FileResults, verbose: bool = False, *, show_progress: bool = False) -> None:
         """Display validation results with Rich formatting, grouped by file."""

--- a/packages/skilllint/rule_registry.py
+++ b/packages/skilllint/rule_registry.py
@@ -36,6 +36,23 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 
+def rule_reference(code: str) -> str:
+    """Return the command that renders a rule's full documentation.
+
+    Findings point here rather than at an external URL. The reference is
+    derived from the rule code, so it cannot drift from the registry, and it
+    resolves for every user of the published CLI regardless of which
+    repository they are linting.
+
+    Args:
+        code: Rule code, e.g. "FM001".
+
+    Returns:
+        The ``skilllint rule <CODE>`` invocation for that rule.
+    """
+    return f"skilllint rule {str(code).upper()}"
+
+
 class RuleAuthority(BaseModel):
     """Structured authority metadata for a validation rule.
 

--- a/packages/skilllint/rules/as_series.py
+++ b/packages/skilllint/rules/as_series.py
@@ -12,7 +12,7 @@ Each violation dict has the shape:
     {"code": str, "severity": str, "message": str}
 
 Severities:
-    "error"   — AS001, AS002, AS003, AS007
+    "error"   — AS001, AS002, AS003
     "warning" — AS004, AS005, AS008, AS009
     "info"    — AS006
 """
@@ -42,7 +42,6 @@ AS_RULES: dict[str, str] = {
     "AS004": "description contains unquoted colons that break YAML — quote the string to fix",
     "AS005": f"SKILL.md body token count exceeds {TOKEN_WARNING_THRESHOLD} tokens — consider splitting into sub-skills",
     "AS006": "No eval_queries.json found — add evaluation queries for quality assurance",
-    "AS007": "Unscoped wildcard in tools field resolves to nothing — use mcp__<server>__* or exact tool names",
     "AS008": "MCP tool name may have incorrect casing — case is sensitive in the tools field",
     "AS009": "Nested skill will not be auto-discovered — skills must be direct children of the skills/ directory",
 }
@@ -55,29 +54,6 @@ _MAX_NAME_LENGTH = 64
 
 _NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
 _CONSECUTIVE_HYPHENS_RE = re.compile(r"--")
-
-# A server-scoped MCP group grant, e.g. "mcp__Ref__*" or
-# "mcp__plugin_dh_backlog__*". Claude Code resolves this to every tool the
-# named server exposes; it is a supported form, not a broken one.
-# Source: .claude/vendor/claude_code/CHANGELOG.md — "Added wildcard syntax
-#   `mcp__server__*` for MCP tool permissions to allow or deny all tools from
-#   a server"
-# Source: .claude/vendor/claude_code/plugins/plugin-dev/skills/mcp-integration/
-#   references/tool-usage.md — documents `allowed-tools:
-#   ["mcp__plugin_asana_asana__*"]` as supported ("use sparingly")
-# The server segment must name a concrete server and nothing more. `mcp__*__*`
-# and `mcp__foo*__*` name none; `mcp__Ref__tool__*` puts the wildcard inside a
-# tool name rather than forming the documented `mcp__<server>__*` group grant.
-# Server names may contain single underscores (`plugin_dh_backlog`) but the
-# `__` separator terminates the segment, so the capture must not span one.
-_MCP_SERVER_GRANT_RE = re.compile(r"^mcp__[^*_]+(?:_[^*_]+)*__\*$")
-
-# Source: code.claude.com/docs/en/sub-agents.md — `tools` field: "If no entry
-#   in the list resolves to a tool, the subagent usually fails to launch with
-#   an error naming the entries."
-# A single unresolvable entry is dropped and the rest of the grant survives;
-# only an entirely unresolvable list is fatal. Severity follows that split.
-_SUBAGENTS_TOOLS_URL = "https://code.claude.com/docs/en/sub-agents.md#supported-frontmatter-fields"
 
 
 def _parse_skill_md(path: pathlib.Path) -> tuple[dict, list[str], str | None]:
@@ -431,18 +407,28 @@ def _check_as005(
     return None
 
 
-def _extract_tools_list(path: pathlib.Path) -> list[str]:
-    """Extract tool names from the tools: frontmatter field.
+def _extract_tools_list(path: pathlib.Path, field: str = "allowed-tools") -> list[str]:
+    """Extract tool names from a tool-declaring frontmatter field.
 
-    Handles both YAML list form and inline comma-separated string form.
-    Uses proper YAML parsing (not the simple key/value parser used by
-    _parse_skill_md) so that multi-line list values are read correctly.
+    Handles the YAML list form and the inline string form. Uses proper YAML
+    parsing (not the simple key/value parser used by _parse_skill_md) so that
+    multi-line list values are read correctly.
+
+    The inline form is split on **both** whitespace and commas. The AgentSkills
+    specification describes ``allowed-tools`` as a space-separated string
+    (agentskills.io/specification.md, fetched 2026-08-22), but marks the field
+    Experimental and notes support varies between implementations, and nothing
+    establishes that another separator is an error. Parsing liberally is what
+    lets a rule *see* the entries either way; whether a given separator is
+    worth reporting is a separate question this function does not answer.
 
     Args:
         path: Path to the SKILL.md file.
+        field: Frontmatter key to read. Defaults to ``allowed-tools``, the
+            field the AgentSkills specification defines for skills.
 
     Returns:
-        List of tool name strings. Empty list if tools field is absent or
+        List of tool name strings. Empty list if the field is absent or
         the file cannot be parsed.
     """
     # Deferred import to break circular dependency; plugin_validator imports
@@ -463,12 +449,12 @@ def _extract_tools_list(path: pathlib.Path) -> list[str]:
     if not isinstance(parsed, dict):
         return []
 
-    tools_value = parsed.get("tools")
+    tools_value = parsed.get(field)
     if isinstance(tools_value, list):
         return [str(t) for t in tools_value if t is not None]
     if isinstance(tools_value, str):
-        # Inline comma-separated: "mcp__Ref__foo, mcp__Bar__baz"
-        return [t.strip() for t in tools_value.split(",") if t.strip()]
+        # Inline form, either separator: "Read Grep" or "Read, Grep".
+        return [t for t in tools_value.replace(",", " ").split() if t]
     return []
 
 
@@ -681,76 +667,6 @@ def _discover_mcp_servers(file_path: pathlib.Path) -> set[str]:
         Set of MCP server name strings (exact case as declared in config).
     """
     return _collect_servers_from_ancestry(file_path) | _collect_servers_from_frontmatter(file_path)
-
-
-@skilllint_rule(
-    "AS007",
-    severity="warning",
-    category="skill",
-    # The agentskills.io specification defines no `tools` field at all — only a
-    # space-separated `allowed-tools`, whose own example is `Bash(git:*)
-    # Bash(jq:*) Read`. It says nothing about wildcards, MCP naming, or what
-    # happens to an entry matching nothing, so it cannot be the authority here.
-    # `tools:` is Claude Code subagent frontmatter; cite the doc that defines it.
-    authority={"origin": "code.claude.com", "reference": _SUBAGENTS_TOOLS_URL},
-)
-def _check_as007(tools: list[str]) -> list[dict]:
-    """AS007 — Unscoped wildcard in tools field resolves to nothing.
-
-    A *server-scoped* MCP grant such as ``mcp__Ref__*`` is supported and is
-    NOT reported: Claude Code resolves it to every tool that server exposes,
-    identically to the bare ``mcp__Ref`` form. Both forms are left alone.
-
-    An *unscoped* wildcard — bare ``*``, or ``mcp__*`` naming no server — has
-    no documented meaning in this field. It is not expanded, so the entry
-    contributes no tools.
-
-    Args:
-        tools: List of tool name strings from the tools: frontmatter field.
-
-    Returns:
-        List of violation dicts — one per wildcard tool entry.
-
-    Fix:
-        Replace each wildcard with the exact registered tool names.
-        For example, replace ``mcp__Ref__*`` with the explicit tool names
-        ``mcp__Ref__ref_read_url`` and ``mcp__Ref__ref_search_documentation``.
-
-    Examples:
-        Invalid: ``mcp__*``, ``*``
-        Valid: ``mcp__Ref__*``, ``mcp__Ref``, ``mcp__Ref__ref_read_url``, ``Read``
-    """
-    unscoped = [t for t in tools if "*" in t and not _MCP_SERVER_GRANT_RE.match(t)]
-    if not unscoped:
-        return []
-
-    # Fatal only when nothing in the list can resolve; otherwise the entry is
-    # dropped and the surviving entries still grant the subagent its tools.
-    # Fatality is only provable in one direction. When every entry is an
-    # unscoped wildcard, nothing can resolve and the subagent cannot launch.
-    # Otherwise a sibling *may* resolve — skilllint cannot confirm it does,
-    # since it has no registry of live tool names, so the message must not
-    # claim the grant survives. `tools: [NoSuchTool, "*"]` is the case that
-    # would make such a claim false.
-    fatal = len(unscoped) == len(tools)
-    severity = "error" if fatal else "warning"
-    consequence = (
-        "so no entry in the tools field resolves and the subagent fails to launch"
-        if fatal
-        else "so it contributes no tools; if no other entry resolves either, the subagent fails to launch"
-    )
-    return [
-        _make_violation(
-            "AS007",
-            severity,
-            f"Unscoped wildcard '{tool_name}' in tools field names no server, {consequence}.",
-            fix=(
-                f"Replace '{tool_name}' with a server-scoped grant (e.g. 'mcp__Ref__*') "
-                "or the exact tool names (e.g. 'mcp__Ref__ref_read_url')."
-            ),
-        )
-        for tool_name in unscoped
-    ]
 
 
 @skilllint_rule(
@@ -1010,7 +926,7 @@ def check_skill_md(path: pathlib.Path) -> list[dict]:
 
     Returns:
         List of violation dicts, each with keys: code, severity, message.
-        May include 'fix' key with auto-fix suggestion for AS004, AS007, AS008, AS009.
+        May include 'fix' key with auto-fix suggestion for AS004, AS008, AS009.
     """
     frontmatter, body_lines, raw_description_line = _parse_skill_md(path)
 
@@ -1050,7 +966,6 @@ def check_skill_md(path: pathlib.Path) -> list[dict]:
         violations.append(v)
 
     tools = _extract_tools_list(path)
-    violations.extend(_check_as007(tools))
     violations.extend(_check_as008(tools, path))
 
     v = _check_as009(path)
@@ -1113,7 +1028,6 @@ def run_as_series(
         violations.append(v)
 
     tools = _extract_tools_list(path)
-    violations.extend(_check_as007(tools))
     violations.extend(_check_as008(tools, path))
 
     v = _check_as009(path)

--- a/packages/skilllint/rules/as_series.py
+++ b/packages/skilllint/rules/as_series.py
@@ -1,7 +1,10 @@
 """AS-series rule validation for agentskills.io SKILL.md files.
 
-Rules AS001-AS009 fire on any SKILL.md file regardless of which platform
-adapter is active. They enforce cross-platform quality standards.
+Rules AS001-AS009 fire on SKILL.md files only, regardless of which platform
+adapter is active. They enforce the AgentSkills specification, a cross-harness
+baseline that defines SKILL.md and does not describe agent files. A check on
+agent frontmatter belongs to a series that governs agent files, cited to the
+harness documentation that defines them — not here.
 
 Entry point: check_skill_md(path: Path) -> list[dict]
 
@@ -193,7 +196,7 @@ def _make_violation(code: str, severity: str, message: str, fix: str | None = No
     category="skill",
     authority={"origin": "agentskills.io", "reference": "/specification#skill-naming"},
 )
-def _check_as001(name: str | None, path: pathlib.Path) -> dict | None:
+def _check_as001(name: str | None) -> dict | None:
     """AS001 — Invalid skill name format.
 
     Skill names must be lowercase alphanumeric with hyphens only, between
@@ -202,9 +205,6 @@ def _check_as001(name: str | None, path: pathlib.Path) -> dict | None:
 
     Args:
         name: The skill name from frontmatter, or None if missing.
-        path: Path to the file being validated, used to tell a SKILL.md
-            (where agentskills.io requires ``name``) from an agent file
-            (where FM001 already reports the missing field).
 
     Returns:
         Violation dict if invalid, None otherwise.
@@ -220,11 +220,10 @@ def _check_as001(name: str | None, path: pathlib.Path) -> dict | None:
     if name is None:
         # agentskills.io requires `name` on a SKILL.md, and FM001 stays silent
         # there (skills.md treats it as optional, falling back to the directory
-        # name). On agent files FM001 already errors, so reporting here only
-        # produced a duplicate finding for the same missing field.
-        if path.name == "SKILL.md":
-            return _make_violation("AS001", "error", "name field is missing")
-        return None
+        # name), so this is the only signal for a skill missing its name.
+        # It used to double-report alongside FM001 on agent files; that is now
+        # impossible because the AS family is wired to SKILL.md only.
+        return _make_violation("AS001", "error", "name field is missing")
 
     if len(name) == 0 or len(name) > _MAX_NAME_LENGTH:
         return _make_violation(
@@ -1015,7 +1014,7 @@ def check_skill_md(path: pathlib.Path) -> list[dict]:
 
     violations: list[dict] = []
 
-    v = _check_as001(name, path)
+    v = _check_as001(name)
     if v:
         violations.append(v)
 
@@ -1078,7 +1077,7 @@ def run_as_series(
 
     violations: list[dict] = []
 
-    v = _check_as001(name, path)
+    v = _check_as001(name)
     if v:
         violations.append(v)
 

--- a/packages/skilllint/rules/as_series.py
+++ b/packages/skilllint/rules/as_series.py
@@ -39,7 +39,7 @@ AS_RULES: dict[str, str] = {
     "AS004": "description contains unquoted colons that break YAML — quote the string to fix",
     "AS005": f"SKILL.md body token count exceeds {TOKEN_WARNING_THRESHOLD} tokens — consider splitting into sub-skills",
     "AS006": "No eval_queries.json found — add evaluation queries for quality assurance",
-    "AS007": "Wildcard pattern in tools field will not resolve — list each tool by its exact registered name",
+    "AS007": "Unscoped wildcard in tools field resolves to nothing — use mcp__<server>__* or exact tool names",
     "AS008": "MCP tool name may have incorrect casing — case is sensitive in the tools field",
     "AS009": "Nested skill will not be auto-discovered — skills must be direct children of the skills/ directory",
 }
@@ -52,6 +52,17 @@ _MAX_NAME_LENGTH = 64
 
 _NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
 _CONSECUTIVE_HYPHENS_RE = re.compile(r"--")
+
+# A server-scoped MCP group grant, e.g. "mcp__Ref__*" or
+# "mcp__plugin_dh_backlog__*". Claude Code resolves this to every tool the
+# named server exposes; it is a supported form, not a broken one.
+# Source: .claude/vendor/claude_code/CHANGELOG.md — "Added wildcard syntax
+#   `mcp__server__*` for MCP tool permissions to allow or deny all tools from
+#   a server"
+# Source: .claude/vendor/claude_code/plugins/plugin-dev/skills/mcp-integration/
+#   references/tool-usage.md — documents `allowed-tools:
+#   ["mcp__plugin_asana_asana__*"]` as supported ("use sparingly")
+_MCP_SERVER_GRANT_RE = re.compile(r"^mcp__.+__\*$")
 
 
 def _parse_skill_md(path: pathlib.Path) -> tuple[dict, list[str], str | None]:
@@ -175,7 +186,7 @@ def _make_violation(code: str, severity: str, message: str, fix: str | None = No
     category="skill",
     authority={"origin": "agentskills.io", "reference": "/specification#skill-naming"},
 )
-def _check_as001(name: str | None) -> dict | None:
+def _check_as001(name: str | None, path: pathlib.Path) -> dict | None:
     """AS001 — Invalid skill name format.
 
     Skill names must be lowercase alphanumeric with hyphens only, between
@@ -184,6 +195,9 @@ def _check_as001(name: str | None) -> dict | None:
 
     Args:
         name: The skill name from frontmatter, or None if missing.
+        path: Path to the file being validated, used to tell a SKILL.md
+            (where agentskills.io requires ``name``) from an agent file
+            (where FM001 already reports the missing field).
 
     Returns:
         Violation dict if invalid, None otherwise.
@@ -197,7 +211,13 @@ def _check_as001(name: str | None) -> dict | None:
         Invalid: ``MySkill``, ``my_skill``, ``skill--name``, ``-skill``
     """
     if name is None:
-        return _make_violation("AS001", "error", "name field is missing")
+        # agentskills.io requires `name` on a SKILL.md, and FM001 stays silent
+        # there (skills.md treats it as optional, falling back to the directory
+        # name). On agent files FM001 already errors, so reporting here only
+        # produced a duplicate finding for the same missing field.
+        if path.name == "SKILL.md":
+            return _make_violation("AS001", "error", "name field is missing")
+        return None
 
     if len(name) == 0 or len(name) > _MAX_NAME_LENGTH:
         return _make_violation(
@@ -659,11 +679,15 @@ def _discover_mcp_servers(file_path: pathlib.Path) -> set[str]:
     authority={"origin": "agentskills.io", "reference": "/specification#tools-field"},
 )
 def _check_as007(tools: list[str]) -> list[dict]:
-    """AS007 — Wildcard pattern in tools field will not resolve.
+    """AS007 — Unscoped wildcard in tools field resolves to nothing.
 
-    Wildcard patterns such as ``mcp__Ref__*`` in the ``tools:`` frontmatter
-    field are silently ignored at runtime. The agent receives no MCP tools
-    when wildcards are used.
+    A *server-scoped* MCP grant such as ``mcp__Ref__*`` is supported and is
+    NOT reported: Claude Code resolves it to every tool that server exposes,
+    identically to the bare ``mcp__Ref`` form. Both forms are left alone.
+
+    An *unscoped* wildcard — bare ``*``, or ``mcp__*`` naming no server — has
+    no documented meaning in this field. It is not expanded, so the entry
+    contributes no tools.
 
     Args:
         tools: List of tool name strings from the tools: frontmatter field.
@@ -677,19 +701,21 @@ def _check_as007(tools: list[str]) -> list[dict]:
         ``mcp__Ref__ref_read_url`` and ``mcp__Ref__ref_search_documentation``.
 
     Examples:
-        Invalid: ``mcp__Ref__*``, ``mcp__*``, ``*``
-        Valid: ``mcp__Ref__ref_read_url``, ``Bash``, ``Read``
+        Invalid: ``mcp__*``, ``*``
+        Valid: ``mcp__Ref__*``, ``mcp__Ref``, ``mcp__Ref__ref_read_url``, ``Read``
     """
     violations: list[dict] = [
         _make_violation(
             "AS007",
             "error",
-            f"Wildcard pattern '{tool_name}' in tools field will not resolve. "
-            "List each tool by its exact registered name.",
-            fix=f"Replace '{tool_name}' with the explicit tool names (e.g., 'mcp__Ref__ref_read_url').",
+            f"Unscoped wildcard '{tool_name}' in tools field names no server, so it resolves to no tools.",
+            fix=(
+                f"Replace '{tool_name}' with a server-scoped grant (e.g. 'mcp__Ref__*') "
+                "or the exact tool names (e.g. 'mcp__Ref__ref_read_url')."
+            ),
         )
         for tool_name in tools
-        if "*" in tool_name
+        if "*" in tool_name and not _MCP_SERVER_GRANT_RE.match(tool_name)
     ]
     return violations
 
@@ -966,7 +992,7 @@ def check_skill_md(path: pathlib.Path) -> list[dict]:
 
     violations: list[dict] = []
 
-    v = _check_as001(name)
+    v = _check_as001(name, path)
     if v:
         violations.append(v)
 
@@ -1029,7 +1055,7 @@ def run_as_series(
 
     violations: list[dict] = []
 
-    v = _check_as001(name)
+    v = _check_as001(name, path)
     if v:
         violations.append(v)
 

--- a/packages/skilllint/rules/as_series.py
+++ b/packages/skilllint/rules/as_series.py
@@ -65,9 +65,12 @@ _CONSECUTIVE_HYPHENS_RE = re.compile(r"--")
 # Source: .claude/vendor/claude_code/plugins/plugin-dev/skills/mcp-integration/
 #   references/tool-usage.md — documents `allowed-tools:
 #   ["mcp__plugin_asana_asana__*"]` as supported ("use sparingly")
-# The server segment must name a concrete server: `mcp__*__*` and
-# `mcp__foo*__*` name none, so they are not group grants.
-_MCP_SERVER_GRANT_RE = re.compile(r"^mcp__[^*]+__\*$")
+# The server segment must name a concrete server and nothing more. `mcp__*__*`
+# and `mcp__foo*__*` name none; `mcp__Ref__tool__*` puts the wildcard inside a
+# tool name rather than forming the documented `mcp__<server>__*` group grant.
+# Server names may contain single underscores (`plugin_dh_backlog`) but the
+# `__` separator terminates the segment, so the capture must not span one.
+_MCP_SERVER_GRANT_RE = re.compile(r"^mcp__[^*_]+(?:_[^*_]+)*__\*$")
 
 # Source: code.claude.com/docs/en/sub-agents.md — `tools` field: "If no entry
 #   in the list resolves to a tool, the subagent usually fails to launch with
@@ -723,12 +726,18 @@ def _check_as007(tools: list[str]) -> list[dict]:
 
     # Fatal only when nothing in the list can resolve; otherwise the entry is
     # dropped and the surviving entries still grant the subagent its tools.
+    # Fatality is only provable in one direction. When every entry is an
+    # unscoped wildcard, nothing can resolve and the subagent cannot launch.
+    # Otherwise a sibling *may* resolve — skilllint cannot confirm it does,
+    # since it has no registry of live tool names, so the message must not
+    # claim the grant survives. `tools: [NoSuchTool, "*"]` is the case that
+    # would make such a claim false.
     fatal = len(unscoped) == len(tools)
     severity = "error" if fatal else "warning"
     consequence = (
         "so no entry in the tools field resolves and the subagent fails to launch"
         if fatal
-        else "so it contributes no tools; the remaining entries still resolve"
+        else "so it contributes no tools; if no other entry resolves either, the subagent fails to launch"
     )
     return [
         _make_violation(

--- a/packages/skilllint/rules/as_series.py
+++ b/packages/skilllint/rules/as_series.py
@@ -65,7 +65,9 @@ _CONSECUTIVE_HYPHENS_RE = re.compile(r"--")
 # Source: .claude/vendor/claude_code/plugins/plugin-dev/skills/mcp-integration/
 #   references/tool-usage.md — documents `allowed-tools:
 #   ["mcp__plugin_asana_asana__*"]` as supported ("use sparingly")
-_MCP_SERVER_GRANT_RE = re.compile(r"^mcp__.+__\*$")
+# The server segment must name a concrete server: `mcp__*__*` and
+# `mcp__foo*__*` name none, so they are not group grants.
+_MCP_SERVER_GRANT_RE = re.compile(r"^mcp__[^*]+__\*$")
 
 # Source: code.claude.com/docs/en/sub-agents.md — `tools` field: "If no entry
 #   in the list resolves to a tool, the subagent usually fails to launch with

--- a/packages/skilllint/rules/as_series.py
+++ b/packages/skilllint/rules/as_series.py
@@ -64,6 +64,13 @@ _CONSECUTIVE_HYPHENS_RE = re.compile(r"--")
 #   ["mcp__plugin_asana_asana__*"]` as supported ("use sparingly")
 _MCP_SERVER_GRANT_RE = re.compile(r"^mcp__.+__\*$")
 
+# Source: code.claude.com/docs/en/sub-agents.md — `tools` field: "If no entry
+#   in the list resolves to a tool, the subagent usually fails to launch with
+#   an error naming the entries."
+# A single unresolvable entry is dropped and the rest of the grant survives;
+# only an entirely unresolvable list is fatal. Severity follows that split.
+_SUBAGENTS_TOOLS_URL = "https://code.claude.com/docs/en/sub-agents.md#supported-frontmatter-fields"
+
 
 def _parse_skill_md(path: pathlib.Path) -> tuple[dict, list[str], str | None]:
     """Parse a SKILL.md file into frontmatter dict and body lines.
@@ -674,9 +681,14 @@ def _discover_mcp_servers(file_path: pathlib.Path) -> set[str]:
 
 @skilllint_rule(
     "AS007",
-    severity="error",
+    severity="warning",
     category="skill",
-    authority={"origin": "agentskills.io", "reference": "/specification#tools-field"},
+    # The agentskills.io specification defines no `tools` field at all — only a
+    # space-separated `allowed-tools`, whose own example is `Bash(git:*)
+    # Bash(jq:*) Read`. It says nothing about wildcards, MCP naming, or what
+    # happens to an entry matching nothing, so it cannot be the authority here.
+    # `tools:` is Claude Code subagent frontmatter; cite the doc that defines it.
+    authority={"origin": "code.claude.com", "reference": _SUBAGENTS_TOOLS_URL},
 )
 def _check_as007(tools: list[str]) -> list[dict]:
     """AS007 — Unscoped wildcard in tools field resolves to nothing.
@@ -704,20 +716,31 @@ def _check_as007(tools: list[str]) -> list[dict]:
         Invalid: ``mcp__*``, ``*``
         Valid: ``mcp__Ref__*``, ``mcp__Ref``, ``mcp__Ref__ref_read_url``, ``Read``
     """
-    violations: list[dict] = [
+    unscoped = [t for t in tools if "*" in t and not _MCP_SERVER_GRANT_RE.match(t)]
+    if not unscoped:
+        return []
+
+    # Fatal only when nothing in the list can resolve; otherwise the entry is
+    # dropped and the surviving entries still grant the subagent its tools.
+    fatal = len(unscoped) == len(tools)
+    severity = "error" if fatal else "warning"
+    consequence = (
+        "so no entry in the tools field resolves and the subagent fails to launch"
+        if fatal
+        else "so it contributes no tools; the remaining entries still resolve"
+    )
+    return [
         _make_violation(
             "AS007",
-            "error",
-            f"Unscoped wildcard '{tool_name}' in tools field names no server, so it resolves to no tools.",
+            severity,
+            f"Unscoped wildcard '{tool_name}' in tools field names no server, {consequence}.",
             fix=(
                 f"Replace '{tool_name}' with a server-scoped grant (e.g. 'mcp__Ref__*') "
                 "or the exact tool names (e.g. 'mcp__Ref__ref_read_url')."
             ),
         )
-        for tool_name in tools
-        if "*" in tool_name and not _MCP_SERVER_GRANT_RE.match(tool_name)
+        for tool_name in unscoped
     ]
-    return violations
 
 
 @skilllint_rule(

--- a/packages/skilllint/rules/cu_series.py
+++ b/packages/skilllint/rules/cu_series.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from skilllint.rule_registry import skilllint_rule
+from skilllint.rule_registry import rule_reference, skilllint_rule
 
 if TYPE_CHECKING:
     from skilllint.plugin_validator import ValidationIssue
@@ -42,7 +42,6 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 _CURSOR_DOCS_URL = "https://docs.cursor.com/context/rules-for-ai"
-_CU_DOCS_BASE = "https://github.com/jamie-bitflight/claude_skills/blob/main/plugins/plugin-creator/docs/ERROR_CODES.md"
 
 
 def _docs_url(code: str) -> str:
@@ -54,7 +53,7 @@ def _docs_url(code: str) -> str:
     Returns:
         Full URL with anchor for the error code documentation.
     """
-    return f"{_CU_DOCS_BASE}#{code.lower()}"
+    return rule_reference(code)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/skilllint/rules/cx_series.py
+++ b/packages/skilllint/rules/cx_series.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
-from skilllint.rule_registry import skilllint_rule
+from skilllint.rule_registry import rule_reference, skilllint_rule
 
 if TYPE_CHECKING:
     from skilllint.plugin_validator import ValidationIssue
@@ -49,8 +49,6 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 _CODEX_AUTHORITY_URL = "https://github.com/openai/codex"
-_CX_DOCS_BASE = "https://github.com/jamie-bitflight/claude_skills/blob/main/plugins/plugin-creator/docs/ERROR_CODES.md"
-
 # Matches: prefix_rule(\n    key = value,\n    ...\n)
 # Captures the body between the outer parentheses.
 # Source: adapters/codex/adapter.py — same regex, moved here with the logic.
@@ -68,7 +66,7 @@ def _docs_url(code: str) -> str:
     Returns:
         Full URL with anchor for the error code documentation.
     """
-    return f"{_CX_DOCS_BASE}#{code.lower()}"
+    return rule_reference(code)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/skilllint/rules/fm_series.py
+++ b/packages/skilllint/rules/fm_series.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Literal
 
-from skilllint.rule_registry import skilllint_rule
+from skilllint.rule_registry import rule_reference, skilllint_rule
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -34,8 +34,6 @@ if TYPE_CHECKING:
 
 _SKILLS_SPEC_URL = "https://docs.anthropic.com/en/docs/claude-code/skills"
 _AGENTS_SPEC_URL = "https://docs.anthropic.com/en/docs/claude-code/sub-agents"
-_FM_DOCS_BASE = "https://github.com/jamie-bitflight/claude_skills/blob/main/plugins/plugin-creator/docs/ERROR_CODES.md"
-
 # Name pattern: lowercase alphanumeric with hyphens, no leading/trailing/consecutive hyphens.
 # Source: skills.md frontmatter reference table — "Lowercase letters, numbers, and hyphens only (max 64 characters)"
 # Source: sub-agents.md — "Unique identifier using lowercase letters and hyphens"
@@ -56,7 +54,7 @@ def _docs_url(code: str) -> str:
     Returns:
         Full URL with anchor for the error code documentation.
     """
-    return f"{_FM_DOCS_BASE}#{code.lower()}"
+    return rule_reference(code)
 
 
 def _make_issue(

--- a/packages/skilllint/rules/hk_series.py
+++ b/packages/skilllint/rules/hk_series.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from skilllint.rule_registry import skilllint_rule
+from skilllint.rule_registry import rule_reference, skilllint_rule
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -43,8 +43,6 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Spec sources
 # ---------------------------------------------------------------------------
-
-_HK_DOCS_BASE = "https://github.com/jamie-bitflight/claude_skills/blob/main/plugins/plugin-creator/docs/ERROR_CODES.md"
 
 
 def _docs_url(code: str) -> str:
@@ -56,7 +54,7 @@ def _docs_url(code: str) -> str:
     Returns:
         Full URL with anchor for the error code documentation.
     """
-    return f"{_HK_DOCS_BASE}#{code.lower()}"
+    return rule_reference(code)
 
 
 # ---------------------------------------------------------------------------
@@ -69,7 +67,7 @@ def _docs_url(code: str) -> str:
     severity="error",
     category="hook",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _HK_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_hk001(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     """## HK001 — Invalid hooks.json structure
@@ -137,7 +135,7 @@ def check_hk001(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     severity="error",
     category="hook",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _HK_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_hk002(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     """## HK002 — Invalid event type in hooks.json
@@ -191,7 +189,7 @@ def check_hk002(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     severity="error",
     category="hook",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _HK_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_hk003(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     """## HK003 — Invalid hook entry structure
@@ -254,7 +252,7 @@ def check_hk003(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     severity="error",
     category="hook",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _HK_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_hk004(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     """## HK004 — Hook script referenced but not found
@@ -308,7 +306,7 @@ def check_hk004(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     severity="warning",
     category="hook",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _HK_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_hk005(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     """## HK005 — Hook script exists but is not executable

--- a/packages/skilllint/rules/lk_series.py
+++ b/packages/skilllint/rules/lk_series.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from skilllint.rule_registry import skilllint_rule
+from skilllint.rule_registry import rule_reference, skilllint_rule
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -37,8 +37,6 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Spec sources
 # ---------------------------------------------------------------------------
-
-_LK_DOCS_BASE = "https://github.com/jamie-bitflight/claude_skills/blob/main/plugins/plugin-creator/docs/ERROR_CODES.md"
 
 
 def _docs_url(code: str) -> str:
@@ -50,7 +48,7 @@ def _docs_url(code: str) -> str:
     Returns:
         Full URL with anchor for the error code documentation.
     """
-    return f"{_LK_DOCS_BASE}#{code.lower()}"
+    return rule_reference(code)
 
 
 # ---------------------------------------------------------------------------
@@ -63,7 +61,7 @@ def _docs_url(code: str) -> str:
     severity="error",
     category="link",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _LK_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_lk001(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     """## LK001 — Broken internal link
@@ -107,7 +105,7 @@ def check_lk001(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     severity="warning",
     category="link",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _LK_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_lk002(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     """## LK002 — Relative link missing ./ prefix

--- a/packages/skilllint/rules/nr_series.py
+++ b/packages/skilllint/rules/nr_series.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from skilllint.rule_registry import skilllint_rule
+from skilllint.rule_registry import rule_reference, skilllint_rule
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -40,8 +40,6 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Spec sources
 # ---------------------------------------------------------------------------
-
-_NR_DOCS_BASE = "https://github.com/jamie-bitflight/claude_skills/blob/main/plugins/plugin-creator/docs/ERROR_CODES.md"
 
 
 def _docs_url(code: str) -> str:
@@ -53,7 +51,7 @@ def _docs_url(code: str) -> str:
     Returns:
         Full URL with anchor for the error code documentation.
     """
-    return f"{_NR_DOCS_BASE}#{code.lower()}"
+    return rule_reference(code)
 
 
 # ---------------------------------------------------------------------------
@@ -66,7 +64,7 @@ def _docs_url(code: str) -> str:
     severity="error",
     category="namespace-reference",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _NR_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_nr001(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     """## NR001 — Namespace reference target does not exist
@@ -128,7 +126,7 @@ def check_nr001(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     severity="error",
     category="namespace-reference",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _NR_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_nr002(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     """## NR002 — Namespace reference points outside plugin directory

--- a/packages/skilllint/rules/pd_series.py
+++ b/packages/skilllint/rules/pd_series.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from skilllint.rule_registry import skilllint_rule
+from skilllint.rule_registry import rule_reference, skilllint_rule
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -39,8 +39,6 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Spec sources
 # ---------------------------------------------------------------------------
-
-_PD_DOCS_BASE = "https://github.com/jamie-bitflight/claude_skills/blob/main/plugins/plugin-creator/docs/ERROR_CODES.md"
 
 
 def _docs_url(code: str) -> str:
@@ -52,7 +50,7 @@ def _docs_url(code: str) -> str:
     Returns:
         Full URL with anchor for the error code documentation.
     """
-    return f"{_PD_DOCS_BASE}#{code.lower()}"
+    return rule_reference(code)
 
 
 # ---------------------------------------------------------------------------
@@ -65,7 +63,7 @@ def _docs_url(code: str) -> str:
     severity="info",
     category="progressive-disclosure",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _PD_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_pd001(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     """## PD001 — No references/ directory found
@@ -114,7 +112,7 @@ def check_pd001(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     severity="info",
     category="progressive-disclosure",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _PD_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_pd002(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     """## PD002 — No examples/ directory found
@@ -163,7 +161,7 @@ def check_pd002(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     severity="info",
     category="progressive-disclosure",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _PD_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_pd003(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     """## PD003 — No scripts/ directory found

--- a/packages/skilllint/rules/pl_series.py
+++ b/packages/skilllint/rules/pl_series.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from skilllint.rule_registry import skilllint_rule
+from skilllint.rule_registry import rule_reference, skilllint_rule
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -46,8 +46,6 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Spec sources
 # ---------------------------------------------------------------------------
-
-_PL_DOCS_BASE = "https://github.com/jamie-bitflight/claude_skills/blob/main/plugins/plugin-creator/docs/ERROR_CODES.md"
 
 
 def _docs_url(code: str) -> str:
@@ -59,7 +57,7 @@ def _docs_url(code: str) -> str:
     Returns:
         Full URL with anchor for the error code documentation.
     """
-    return f"{_PL_DOCS_BASE}#{code.lower()}"
+    return rule_reference(code)
 
 
 # ---------------------------------------------------------------------------
@@ -72,7 +70,7 @@ def _docs_url(code: str) -> str:
     severity="error",
     category="plugin",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _PL_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_pl001(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     r"""## PL001 — Missing plugin.json file
@@ -124,7 +122,7 @@ def check_pl001(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     severity="error",
     category="plugin",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _PL_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_pl002(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     """## PL002 — Invalid JSON syntax in plugin.json or marketplace.json
@@ -173,7 +171,7 @@ def check_pl002(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     severity="error",
     category="plugin",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _PL_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_pl003(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     """## PL003 — Missing required field 'name' in plugin.json
@@ -220,7 +218,7 @@ def check_pl003(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     severity="error",
     category="plugin",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _PL_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_pl004(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     r"""## PL004 — Component path does not start with './'
@@ -268,7 +266,7 @@ def check_pl004(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     severity="error",
     category="plugin",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _PL_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_pl005(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     """## PL005 — Referenced component file does not exist
@@ -318,7 +316,7 @@ def check_pl005(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     severity="error",
     category="plugin",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _PL_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_pl006(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     """## PL006 — marketplace.json has invalid top-level keys

--- a/packages/skilllint/rules/pr_series.py
+++ b/packages/skilllint/rules/pr_series.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from skilllint.rule_registry import skilllint_rule
+from skilllint.rule_registry import rule_reference, skilllint_rule
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -43,8 +43,6 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Spec sources
 # ---------------------------------------------------------------------------
-
-_PR_DOCS_BASE = "https://github.com/jamie-bitflight/claude_skills/blob/main/plugins/plugin-creator/docs/ERROR_CODES.md"
 
 
 def _docs_url(code: str) -> str:
@@ -56,7 +54,7 @@ def _docs_url(code: str) -> str:
     Returns:
         Full URL with anchor for the error code documentation.
     """
-    return f"{_PR_DOCS_BASE}#{code.lower()}"
+    return rule_reference(code)
 
 
 # ---------------------------------------------------------------------------
@@ -69,7 +67,7 @@ def _docs_url(code: str) -> str:
     severity="warning",
     category="plugin-registration",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _PR_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_pr001(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     """## PR001 — Capability exists but not explicitly registered
@@ -123,7 +121,7 @@ def check_pr001(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     severity="error",
     category="plugin-registration",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _PR_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_pr002(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     """## PR002 — Registered capability path does not exist
@@ -171,7 +169,7 @@ def check_pr002(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     severity="info",
     category="plugin-registration",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _PR_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_pr003(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     """## PR003 — Plugin metadata fields not populated
@@ -220,7 +218,7 @@ def check_pr003(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     severity="warning",
     category="plugin-registration",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _PR_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_pr004(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     """## PR004 — Plugin metadata repository URL mismatches git remote URL
@@ -267,7 +265,7 @@ def check_pr004(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     severity="error",
     category="plugin-registration",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _PR_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_pr005(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     """## PR005 — Registered command path is a skill directory

--- a/packages/skilllint/rules/sk_series.py
+++ b/packages/skilllint/rules/sk_series.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
-from skilllint.rule_registry import skilllint_rule
+from skilllint.rule_registry import rule_reference, skilllint_rule
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -41,8 +41,6 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 _SKILLS_SPEC_URL = "https://docs.anthropic.com/en/docs/claude-code/skills"
-_SK_DOCS_BASE = "https://github.com/jamie-bitflight/claude_skills/blob/main/plugins/plugin-creator/docs/ERROR_CODES.md"
-
 # Name pattern: lowercase alphanumeric with hyphens, no leading/trailing/consecutive hyphens.
 # Source: skills.md — "Lowercase letters, numbers, and hyphens only (max 64 characters)"
 _NAME_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
@@ -61,7 +59,7 @@ def _docs_url(code: str) -> str:
     Returns:
         Full URL with anchor for the error code documentation.
     """
-    return f"{_SK_DOCS_BASE}#{code.lower()}"
+    return rule_reference(code)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/skilllint/rules/sl_series.py
+++ b/packages/skilllint/rules/sl_series.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from skilllint.rule_registry import skilllint_rule
+from skilllint.rule_registry import rule_reference, skilllint_rule
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -39,8 +39,6 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Spec sources
 # ---------------------------------------------------------------------------
-
-_SL_DOCS_BASE = "https://github.com/jamie-bitflight/claude_skills/blob/main/plugins/plugin-creator/docs/ERROR_CODES.md"
 
 
 def _docs_url(code: str) -> str:
@@ -52,7 +50,7 @@ def _docs_url(code: str) -> str:
     Returns:
         Full URL with anchor for the error code documentation.
     """
-    return f"{_SL_DOCS_BASE}#{code.lower()}"
+    return rule_reference(code)
 
 
 # ---------------------------------------------------------------------------
@@ -65,7 +63,7 @@ def _docs_url(code: str) -> str:
     severity="error",
     category="symlink",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _SL_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_sl001(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     r"""## SL001 — Symlink target has trailing whitespace or newlines

--- a/packages/skilllint/rules/tc_series.py
+++ b/packages/skilllint/rules/tc_series.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from skilllint.rule_registry import skilllint_rule
+from skilllint.rule_registry import rule_reference, skilllint_rule
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -38,8 +38,6 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Spec sources
 # ---------------------------------------------------------------------------
-
-_TC_DOCS_BASE = "https://github.com/jamie-bitflight/claude_skills/blob/main/plugins/plugin-creator/docs/ERROR_CODES.md"
 
 
 def _docs_url(code: str) -> str:
@@ -51,7 +49,7 @@ def _docs_url(code: str) -> str:
     Returns:
         Full URL with anchor for the error code documentation.
     """
-    return f"{_TC_DOCS_BASE}#{code.lower()}"
+    return rule_reference(code)
 
 
 # ---------------------------------------------------------------------------
@@ -64,7 +62,7 @@ def _docs_url(code: str) -> str:
     severity="info",
     category="token-count",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills", "reference": _TC_DOCS_BASE},
+    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
 )
 def check_tc001(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
     """## TC001 — Token count info

--- a/packages/skilllint/tests/fixtures/providers/agentskills/failing-examples/AS008/wrong-case-mcp/skills/bad-mcp-ref/SKILL.md
+++ b/packages/skilllint/tests/fixtures/providers/agentskills/failing-examples/AS008/wrong-case-mcp/skills/bad-mcp-ref/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bad-mcp-ref
 description: "Use this skill when you need to demonstrate wrong-case MCP server tool references."
-tools: mcp__ref__read_url
+allowed-tools: mcp__ref__read_url
 ---
 This skill uses the Ref MCP server but the tool name has lowercase "ref" instead of "Ref".

--- a/packages/skilllint/tests/fixtures/providers/agentskills/passing-examples/AS008/correct-case-mcp/skills/good-mcp-ref/SKILL.md
+++ b/packages/skilllint/tests/fixtures/providers/agentskills/passing-examples/AS008/correct-case-mcp/skills/good-mcp-ref/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: good-mcp-ref
 description: "Use this skill when you need to reference an MCP server tool with correct case sensitivity."
-tools: mcp__Ref__read_url
+allowed-tools: mcp__Ref__read_url
 ---
 This skill uses the Ref MCP server with the correct case "Ref" in the tool name.

--- a/packages/skilllint/tests/test_as_series.py
+++ b/packages/skilllint/tests/test_as_series.py
@@ -304,6 +304,21 @@ def test_as007_unscoped_wildcard_in_tools_list_produces_error(tmp_path: pathlib.
     assert "fix" in as007[0]
 
 
+def test_as007_wildcard_server_segment_is_not_a_group_grant(tmp_path: pathlib.Path):
+    """A wildcard in the server segment names no server, so it is not exempt.
+
+    `mcp__*__*` and `mcp__foo*__*` look like server-scoped grants but identify
+    no concrete server, so nothing resolves and the subagent cannot launch.
+    """
+    for entry in ("mcp__*__*", "mcp__foo*__*"):
+        case_dir = tmp_path / entry.replace("*", "star")
+        case_dir.mkdir()
+        skill_md = _make_skill_with_tools(case_dir, f"tools:\n  - {entry}")
+        as007 = _violations_with_code(check_skill_md(skill_md), "AS007")
+        assert as007 != [], f"AS007 must fire for {entry!r}: it names no server"
+        assert as007[0]["severity"] == "error", f"{entry!r} is the only entry, so nothing resolves"
+
+
 def test_as007_entirely_unresolvable_list_is_error(tmp_path: pathlib.Path):
     """When every entry is an unscoped wildcard, the subagent cannot launch.
 

--- a/packages/skilllint/tests/test_as_series.py
+++ b/packages/skilllint/tests/test_as_series.py
@@ -473,21 +473,32 @@ def _make_agent_md(tmp_path: pathlib.Path, tools_yaml: str) -> pathlib.Path:
     return agent_md
 
 
-def test_as007_fires_on_agent_file_with_wildcard_via_validator(tmp_path: pathlib.Path):
-    """AsSeriesValidator surfaces AS007 for wildcard tools on an agent .md file.
+def test_as_family_does_not_run_on_agent_files(tmp_path: pathlib.Path):
+    """No AS-series rule may fire on an agent file.
 
-    This verifies the wiring in _get_validators_for_path: agent files must
-    have AsSeriesValidator in their validator list so AS007 fires without
-    requiring --platform.
+    The AgentSkills specification is a cross-harness baseline that defines
+    SKILL.md and does not describe agent files at all. An AS rule evaluating
+    agent frontmatter is a category error regardless of what it checks, so the
+    boundary lives in the family wiring rather than in each rule's own guard.
+
+    This asserts the routing in _get_validators_for_path, not a rule in
+    isolation — calling AsSeriesValidator directly would bypass the boundary
+    and pass even when the wiring is wrong.
     """
-    from skilllint.plugin_validator import AsSeriesValidator
+    from skilllint.plugin_validator import _get_validators_for_path
 
     agent_md = _make_agent_md(tmp_path, "tools: mcp__*, Read, Bash")
-    result = AsSeriesValidator().validate(agent_md)
-    codes = [i.field for i in result.errors + result.warnings + result.info]
-    assert "AS007" in codes, f"Expected AS007 in AsSeriesValidator output for wildcard tool, got: {codes}"
-    # Read and Bash still resolve, so the subagent launches: reported, not fatal.
-    assert [i.severity for i in result.warnings if i.field == "AS007"] == ["warning"]
+    names = [type(v).__name__ for v in _get_validators_for_path(agent_md)]
+    assert "AsSeriesValidator" not in names, f"AS family must not be wired to agent files, got: {names}"
+
+
+def test_as_family_still_runs_on_skill_md(tmp_path: pathlib.Path):
+    """The boundary must not cost SKILL.md its AS coverage."""
+    from skilllint.plugin_validator import _get_validators_for_path
+
+    skill_md = _make_skill_with_tools(tmp_path, "tools:\n  - Read")
+    names = [type(v).__name__ for v in _get_validators_for_path(skill_md)]
+    assert "AsSeriesValidator" in names, f"AS family must still run on SKILL.md, got: {names}"
 
 
 def test_as002_suppressed_for_agent_files_via_validator(tmp_path: pathlib.Path):

--- a/packages/skilllint/tests/test_as_series.py
+++ b/packages/skilllint/tests/test_as_series.py
@@ -307,10 +307,11 @@ def test_as007_unscoped_wildcard_in_tools_list_produces_error(tmp_path: pathlib.
 def test_as007_wildcard_server_segment_is_not_a_group_grant(tmp_path: pathlib.Path):
     """A wildcard in the server segment names no server, so it is not exempt.
 
-    `mcp__*__*` and `mcp__foo*__*` look like server-scoped grants but identify
-    no concrete server, so nothing resolves and the subagent cannot launch.
+    `mcp__*__*` and `mcp__foo*__*` identify no concrete server.
+    `mcp__Ref__tool__*` names a real server but puts the wildcard inside a tool
+    name, so it is not the documented `mcp__<server>__*` group grant either.
     """
-    for entry in ("mcp__*__*", "mcp__foo*__*"):
+    for entry in ("mcp__*__*", "mcp__foo*__*", "mcp__Ref__tool__*"):
         case_dir = tmp_path / entry.replace("*", "star")
         case_dir.mkdir()
         skill_md = _make_skill_with_tools(case_dir, f"tools:\n  - {entry}")

--- a/packages/skilllint/tests/test_as_series.py
+++ b/packages/skilllint/tests/test_as_series.py
@@ -269,12 +269,12 @@ def test_as006_no_eval_queries_info(tmp_path: pathlib.Path):
 
 
 # ---------------------------------------------------------------------------
-# AS007: wildcard patterns in tools field produce an error
+# AS008: MCP server name references in the allowed-tools field
 # ---------------------------------------------------------------------------
 
 
 def _make_skill_with_tools(tmp_path: pathlib.Path, tools_block: str) -> pathlib.Path:
-    """Write a minimal valid SKILL.md with the given tools: block and return its path.
+    """Write a minimal valid SKILL.md with the given tool-field block and return its path.
 
     The tools_block is inserted verbatim between the description line and the
     closing '---' delimiter. It must not be indented (textwrap.dedent would
@@ -292,122 +292,37 @@ def _make_skill_with_tools(tmp_path: pathlib.Path, tools_block: str) -> pathlib.
     return skill_md
 
 
-def test_as007_unscoped_wildcard_in_tools_list_produces_error(tmp_path: pathlib.Path):
-    """tools: list containing an unscoped wildcard produces AS007 error."""
-    skill_md = _make_skill_with_tools(tmp_path, "tools:\n  - mcp__Ref__ref_read_url\n  - mcp__*")
-    violations = check_skill_md(skill_md)
-    as007 = _violations_with_code(violations, "AS007")
-    assert as007 != [], "Expected AS007 violation for unscoped wildcard 'mcp__*'"
-    # A sibling entry still resolves, so the subagent launches: warning, not error.
-    assert as007[0]["severity"] == "warning"
-    assert "mcp__*" in as007[0]["message"]
-    assert "fix" in as007[0]
+def test_as008_reads_the_spec_field_and_both_separators(tmp_path: pathlib.Path):
+    """AS008 must see `allowed-tools`, in list form and either inline separator.
 
-
-def test_as007_wildcard_server_segment_is_not_a_group_grant(tmp_path: pathlib.Path):
-    """A wildcard in the server segment names no server, so it is not exempt.
-
-    `mcp__*__*` and `mcp__foo*__*` identify no concrete server.
-    `mcp__Ref__tool__*` names a real server but puts the wildcard inside a tool
-    name, so it is not the documented `mcp__<server>__*` group grant either.
+    `allowed-tools` is the field the AgentSkills specification defines for
+    skills (agentskills.io/specification.md, fetched 2026-08-22); AS008 read
+    `tools:` and was blind to it. The spec describes the inline form as
+    space-separated but marks the field Experimental, and nothing establishes
+    that a comma is an error — so the parser accepts both rather than picking
+    one and silently missing entries written the other way.
     """
-    for entry in ("mcp__*__*", "mcp__foo*__*", "mcp__Ref__tool__*"):
-        case_dir = tmp_path / entry.replace("*", "star")
+    _write_mcp_json(tmp_path, "Ref")
+    forms = (
+        "allowed-tools:\n  - mcp__ref__read_url\n  - Bash",  # YAML list
+        "allowed-tools: mcp__ref__read_url Bash",  # space-separated (spec form)
+        "allowed-tools: mcp__ref__read_url, Bash",  # comma-separated
+    )
+    for i, block in enumerate(forms):
+        case_dir = tmp_path / f"form{i}"
         case_dir.mkdir()
-        skill_md = _make_skill_with_tools(case_dir, f"tools:\n  - {entry}")
-        as007 = _violations_with_code(check_skill_md(skill_md), "AS007")
-        assert as007 != [], f"AS007 must fire for {entry!r}: it names no server"
-        assert as007[0]["severity"] == "error", f"{entry!r} is the only entry, so nothing resolves"
+        _write_mcp_json(case_dir, "Ref")
+        as008 = _violations_with_code(check_skill_md(_make_skill_with_tools(case_dir, block)), "AS008")
+        assert as008 != [], f"AS008 must catch the wrong-case server in form {block!r}"
 
 
-def test_as007_entirely_unresolvable_list_is_error(tmp_path: pathlib.Path):
-    """When every entry is an unscoped wildcard, the subagent cannot launch.
-
-    Source: code.claude.com/docs/en/sub-agents.md — "If no entry in the list
-    resolves to a tool, the subagent usually fails to launch with an error
-    naming the entries."
-    """
-    skill_md = _make_skill_with_tools(tmp_path, 'tools:\n  - mcp__*\n  - "*"')
-    violations = check_skill_md(skill_md)
-    as007 = _violations_with_code(violations, "AS007")
-    assert len(as007) == 2, f"Expected one AS007 per unscoped entry, got {len(as007)}"
-    assert all(v["severity"] == "error" for v in as007), "A wholly unresolvable tools list must be an error"
-
-
-def test_as007_server_scoped_grant_passes(tmp_path: pathlib.Path):
-    """A server-scoped MCP grant is a supported form and must not fire AS007.
-
-    Claude Code resolves ``mcp__<server>__*`` to every tool that server
-    exposes, identically to the bare ``mcp__<server>`` form. Both are left
-    alone; flagging one while passing the other pushed authors between two
-    spellings with the same outcome.
-    """
-    for entry in ("mcp__Ref__*", "mcp__Ref", "mcp__plugin_dh_backlog__*"):
-        case_dir = tmp_path / entry.replace("*", "star")
-        case_dir.mkdir()
-        skill_md = _make_skill_with_tools(case_dir, f"tools:\n  - {entry}\n  - Read")
-        violations = check_skill_md(skill_md)
-        assert _violations_with_code(violations, "AS007") == [], (
-            f"AS007 must not fire for server-scoped grant {entry!r}"
-        )
-
-
-def test_as007_wildcard_inline_tools_produces_error(tmp_path: pathlib.Path):
-    """Inline comma-separated tools: containing a wildcard produces AS007 error."""
-    skill_md = _make_skill_with_tools(tmp_path, "tools: mcp__Ref__ref_read_url, mcp__*")
-    violations = check_skill_md(skill_md)
-    as007 = _violations_with_code(violations, "AS007")
-    assert as007 != [], "Expected AS007 violation for inline unscoped wildcard 'mcp__*'"
-    assert as007[0]["severity"] == "warning"
-
-
-def test_as007_multiple_wildcards_produce_one_violation_each(tmp_path: pathlib.Path):
-    """Each unscoped wildcard entry produces its own AS007 violation.
-
-    ``mcp__Ref__*`` is a server-scoped grant and is deliberately not counted.
-    """
-    skill_md = _make_skill_with_tools(tmp_path, 'tools:\n  - mcp__Ref__*\n  - mcp__*\n  - "*"\n  - Read')
-    violations = check_skill_md(skill_md)
-    as007 = _violations_with_code(violations, "AS007")
-    assert len(as007) == 2, f"Expected 2 AS007 violations for 2 unscoped wildcards, got: {len(as007)}"
-
-
-def test_as007_explicit_tool_names_pass(tmp_path: pathlib.Path):
-    """Explicit tool names without wildcards do not trigger AS007."""
-    skill_md = _make_skill_with_tools(
-        tmp_path, "tools:\n  - mcp__Ref__ref_read_url\n  - mcp__Ref__ref_search_documentation\n  - Bash"
+def test_as008_ignores_the_agent_tools_field_on_a_skill(tmp_path: pathlib.Path):
+    """`tools:` is agent frontmatter; the AgentSkills spec does not define it for skills."""
+    _write_mcp_json(tmp_path, "Ref")
+    skill_md = _make_skill_with_tools(tmp_path, "tools:\n  - mcp__ref__read_url")
+    assert _violations_with_code(check_skill_md(skill_md), "AS008") == [], (
+        "AS008 must not read `tools:` on a SKILL.md — that is not the spec's field"
     )
-    violations = check_skill_md(skill_md)
-    assert _violations_with_code(violations, "AS007") == [], (
-        "AS007 must not fire for explicit tool names without wildcards"
-    )
-
-
-def test_as007_no_tools_field_passes(tmp_path: pathlib.Path):
-    """SKILL.md without a tools: field produces no AS007 violation."""
-    skill_dir = tmp_path / "my-skill"
-    skill_dir.mkdir()
-    skill_md = skill_dir / "SKILL.md"
-    skill_md.write_text(
-        textwrap.dedent("""\
-            ---
-            name: my-skill
-            description: A skill without a tools field.
-            ---
-
-            Body content.
-        """)
-    )
-    violations = check_skill_md(skill_md)
-    assert _violations_with_code(violations, "AS007") == [], "AS007 must not fire when tools field is absent"
-
-
-# ---------------------------------------------------------------------------
-# AS008: MCP server discovery — exact match, case mismatch, unknown server
-# ---------------------------------------------------------------------------
-
-# Helper: write a .mcp.json in tmp_path with the given server names so that
-# _discover_mcp_servers() finds them when scanning skill files under tmp_path.
 
 
 def _write_mcp_json(directory: pathlib.Path, *server_names: str) -> None:
@@ -421,7 +336,7 @@ def _write_mcp_json(directory: pathlib.Path, *server_names: str) -> None:
 def test_as008_exact_match_discovered_server_passes(tmp_path: pathlib.Path):
     """Exact server name match against .mcp.json discovery produces no AS008 violation."""
     _write_mcp_json(tmp_path, "Ref")
-    skill_md = _make_skill_with_tools(tmp_path, "tools:\n  - mcp__Ref__ref_search_documentation")
+    skill_md = _make_skill_with_tools(tmp_path, "allowed-tools:\n  - mcp__Ref__ref_search_documentation")
     violations = check_skill_md(skill_md)
     assert _violations_with_code(violations, "AS008") == [], (
         "AS008 must not fire when server 'Ref' exactly matches .mcp.json discovery"
@@ -432,7 +347,7 @@ def test_as008_case_mismatch_with_discovered_server_produces_error(tmp_path: pat
     """Wrong-case server name against a discovered server produces AS008 error."""
     # .mcp.json declares 'Ref'; skill uses 'ref' (lowercase) — case mismatch
     _write_mcp_json(tmp_path, "Ref")
-    skill_md = _make_skill_with_tools(tmp_path, "tools:\n  - mcp__ref__ref_search_documentation")
+    skill_md = _make_skill_with_tools(tmp_path, "allowed-tools:\n  - mcp__ref__ref_search_documentation")
     violations = check_skill_md(skill_md)
     as008 = _violations_with_code(violations, "AS008")
     assert as008 != [], "Expected AS008 error for case mismatch 'mcp__ref__' vs discovered 'Ref'"
@@ -444,7 +359,7 @@ def test_as008_case_mismatch_with_discovered_server_produces_error(tmp_path: pat
 def test_as008_unknown_server_not_in_any_config_produces_warning(tmp_path: pathlib.Path):
     """MCP tool referencing a server absent from all config files produces AS008 warning."""
     # No .mcp.json written — server is entirely unknown
-    skill_md = _make_skill_with_tools(tmp_path, "tools:\n  - mcp__someUnknownServer__some_tool")
+    skill_md = _make_skill_with_tools(tmp_path, "allowed-tools:\n  - mcp__someUnknownServer__some_tool")
     violations = check_skill_md(skill_md)
     as008 = _violations_with_code(violations, "AS008")
     assert as008 != [], "Expected AS008 warning for server not found in any config"
@@ -455,7 +370,7 @@ def test_as008_unknown_server_not_in_any_config_produces_warning(tmp_path: pathl
 # ---------------------------------------------------------------------------
 # AsSeriesValidator integration — agent file wiring
 # ---------------------------------------------------------------------------
-# These tests verify that AS007 and AS008 fire when AsSeriesValidator is used
+# These tests verify the AS family's file-type boundary and AS008 wiring
 # via the default validate_single_path code path (not --platform).
 # AS002 must be suppressed for agent files because agents live directly in
 # agents/ — the parent directory name is always "agents", not the agent name.
@@ -503,7 +418,7 @@ def test_as_family_does_not_run_on_agent_files(tmp_path: pathlib.Path):
     """
     from skilllint.plugin_validator import _get_validators_for_path
 
-    agent_md = _make_agent_md(tmp_path, "tools: mcp__*, Read, Bash")
+    agent_md = _make_agent_md(tmp_path, "allowed-tools: mcp__*, Read, Bash")
     names = [type(v).__name__ for v in _get_validators_for_path(agent_md)]
     assert "AsSeriesValidator" not in names, f"AS family must not be wired to agent files, got: {names}"
 
@@ -512,7 +427,7 @@ def test_as_family_still_runs_on_skill_md(tmp_path: pathlib.Path):
     """The boundary must not cost SKILL.md its AS coverage."""
     from skilllint.plugin_validator import _get_validators_for_path
 
-    skill_md = _make_skill_with_tools(tmp_path, "tools:\n  - Read")
+    skill_md = _make_skill_with_tools(tmp_path, "allowed-tools:\n  - Read")
     names = [type(v).__name__ for v in _get_validators_for_path(skill_md)]
     assert "AsSeriesValidator" in names, f"AS family must still run on SKILL.md, got: {names}"
 
@@ -526,7 +441,7 @@ def test_as002_suppressed_for_agent_files_via_validator(tmp_path: pathlib.Path):
     """
     from skilllint.plugin_validator import AsSeriesValidator
 
-    agent_md = _make_agent_md(tmp_path, "tools: Read")
+    agent_md = _make_agent_md(tmp_path, "allowed-tools: Read")
     result = AsSeriesValidator().validate(agent_md)
     codes = [i.field for i in result.errors + result.warnings + result.info]
     assert "AS002" not in codes, f"AS002 must not fire for agent files, got: {codes}"
@@ -563,7 +478,7 @@ def test_as008_hyphen_vs_underscore_unrecognized_server_produces_warning(tmp_pat
     # 'sequential-thinking' (hyphen) vs 'sequential_thinking' (underscore) differ by more than
     # case — case-folding won't unify them, so it falls through to "unknown server → warning".
     _write_mcp_json(tmp_path, "sequential_thinking")
-    skill_md = _make_skill_with_tools(tmp_path, "tools:\n  - mcp__sequential-thinking__sequentialthinking")
+    skill_md = _make_skill_with_tools(tmp_path, "allowed-tools:\n  - mcp__sequential-thinking__sequentialthinking")
     violations = check_skill_md(skill_md)
     as008 = _violations_with_code(violations, "AS008")
     assert as008 != [], "Expected AS008 warning for 'mcp__sequential-thinking__' (not a case-fold match)"
@@ -574,7 +489,7 @@ def test_as008_hyphen_vs_underscore_unrecognized_server_produces_warning(tmp_pat
 def test_as008_correct_server_with_discovered_context_passes(tmp_path: pathlib.Path):
     """Correct server name when that server is in .mcp.json produces no AS008 violation."""
     _write_mcp_json(tmp_path, "sequential_thinking")
-    skill_md = _make_skill_with_tools(tmp_path, "tools:\n  - mcp__sequential_thinking__sequentialthinking")
+    skill_md = _make_skill_with_tools(tmp_path, "allowed-tools:\n  - mcp__sequential_thinking__sequentialthinking")
     violations = check_skill_md(skill_md)
     assert _violations_with_code(violations, "AS008") == [], (
         "AS008 must not fire when server name exactly matches discovered 'sequential_thinking'"
@@ -585,7 +500,7 @@ def test_as008_mixed_exact_and_case_mismatch_produces_one_error(tmp_path: pathli
     """One case-mismatched and one correct tool produces exactly one AS008 violation."""
     _write_mcp_json(tmp_path, "Ref")
     skill_md = _make_skill_with_tools(
-        tmp_path, "tools:\n  - mcp__ref__ref_read_url\n  - mcp__Ref__ref_search_documentation\n  - Bash"
+        tmp_path, "allowed-tools:\n  - mcp__ref__ref_read_url\n  - mcp__Ref__ref_search_documentation\n  - Bash"
     )
     violations = check_skill_md(skill_md)
     as008 = _violations_with_code(violations, "AS008")
@@ -595,7 +510,7 @@ def test_as008_mixed_exact_and_case_mismatch_produces_one_error(tmp_path: pathli
 
 def test_as008_non_mcp_tools_are_ignored(tmp_path: pathlib.Path):
     """Non-MCP tool names (Bash, Read, Write) never trigger AS008."""
-    skill_md = _make_skill_with_tools(tmp_path, "tools:\n  - Bash\n  - Read\n  - Write\n  - Edit")
+    skill_md = _make_skill_with_tools(tmp_path, "allowed-tools:\n  - Bash\n  - Read\n  - Write\n  - Edit")
     violations = check_skill_md(skill_md)
     assert _violations_with_code(violations, "AS008") == [], "AS008 must not fire for non-MCP tool names"
 

--- a/packages/skilllint/tests/test_as_series.py
+++ b/packages/skilllint/tests/test_as_series.py
@@ -292,32 +292,53 @@ def _make_skill_with_tools(tmp_path: pathlib.Path, tools_block: str) -> pathlib.
     return skill_md
 
 
-def test_as007_wildcard_in_tools_list_produces_error(tmp_path: pathlib.Path):
-    """tools: list containing a wildcard entry produces AS007 error."""
-    skill_md = _make_skill_with_tools(tmp_path, "tools:\n  - mcp__Ref__ref_read_url\n  - mcp__Ref__*")
+def test_as007_unscoped_wildcard_in_tools_list_produces_error(tmp_path: pathlib.Path):
+    """tools: list containing an unscoped wildcard produces AS007 error."""
+    skill_md = _make_skill_with_tools(tmp_path, "tools:\n  - mcp__Ref__ref_read_url\n  - mcp__*")
     violations = check_skill_md(skill_md)
     as007 = _violations_with_code(violations, "AS007")
-    assert as007 != [], "Expected AS007 violation for wildcard 'mcp__Ref__*'"
+    assert as007 != [], "Expected AS007 violation for unscoped wildcard 'mcp__*'"
     assert as007[0]["severity"] == "error"
-    assert "mcp__Ref__*" in as007[0]["message"]
+    assert "mcp__*" in as007[0]["message"]
     assert "fix" in as007[0]
+
+
+def test_as007_server_scoped_grant_passes(tmp_path: pathlib.Path):
+    """A server-scoped MCP grant is a supported form and must not fire AS007.
+
+    Claude Code resolves ``mcp__<server>__*`` to every tool that server
+    exposes, identically to the bare ``mcp__<server>`` form. Both are left
+    alone; flagging one while passing the other pushed authors between two
+    spellings with the same outcome.
+    """
+    for entry in ("mcp__Ref__*", "mcp__Ref", "mcp__plugin_dh_backlog__*"):
+        case_dir = tmp_path / entry.replace("*", "star")
+        case_dir.mkdir()
+        skill_md = _make_skill_with_tools(case_dir, f"tools:\n  - {entry}\n  - Read")
+        violations = check_skill_md(skill_md)
+        assert _violations_with_code(violations, "AS007") == [], (
+            f"AS007 must not fire for server-scoped grant {entry!r}"
+        )
 
 
 def test_as007_wildcard_inline_tools_produces_error(tmp_path: pathlib.Path):
     """Inline comma-separated tools: containing a wildcard produces AS007 error."""
-    skill_md = _make_skill_with_tools(tmp_path, "tools: mcp__Ref__ref_read_url, mcp__Ref__*")
+    skill_md = _make_skill_with_tools(tmp_path, "tools: mcp__Ref__ref_read_url, mcp__*")
     violations = check_skill_md(skill_md)
     as007 = _violations_with_code(violations, "AS007")
-    assert as007 != [], "Expected AS007 violation for inline wildcard 'mcp__Ref__*'"
+    assert as007 != [], "Expected AS007 violation for inline unscoped wildcard 'mcp__*'"
     assert as007[0]["severity"] == "error"
 
 
 def test_as007_multiple_wildcards_produce_one_violation_each(tmp_path: pathlib.Path):
-    """Each wildcard tool entry produces its own AS007 violation."""
-    skill_md = _make_skill_with_tools(tmp_path, "tools:\n  - mcp__Ref__*\n  - mcp__*\n  - Read")
+    """Each unscoped wildcard entry produces its own AS007 violation.
+
+    ``mcp__Ref__*`` is a server-scoped grant and is deliberately not counted.
+    """
+    skill_md = _make_skill_with_tools(tmp_path, 'tools:\n  - mcp__Ref__*\n  - mcp__*\n  - "*"\n  - Read')
     violations = check_skill_md(skill_md)
     as007 = _violations_with_code(violations, "AS007")
-    assert len(as007) == 2, f"Expected 2 AS007 violations for 2 wildcards, got: {len(as007)}"
+    assert len(as007) == 2, f"Expected 2 AS007 violations for 2 unscoped wildcards, got: {len(as007)}"
 
 
 def test_as007_explicit_tool_names_pass(tmp_path: pathlib.Path):
@@ -446,7 +467,7 @@ def test_as007_fires_on_agent_file_with_wildcard_via_validator(tmp_path: pathlib
     """
     from skilllint.plugin_validator import AsSeriesValidator
 
-    agent_md = _make_agent_md(tmp_path, "tools: mcp__Ref__*, Read, Bash")
+    agent_md = _make_agent_md(tmp_path, "tools: mcp__*, Read, Bash")
     result = AsSeriesValidator().validate(agent_md)
     codes = [i.field for i in result.errors + result.warnings + result.info]
     assert "AS007" in codes, f"Expected AS007 in AsSeriesValidator output for wildcard tool, got: {codes}"

--- a/packages/skilllint/tests/test_as_series.py
+++ b/packages/skilllint/tests/test_as_series.py
@@ -298,9 +298,24 @@ def test_as007_unscoped_wildcard_in_tools_list_produces_error(tmp_path: pathlib.
     violations = check_skill_md(skill_md)
     as007 = _violations_with_code(violations, "AS007")
     assert as007 != [], "Expected AS007 violation for unscoped wildcard 'mcp__*'"
-    assert as007[0]["severity"] == "error"
+    # A sibling entry still resolves, so the subagent launches: warning, not error.
+    assert as007[0]["severity"] == "warning"
     assert "mcp__*" in as007[0]["message"]
     assert "fix" in as007[0]
+
+
+def test_as007_entirely_unresolvable_list_is_error(tmp_path: pathlib.Path):
+    """When every entry is an unscoped wildcard, the subagent cannot launch.
+
+    Source: code.claude.com/docs/en/sub-agents.md — "If no entry in the list
+    resolves to a tool, the subagent usually fails to launch with an error
+    naming the entries."
+    """
+    skill_md = _make_skill_with_tools(tmp_path, 'tools:\n  - mcp__*\n  - "*"')
+    violations = check_skill_md(skill_md)
+    as007 = _violations_with_code(violations, "AS007")
+    assert len(as007) == 2, f"Expected one AS007 per unscoped entry, got {len(as007)}"
+    assert all(v["severity"] == "error" for v in as007), "A wholly unresolvable tools list must be an error"
 
 
 def test_as007_server_scoped_grant_passes(tmp_path: pathlib.Path):
@@ -327,7 +342,7 @@ def test_as007_wildcard_inline_tools_produces_error(tmp_path: pathlib.Path):
     violations = check_skill_md(skill_md)
     as007 = _violations_with_code(violations, "AS007")
     assert as007 != [], "Expected AS007 violation for inline unscoped wildcard 'mcp__*'"
-    assert as007[0]["severity"] == "error"
+    assert as007[0]["severity"] == "warning"
 
 
 def test_as007_multiple_wildcards_produce_one_violation_each(tmp_path: pathlib.Path):
@@ -471,7 +486,8 @@ def test_as007_fires_on_agent_file_with_wildcard_via_validator(tmp_path: pathlib
     result = AsSeriesValidator().validate(agent_md)
     codes = [i.field for i in result.errors + result.warnings + result.info]
     assert "AS007" in codes, f"Expected AS007 in AsSeriesValidator output for wildcard tool, got: {codes}"
-    assert not result.passed, "AsSeriesValidator must not pass when a wildcard tool is present"
+    # Read and Bash still resolve, so the subagent launches: reported, not fatal.
+    assert [i.severity for i in result.warnings if i.field == "AS007"] == ["warning"]
 
 
 def test_as002_suppressed_for_agent_files_via_validator(tmp_path: pathlib.Path):

--- a/plugins/agentskills-skilllint/README.md
+++ b/plugins/agentskills-skilllint/README.md
@@ -71,7 +71,7 @@ The skill includes a [full rule catalog](./skills/skilllint/references/rule-cata
 |--------|--------|
 | FM001–FM010 | YAML frontmatter validity |
 | SK001–SK009 | Skill name, description, and token budget |
-| AS001–AS009 | AgentSkills open standard cross-platform compliance |
+| AS001–AS009 | SKILL.md conformance with the AgentSkills open standard (AS007 removed) |
 | LK001–LK002 | Internal markdown links |
 | PD001–PD003 | Progressive disclosure directory structure |
 | PL001–PL006 | Plugin manifest (`plugin.json`) |


### PR DESCRIPTION
## Why

skilllint ships as `uvx skilllint@latest`. Every finding it printed carried a hardcoded URL into a third-party repository:

```
→ https://github.com/jamie-bitflight/claude_skills/blob/main/plugins/plugin-creator/docs/ERROR_CODES.md#fm001
```

For anyone who is not that repo, the link is irrelevant or inaccessible. Those catalogue files are also being deleted, which would have 404'd every link skilllint emits.

## What changed

**Finding references are now derived from the rule code.**

```
❌ [FM001] name: Missing required field: name
   → skilllint rule FM001
```

No external URL, nothing maintained in parallel with the code. All 58 registered rules already render their full docstring, severity, category, platforms, fix and sources through `skilllint rule` — verified across every family (AS/CU/CX/FM/HK/LK/NR/PA/PD/PL/PR/SK/SL/TC), not a sample. The URL literal was duplicated in 13 files; all now route through one `rule_reference()` in `rule_registry.py`. `ERROR_CODE_BASE_URL` and the twelve `_XX_DOCS_BASE` constants are gone.

**AS001 — stop double-reporting a missing name.**

AS001 is a name *format* rule that also emitted `name field is missing`, duplicating FM001 on agent files. The presence check is now scoped to `SKILL.md`. Deleting it outright would have been a regression: FM001 deliberately skips skills, because `skills.md` marks `name` optional with a directory-name fallback, so AS001 was the only missing-name signal there.

| file | before | after |
|---|---|---|
| agent `.md`, no `name` | FM001 + AS001 | FM001 |
| `SKILL.md`, no `name` | AS001 | AS001 |

**AS007 — correct a measurably false claim.**

AS007 errored on any `*`, asserting entries "will not resolve" and that "the agent receives no MCP tools". That is false for a server-scoped grant: `mcp__<server>__*` resolves to every tool that server exposes, identically to the bare `mcp__<server>` form AS007 already accepted. The rule was pushing authors between two spellings with the same outcome.

| `tools:` entry | before | after |
|---|---|---|
| `mcp__plugin_dh_backlog__*` | ❌ AS007 | clean |
| `mcp__plugin_dh_backlog` | clean | clean |
| `Read, mcp__Ref__*` | ❌ AS007 | clean |
| `mcp__*` | ❌ AS007 | ❌ AS007 |
| `"*"` | ❌ AS007 | ❌ AS007 |

Sourced to this repo's own vendored Anthropic docs, verifiable offline:
- `.claude/vendor/claude_code/CHANGELOG.md` — "Added wildcard syntax `mcp__server__*` for MCP tool permissions to allow or deny all tools from a server"
- `.claude/vendor/claude_code/plugins/plugin-dev/skills/mcp-integration/references/tool-usage.md` — documents `allowed-tools: ["mcp__plugin_asana_asana__*"]` as supported

## Open items this PR deliberately does not resolve

- **25 rules have an origin but no authority** (hk 5, pl 6, pr 5, pd 3, lk 2, nr 2, sl 1, tc 1). They cited the ERROR_CODES.md URL as their `reference`. The dead reference is removed and `origin` kept, so the gap is now visible instead of hidden behind a link that was about to break. These need real upstream authorities — a follow-up.
- **AS007's authority still reads `agentskills.io /specification#tools-field`.** There is reason to believe that anchor does not exist and the spec defines no `tools` field at all, which would mean the rule should be deleted rather than narrowed. There is no cached agentskills spec under `.claude/vendor/`, so this could not be confirmed offline and was not acted on.
- **`Bash(git:*)` is untouched** — still flagged by AS007 because it contains `*`. Whether a parenthesised specifier is meaningful in an agent `tools:` field is unresolved; this is the status quo, not a decision.

## Verification

- 1166 passed, 10 skipped
- `ruff check packages/` clean
- `ty check packages/` clean
- 17 files, +143/−106

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJeBLNA9ybmQvv5REMDkrc