### PR TITLE
ci: skip claude-review on dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,10 @@ on:
 
 jobs:
   claude-review:
+    # Dependabot PRs are version bumps with no design to review, and the action
+    # rejects bot actors outright ("Workflow initiated by non-human actor").
+    # Skipping reports SKIPPED rather than a spurious FAILURE on every bump.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
## Problem

`claude-review` fails on every dependabot PR. The action rejects bot actors:

```
Action failed with error: Workflow initiated by non-human actor: dependabot
(type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.
```

This is the only failing check on #98 and #110, and one of three on #107. It makes those PRs read as broken when the code is fine — only the review job is misconfigured.

## Fix

One job-level condition skipping dependabot.

## Why skip rather than allowlist the bot

The action offers `allowed_bots` as the intended knob, but a dependency version bump has no design to review — allowlisting would spend review tokens on every bump for no signal. Skipping also reports the check as SKIPPED rather than a spurious FAILURE.

## Verification

Effect is visible once this is on `main` and the dependabot PRs are rebased onto it: `claude-review` should report SKIPPED instead of FAILURE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJeBLNA9ybmQvv5REMDkrc