### PR TITLE
fix(lk,nr): correct NR002 citation, delete LK002, resolve ${CLAUDE_*} vars before LK001

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ skilllint check --platform claude-code plugins/my-plugin
 | FM001–FM010 | Frontmatter | Required fields, valid values, schema compliance |
 | SK001–SK009 | Skill | Description quality, token limits, complexity, internal links |
 | AS001–AS009 | AgentSkills | SKILL.md conformance with the AgentSkills open standard (AS007 removed) |
-| LK001–LK002 | Links | Markdown link validity and broken reference detection |
+| LK001 | Links | Broken internal markdown link detection |
 | PD001–PD003 | Progressive disclosure | Directory structure for references/, examples/, scripts/ |
 | PL001–PL006 | Plugin | Structure, manifest correctness, marketplace layout, subprocess safety |
 | HK001–HK005 | Hook | Script existence, configuration validity |
@@ -477,7 +477,7 @@ Use a `.skilllint.json` file to suppress specific rule codes for a directory tre
 {
   "ignore": {
     "": ["AS008"],
-    "skills/legacy": ["LK002", "SK006"]
+    "skills/legacy": ["FM007", "SK006"]
   }
 }
 ```

--- a/docs/ignore-config.md
+++ b/docs/ignore-config.md
@@ -12,7 +12,7 @@ Place `.skilllint.json` at any directory level. When validating a file, skilllin
 {
   "ignore": {
     "": ["AS008"],
-    "skills/legacy": ["LK002", "SK006"],
+    "skills/legacy": ["FM007", "SK006"],
     "agents/generated": ["FM004", "FM007", "FM009"]
   }
 }
@@ -45,11 +45,11 @@ Prefix matching is used: `"skills"` suppresses `skills/foo/SKILL.md`, `skills/ba
 
 Place this at the repo root. Every file skilllint scans under that root will have AS008 suppressed.
 
-**Example — suppress LK002 for one subdirectory:**
+**Example — suppress FM007 for one subdirectory:**
 
 ```
 my-repo/
-  .skilllint.json          ← suppress LK002 under .agents/skills/legacy/
+  .skilllint.json          ← suppress FM007 under .agents/skills/legacy/
   .agents/
     skills/
       legacy/
@@ -59,7 +59,7 @@ my-repo/
 ```json
 {
   "ignore": {
-    ".agents/skills/legacy": ["LK002"]
+    ".agents/skills/legacy": ["FM007"]
   }
 }
 ```
@@ -98,6 +98,6 @@ Only one config file is used per file — the nearest one found while walking up
 Run `skilllint rules` to list all available rule codes and their descriptions.
 
 ```bash
-skilllint rule LK002   # show detail for one rule
+skilllint rule FM007   # show detail for one rule
 skilllint rules        # list all rules
 ```

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -1391,6 +1391,21 @@ class InternalLinkValidator:
     # Regex pattern for inline code spans (single or multiple backticks)
     INLINE_CODE_PATTERN: ClassVar[str] = r"(`+)(?!`)(.+?)(?<!`)\1(?!`)"
 
+    # Regex pattern for any ${...} substitution-style token. Matches both
+    # Claude Code's documented ${CLAUDE_*} variables
+    # (code.claude.com/docs/en/skills.md#available-string-substitutions)
+    # and any other unrecognized ${...} token, so both can be routed through
+    # _STATICALLY_RESOLVABLE_CLAUDE_VARS and skipped when unresolvable.
+    CLAUDE_VAR_PATTERN: ClassVar[str] = r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}"
+
+    # Of the four documented variables, only these two have a target
+    # skilllint can determine statically from the plugin source tree.
+    # ${CLAUDE_PROJECT_DIR} and ${CLAUDE_PLUGIN_DATA} target install-time
+    # locations (the invoking project root; the plugin's persistent data
+    # directory) that do not exist in the plugin source, so skilllint has
+    # no basis for resolving or asserting them broken.
+    _STATICALLY_RESOLVABLE_CLAUDE_VARS: ClassVar[frozenset[str]] = frozenset({"CLAUDE_SKILL_DIR", "CLAUDE_PLUGIN_ROOT"})
+
     @staticmethod
     def _strip_code_blocks(content: str) -> str:
         """Remove fenced code blocks and inline code spans from content.
@@ -1465,9 +1480,16 @@ class InternalLinkValidator:
             # e.g., ./references/file.md#heading → ./references/file.md
             link_url_no_fragment = link_url.split("#")[0]
 
-            # Resolve link path relative to SKILL.md directory
+            # Resolve documented ${CLAUDE_*} substitution variables before
+            # the existence check. Returns None when the link must be
+            # skipped because a variable's target cannot be determined.
             skill_dir = path.parent
-            link_path = (skill_dir / link_url_no_fragment).resolve()
+            resolved_url = self._resolve_claude_variables(link_url_no_fragment, skill_dir)
+            if resolved_url is None:
+                continue
+
+            # Resolve link path relative to SKILL.md directory
+            link_path = (skill_dir / resolved_url).resolve()
 
             # Check if linked file exists (error)
             if not link_path.exists():
@@ -1530,6 +1552,54 @@ class InternalLinkValidator:
 
         # Ignore absolute paths
         return bool(url.startswith("/"))
+
+    @classmethod
+    def _resolve_claude_variables(cls, url: str, skill_dir: Path) -> str | None:
+        """Substitute ${CLAUDE_*} variables skilllint can statically resolve.
+
+        Claude Code substitutes ``${CLAUDE_SKILL_DIR}``, ``${CLAUDE_PROJECT_DIR}``,
+        ``${CLAUDE_PLUGIN_ROOT}``, and ``${CLAUDE_PLUGIN_DATA}`` in skill markdown
+        content at runtime (code.claude.com/docs/en/skills.md
+        #available-string-substitutions). ``${CLAUDE_SKILL_DIR}`` always
+        resolves to the directory containing ``SKILL.md``. ``${CLAUDE_PLUGIN_ROOT}``
+        resolves via :func:`find_plugin_dir` when the link's SKILL.md lives
+        inside a plugin (same lookup ``HookValidator`` uses for
+        ``${CLAUDE_PLUGIN_ROOT}`` in hook commands).
+
+        ``${CLAUDE_PROJECT_DIR}`` and ``${CLAUDE_PLUGIN_DATA}`` target
+        install-time locations skilllint cannot determine from the plugin
+        source tree, and any other ``${...}`` token is not a documented
+        substitution variable at all. skilllint has no basis for asserting
+        either kind of target is broken, so the link is skipped rather than
+        reported.
+
+        Args:
+            url: The link URL (fragment already stripped) as written in the
+                markdown source.
+            skill_dir: Directory containing the ``SKILL.md`` file being
+                validated -- used both as the ``${CLAUDE_SKILL_DIR}`` target
+                and as the search start for ``${CLAUDE_PLUGIN_ROOT}``.
+
+        Returns:
+            The URL with resolvable variables substituted, or ``None`` if the
+            link should be skipped because a variable's target cannot be
+            determined.
+        """
+        tokens = set(re.findall(cls.CLAUDE_VAR_PATTERN, url))
+        if not tokens:
+            return url
+        if tokens - cls._STATICALLY_RESOLVABLE_CLAUDE_VARS:
+            return None
+
+        resolved = url
+        if "${CLAUDE_SKILL_DIR}" in resolved:
+            resolved = resolved.replace("${CLAUDE_SKILL_DIR}", str(skill_dir))
+        if "${CLAUDE_PLUGIN_ROOT}" in resolved:
+            plugin_root = find_plugin_dir(skill_dir)
+            if plugin_root is None:
+                return None
+            resolved = resolved.replace("${CLAUDE_PLUGIN_ROOT}", str(plugin_root))
+        return resolved
 
 
 # ============================================================================

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -318,9 +318,8 @@ class ErrorCode(StrEnum):
     SK008 = "SK008"  # Skill directory name violates naming convention
     SK009 = "SK009"  # Plugin uses manual skill selection (overrides auto-discovery)
 
-    # Link (LK001-LK002)
+    # Link (LK001)
     LK001 = "LK001"  # Broken internal link (file does not exist)
-    LK002 = "LK002"  # Link missing ./ prefix
 
     # Progressive Disclosure (PD001-PD003)
     PD001 = "PD001"  # No `references/` directory found
@@ -400,7 +399,7 @@ SK001, SK002, SK003, SK004, SK005, SK006, SK007, SK008, SK009 = (
     ErrorCode.SK008,
     ErrorCode.SK009,
 )
-LK001, LK002 = ErrorCode.LK001, ErrorCode.LK002
+LK001 = ErrorCode.LK001
 PD001, PD002, PD003 = ErrorCode.PD001, ErrorCode.PD002, ErrorCode.PD003
 PL001, PL002, PL003, PL004, PL005, PL006 = (
     ErrorCode.PL001,
@@ -1377,8 +1376,7 @@ class ProgressiveDisclosureValidator:
 class InternalLinkValidator:
     """Validates internal markdown links in SKILL.md files.
 
-    Checks that relative links point to existing files (LK001) and that
-    relative links use the ./ prefix convention (LK002).
+    Checks that relative links point to existing files (LK001).
 
     Architecture lines 1188-1256, Task T8 lines 897-982
     """
@@ -1481,20 +1479,6 @@ class InternalLinkValidator:
                         code=LK001,
                         docs_url=generate_docs_url(LK001),
                         suggestion=f"Create missing file or fix link path: {link_url}",
-                    )
-                )
-
-            # Warn if relative link is missing ./ prefix (LK002)
-            # Links starting with ../ are valid cross-directory references; skip them.
-            if not link_url_no_fragment.startswith(("./", "../")):
-                warnings.append(
-                    ValidationIssue(
-                        field="internal-links",
-                        severity="warning",
-                        message=f"Link missing ./ prefix: [{link_text}]({link_url})",
-                        code=LK002,
-                        docs_url=generate_docs_url(LK002),
-                        suggestion=f"Add ./ prefix: ./{link_url}",
                     )
                 )
 

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -1878,8 +1878,14 @@ class NamespaceReferenceValidator:
         contains such a sequence, the reference is treated as escaping the
         plugin boundary and NR002 is emitted.
 
-        Source: https://agentskills.io/specification.md — plugin boundary is
-        a portability and security constraint.
+        Source: https://code.claude.com/docs/en/plugins-reference.md#path-traversal-limitations
+        — "Claude Code doesn't let a plugin reference files outside its own
+        directory. It rejects a component path that resolves outside the
+        plugin root, such as `../shared-utils`...". The `/` and `\\`
+        separator check derives from the same doc's plugin-init reference
+        (#plugin-init): a plugin `<name>` "cannot contain spaces or path
+        separators" because it becomes the skill namespace and directory
+        name.
 
         Args:
             label: Human-readable reference label for the error message.

--- a/packages/skilllint/rules/lk_series.py
+++ b/packages/skilllint/rules/lk_series.py
@@ -1,22 +1,30 @@
-"""LK-series internal link rules (LK001-LK002).
+"""LK-series internal link rules (LK001).
 
 Each function is decorated with @skilllint_rule and returns a list of
 ValidationIssue objects.
 
-LK001 and LK002 are emitted by ``InternalLinkValidator`` in
-``plugin_validator.py`` after reading file content and resolving filesystem
-paths.  The validator functions registered here are **registration-only
-stubs** — they exist to make rule metadata available via ``RULE_REGISTRY``
-(and therefore via ``skilllint rule LKxxx``) without duplicating the
-detection logic that requires live file I/O.
+LK001 is emitted by ``InternalLinkValidator`` in ``plugin_validator.py``
+after reading file content and resolving filesystem paths.  The validator
+function registered here is a **registration-only stub** — it exists to
+make rule metadata available via ``RULE_REGISTRY`` (and therefore via
+``skilllint rule LKxxx``) without duplicating the detection logic that
+requires live file I/O.
 
 Rule IDs and default severities:
     +-------+-----------------------------------------------+-----------+
     | ID    | Summary                                       | Severity  |
     +-------+-----------------------------------------------+-----------+
     | LK001 | Broken internal link (file does not exist)    | error     |
-    | LK002 | Relative link missing ./ prefix               | warning   |
     +-------+-----------------------------------------------+-----------+
+
+LK002 ("relative link missing ./ prefix") was deleted: both the
+AgentSkills specification's own worked example
+(``[the reference guide](references/REFERENCE.md)``) and Anthropic's
+skills doc (``[reference.md](reference.md)``) use bare relative links
+with no ``./`` prefix. LK002 fired on both specs' own examples and had no
+sourced justification. The real ``./``-prefix requirement upstream
+applies to ``plugin.json`` manifest path fields, a different thing
+already covered by PL004.
 
 Import note: ValidationIssue is deferred inside each function to break the
 circular import: plugin_validator imports rules/, so rules/ cannot import
@@ -74,6 +82,15 @@ def check_lk001(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     each relative link path against the `SKILL.md` parent directory and
     checks for existence via ``Path.exists()``.
 
+    Links containing Claude Code's documented ``${CLAUDE_SKILL_DIR}`` and
+    ``${CLAUDE_PLUGIN_ROOT}`` substitution variables are resolved before the
+    existence check (see `code.claude.com/docs/en/skills.md
+    #available-string-substitutions`). Links containing any other
+    unexpanded ``${...}`` token (e.g. ``${CLAUDE_PROJECT_DIR}``,
+    ``${CLAUDE_PLUGIN_DATA}``, or an unrecognized variable) are skipped —
+    skilllint has no static basis for resolving those targets and no basis
+    for asserting they are broken.
+
     **Fix:** Either create the missing file at the referenced path, or
     correct the link to point to an existing file:
 
@@ -95,49 +112,4 @@ def check_lk001(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     return []
 
 
-# ---------------------------------------------------------------------------
-# LK002 — Relative link missing ./ prefix
-# ---------------------------------------------------------------------------
-
-
-@skilllint_rule(
-    "LK002",
-    severity="warning",
-    category="link",
-    platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
-)
-def check_lk002(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
-    """## LK002 — Relative link missing ./ prefix
-
-    A relative markdown link does not start with `./` or `../`.  The `./`
-    prefix makes the relative nature of the link explicit and avoids
-    ambiguity on systems that interpret bare names differently.
-
-    **Source:** `InternalLinkValidator` in `plugin_validator.py` — checks
-    each relative link URL for a leading `./` or `../` prefix.
-
-    **Fix:** Add the `./` prefix to the relative link:
-
-    ```markdown
-    <!-- Before -->
-    See [Reference](references/my-doc.md)
-
-    <!-- After -->
-    See [Reference](./references/my-doc.md)
-    ```
-
-    Links that already start with `../` (cross-directory references) are
-    valid and do not trigger this warning.
-
-    Returns:
-        Always an empty list.  LK002 is emitted by ``InternalLinkValidator``
-        in ``plugin_validator.py`` after inspecting the link URL prefix; this
-        function exists for rule metadata registration only.
-
-    <!-- examples: LK002 -->
-    """
-    return []
-
-
-__all__ = ["check_lk001", "check_lk002"]
+__all__ = ["check_lk001"]

--- a/packages/skilllint/rules/nr_series.py
+++ b/packages/skilllint/rules/nr_series.py
@@ -41,6 +41,19 @@ if TYPE_CHECKING:
 # Spec sources
 # ---------------------------------------------------------------------------
 
+# NR002 authority: code.claude.com/docs/en/plugins-reference, "Path traversal
+# limitations" section. Verified via `skilllint docs fetch` — the cached page
+# states verbatim: "Claude Code doesn't let a plugin reference files outside
+# its own directory. It rejects a component path that resolves outside the
+# plugin root, such as `../shared-utils`...". The same page's "plugin init"
+# reference defines `<name>` as becoming "the skill namespace and the
+# directory name under `~/.claude/skills/`, so it cannot contain spaces or
+# path separators" — the basis for rejecting `/` and `\` in reference
+# components. (Previously this rule cited agentskills.io/specification.md,
+# which says nothing about traversal, boundaries, escaping, or symlinks —
+# verified via `grep -ci` returning 0 for those terms against the cached spec.)
+_NR002_PATH_TRAVERSAL_URL = "https://code.claude.com/docs/en/plugins-reference.md#path-traversal-limitations"
+
 
 def _docs_url(code: str) -> str:
     """Return the documentation URL for an NR rule code.
@@ -126,27 +139,36 @@ def check_nr001(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     severity="error",
     category="namespace-reference",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
+    authority={"origin": "code.claude.com", "reference": _NR002_PATH_TRAVERSAL_URL},
 )
 def check_nr002(frontmatter: dict[str, object], path: Path, file_type: str) -> list[ValidationIssue]:
-    """## NR002 — Namespace reference points outside plugin directory
+    r"""## NR002 — Namespace reference points outside plugin directory
 
-    A resolved namespace reference target falls outside the expected plugin
-    directory boundary.  This can occur when path traversal sequences (e.g.
-    ``../``) or symlinks cause the resolved file path to escape the plugin
-    directory that owns the reference.
+    A namespace reference's plugin prefix or target name contains a
+    path-traversal sequence (``..``) or a path separator (``/`` or ``\\``),
+    which would cause the resolved file path to escape the plugin directory
+    that owns the reference.
 
-    Such references are considered invalid because the plugin boundary is a
-    security and portability constraint: each plugin is a self-contained unit
-    and should only reference files within its own directory tree.
+    **Source (`..` traversal):** ``code.claude.com/docs/en/plugins-reference``
+    — "Path traversal limitations": "Claude Code doesn't let a plugin
+    reference files outside its own directory. It rejects a component path
+    that resolves outside the plugin root, such as `../shared-utils`...".
+    See https://code.claude.com/docs/en/plugins-reference.md#path-traversal-limitations
 
-    **Source:** ``NamespaceReferenceValidator`` in ``plugin_validator.py``
-    — resolves reference paths and checks that the canonical path remains
-    within the plugin root.
+    **Source (`/` and `\\` separators):** the same doc's ``plugin init``
+    reference defines a plugin's ``<name>``: "Becomes the skill namespace
+    and the directory name under `~/.claude/skills/`, so it cannot contain
+    spaces or path separators." See
+    https://code.claude.com/docs/en/plugins-reference.md#plugin-init
 
-    **Fix:** Remove any path-traversal segments from reference names.
-    References must resolve to files that live inside the plugin directory
-    they belong to:
+    **Source (detection):**
+    ``NamespaceReferenceValidator._check_nr002_traversal`` in
+    ``plugin_validator.py`` — rejects namespace prefix/target components
+    containing ``..``, ``/``, or ``\\``.
+
+    **Fix:** Remove any path-traversal segments or path separators from
+    reference names.  References must resolve to files that live inside the
+    plugin directory they belong to:
 
     ```yaml
     # Problematic (traverses outside the plugin boundary)

--- a/packages/skilllint/tests/test_external_scan_proof.py
+++ b/packages/skilllint/tests/test_external_scan_proof.py
@@ -86,7 +86,7 @@ def _extract_rule_codes(output: str) -> set[str]:
     # Strip ANSI escape codes first
     clean_output = _ANSI_ESCAPE.sub("", output)
 
-    # Pattern matches rule codes like FM003, FM005, AS004, SK006, LK002, etc.
+    # Pattern matches rule codes like FM003, FM005, AS004, SK006, etc.
     # Codes appear as [FM003] in output, we extract just the code
     pattern = r"\[([A-Z]{2,3}\d{3})\]"
     return set(re.findall(pattern, clean_output))
@@ -146,7 +146,7 @@ class TestClaudePluginsOfficial:
         # (This is a tautology with the current sets, but documents the intent)
 
         # Check for any codes that are NOT in our known sets
-        (found_codes - ERROR_RULE_CODES - WARNING_RULE_CODES - {"SK004", "SK005", "SK006", "LK002", "FM010"})
+        (found_codes - ERROR_RULE_CODES - WARNING_RULE_CODES - {"SK004", "SK005", "SK006", "FM010"})
         # unknown_codes are allowed (other warning-level rules)
         # The key assertion is that only FM003/FM005 cause exit code 1
 

--- a/packages/skilllint/tests/test_ignore_config_discovery.py
+++ b/packages/skilllint/tests/test_ignore_config_discovery.py
@@ -30,15 +30,18 @@ _MINIMAL_SKILL = """\
 name: smoke-skill
 description: Use when testing smoke test scenarios for suppression.
 version: "1.0.0"
+tools:
+  - Read
+  - Write
 ---
 # Smoke Skill
 
-See [other file](other-file.md) for details.
+Testing rule suppression behavior.
 """
 
 
 def _make_skill(directory: Path, name: str = "smoke-skill") -> Path:
-    """Write a minimal SKILL.md that triggers LK002 (missing ./ prefix)."""
+    """Write a minimal SKILL.md that triggers FM007 (tools field as YAML array)."""
     directory.mkdir(parents=True, exist_ok=True)
     skill_file = directory / "SKILL.md"
     skill_file.write_text(_MINIMAL_SKILL, encoding="utf-8")
@@ -61,13 +64,13 @@ def _make_plugin_root(directory: Path) -> Path:
 def test_load_skilllint_config_valid_returns_ignore_mapping(tmp_path: Path) -> None:
     # Arrange
     cfg = tmp_path / ".skilllint.json"
-    cfg.write_text(json.dumps({"ignore": {"": ["LK002"], "skills/foo": ["AS008"]}}), encoding="utf-8")
+    cfg.write_text(json.dumps({"ignore": {"": ["FM007"], "skills/foo": ["AS008"]}}), encoding="utf-8")
 
     # Act
     result = _load_skilllint_config(cfg)
 
     # Assert
-    assert result == {"": ["LK002"], "skills/foo": ["AS008"]}
+    assert result == {"": ["FM007"], "skills/foo": ["AS008"]}
 
 
 def test_load_skilllint_config_missing_file_returns_empty(tmp_path: Path) -> None:
@@ -83,7 +86,7 @@ def test_load_skilllint_config_malformed_json_returns_empty(tmp_path: Path) -> N
 
 def test_load_skilllint_config_ignore_not_dict_returns_empty(tmp_path: Path) -> None:
     cfg = tmp_path / ".skilllint.json"
-    cfg.write_text(json.dumps({"ignore": ["LK002"]}), encoding="utf-8")
+    cfg.write_text(json.dumps({"ignore": ["FM007"]}), encoding="utf-8")
     assert _load_skilllint_config(cfg) == {}
 
 
@@ -95,9 +98,9 @@ def test_load_skilllint_config_no_ignore_key_returns_empty(tmp_path: Path) -> No
 
 def test_load_skilllint_config_skips_non_list_values(tmp_path: Path) -> None:
     cfg = tmp_path / ".skilllint.json"
-    cfg.write_text(json.dumps({"ignore": {"good": ["LK002"], "bad": "LK003"}}), encoding="utf-8")
+    cfg.write_text(json.dumps({"ignore": {"good": ["FM007"], "bad": "LK003"}}), encoding="utf-8")
     result = _load_skilllint_config(cfg)
-    assert result == {"good": ["LK002"]}
+    assert result == {"good": ["FM007"]}
     assert "bad" not in result
 
 
@@ -108,15 +111,15 @@ def test_load_skilllint_config_skips_non_list_values(tmp_path: Path) -> None:
 
 def test_is_suppressed_empty_prefix_matches_any_file(tmp_path: Path) -> None:
     # Arrange
-    config: IgnoreConfig = {"": ["LK002"]}
+    config: IgnoreConfig = {"": ["FM007"]}
     file_path = tmp_path / "subdir" / "SKILL.md"
 
     # Act / Assert
-    assert _is_suppressed(config, file_path, tmp_path, "LK002") is True
+    assert _is_suppressed(config, file_path, tmp_path, "FM007") is True
 
 
 def test_is_suppressed_empty_prefix_does_not_match_different_code(tmp_path: Path) -> None:
-    config: IgnoreConfig = {"": ["LK002"]}
+    config: IgnoreConfig = {"": ["FM007"]}
     file_path = tmp_path / "SKILL.md"
     assert _is_suppressed(config, file_path, tmp_path, "LK001") is False
 
@@ -147,7 +150,7 @@ def test_is_suppressed_prefix_no_partial_segment_match(tmp_path: Path) -> None:
 
 def test_resolve_ignore_config_finds_skilllint_json(tmp_path: Path) -> None:
     # Arrange
-    (tmp_path / ".skilllint.json").write_text(json.dumps({"ignore": {"": ["LK002"]}}), encoding="utf-8")
+    (tmp_path / ".skilllint.json").write_text(json.dumps({"ignore": {"": ["FM007"]}}), encoding="utf-8")
     skill_file = tmp_path / "SKILL.md"
     skill_file.write_text("# x", encoding="utf-8")
     cache: dict[str, tuple[IgnoreConfig, Path | None]] = {}
@@ -156,7 +159,7 @@ def test_resolve_ignore_config_finds_skilllint_json(tmp_path: Path) -> None:
     config, root = _resolve_ignore_config(skill_file, cache)
 
     # Assert
-    assert config == {"": ["LK002"]}
+    assert config == {"": ["FM007"]}
     assert root == tmp_path
 
 
@@ -169,7 +172,7 @@ def test_resolve_ignore_config_plugin_root_wins_over_skilllint_json_at_same_dir(
         json.dumps({"ignore": {"": ["FM010"]}}), encoding="utf-8"
     )
     # .skilllint.json at the same level — should be ignored because plugin.json wins
-    (tmp_path / ".skilllint.json").write_text(json.dumps({"ignore": {"": ["LK002"]}}), encoding="utf-8")
+    (tmp_path / ".skilllint.json").write_text(json.dumps({"ignore": {"": ["FM007"]}}), encoding="utf-8")
     skill_file = tmp_path / "SKILL.md"
     skill_file.write_text("# x", encoding="utf-8")
     cache: dict[str, tuple[IgnoreConfig, Path | None]] = {}
@@ -177,7 +180,7 @@ def test_resolve_ignore_config_plugin_root_wins_over_skilllint_json_at_same_dir(
     # Act
     config, root = _resolve_ignore_config(skill_file, cache)
 
-    # Assert: plugin root wins, so FM010 is suppressed (not LK002)
+    # Assert: plugin root wins, so FM010 is suppressed (not FM007)
     assert root == tmp_path
     assert config == {"": ["FM010"]}
 
@@ -196,7 +199,7 @@ def test_resolve_ignore_config_returns_empty_when_nothing_found(tmp_path: Path) 
 def test_resolve_ignore_config_populates_cache_for_walked_dirs(tmp_path: Path) -> None:
     """All directories in the walk chain are cached after the first call."""
     # Arrange
-    (tmp_path / ".skilllint.json").write_text(json.dumps({"ignore": {"": ["LK002"]}}), encoding="utf-8")
+    (tmp_path / ".skilllint.json").write_text(json.dumps({"ignore": {"": ["FM007"]}}), encoding="utf-8")
     nested = tmp_path / "a" / "b" / "c"
     nested.mkdir(parents=True)
     skill_file = nested / "SKILL.md"
@@ -215,7 +218,7 @@ def test_resolve_ignore_config_populates_cache_for_walked_dirs(tmp_path: Path) -
 def test_resolve_ignore_config_cache_hit_returns_same_result(tmp_path: Path) -> None:
     """Second call for same directory returns cached value without re-walking."""
     # Arrange
-    (tmp_path / ".skilllint.json").write_text(json.dumps({"ignore": {"": ["LK002"]}}), encoding="utf-8")
+    (tmp_path / ".skilllint.json").write_text(json.dumps({"ignore": {"": ["FM007"]}}), encoding="utf-8")
     skill_file = tmp_path / "SKILL.md"
     skill_file.write_text("# x", encoding="utf-8")
     cache: dict[str, tuple[IgnoreConfig, Path | None]] = {}
@@ -227,13 +230,13 @@ def test_resolve_ignore_config_cache_hit_returns_same_result(tmp_path: Path) -> 
 
     config2, root2 = _resolve_ignore_config(skill_file, cache)
 
-    assert config1 == config2 == {"": ["LK002"]}
+    assert config1 == config2 == {"": ["FM007"]}
     assert root1 == root2
 
 
 def test_resolve_ignore_config_sibling_files_share_cache(tmp_path: Path) -> None:
     """Two files in the same directory reuse the cached result."""
-    (tmp_path / ".skilllint.json").write_text(json.dumps({"ignore": {"": ["LK002"]}}), encoding="utf-8")
+    (tmp_path / ".skilllint.json").write_text(json.dumps({"ignore": {"": ["FM007"]}}), encoding="utf-8")
     file_a = tmp_path / "SKILL_A.md"
     file_b = tmp_path / "SKILL_B.md"
     file_a.write_text("# a", encoding="utf-8")
@@ -243,7 +246,7 @@ def test_resolve_ignore_config_sibling_files_share_cache(tmp_path: Path) -> None
     config_a, root_a = _resolve_ignore_config(file_a, cache)
     config_b, root_b = _resolve_ignore_config(file_b, cache)
 
-    assert config_a == config_b == {"": ["LK002"]}
+    assert config_a == config_b == {"": ["FM007"]}
     assert root_a == root_b == tmp_path
     # Cache should have exactly one entry (the shared directory)
     assert len(cache) == 1
@@ -254,12 +257,12 @@ def test_resolve_ignore_config_sibling_files_share_cache(tmp_path: Path) -> None
 # ---------------------------------------------------------------------------
 
 
-def test_validate_single_path_lk002_suppressed_by_skilllint_json(tmp_path: Path) -> None:
-    """LK002 is not reported when .skilllint.json suppresses it globally."""
+def test_validate_single_path_fm007_suppressed_by_skilllint_json(tmp_path: Path) -> None:
+    """FM007 is not reported when .skilllint.json suppresses it globally."""
     # Arrange
     skill_dir = tmp_path / "smoke-skill"
     skill_file = _make_skill(skill_dir)
-    (tmp_path / ".skilllint.json").write_text(json.dumps({"ignore": {"": ["LK002"]}}), encoding="utf-8")
+    (tmp_path / ".skilllint.json").write_text(json.dumps({"ignore": {"": ["FM007"]}}), encoding="utf-8")
 
     # Act
     results = validate_single_path(skill_file, check=True, fix=False, verbose=False)
@@ -271,11 +274,11 @@ def test_validate_single_path_lk002_suppressed_by_skilllint_json(tmp_path: Path)
         for _, vr in validator_results
         for issue in (vr.errors + vr.warnings + vr.info)
     }
-    assert "LK002" not in all_codes, f"LK002 should have been suppressed, but got codes: {all_codes}"
+    assert "FM007" not in all_codes, f"FM007 should have been suppressed, but got codes: {all_codes}"
 
 
-def test_validate_single_path_lk002_not_suppressed_without_config(tmp_path: Path) -> None:
-    """LK002 is reported normally when no .skilllint.json is present."""
+def test_validate_single_path_fm007_not_suppressed_without_config(tmp_path: Path) -> None:
+    """FM007 is reported normally when no .skilllint.json is present."""
     # Arrange
     skill_dir = tmp_path / "smoke-skill"
     skill_file = _make_skill(skill_dir)
@@ -284,39 +287,39 @@ def test_validate_single_path_lk002_not_suppressed_without_config(tmp_path: Path
     # Act
     results = validate_single_path(skill_file, check=True, fix=False, verbose=False)
 
-    # Assert — LK002 must appear
+    # Assert — FM007 must appear
     all_codes = {
         str(issue.code)
         for validator_results in results.values()
         for _, vr in validator_results
         for issue in (vr.errors + vr.warnings + vr.info)
     }
-    assert "LK002" in all_codes, f"LK002 should have been reported, but got codes: {all_codes}"
+    assert "FM007" in all_codes, f"FM007 should have been reported, but got codes: {all_codes}"
 
 
 def test_validate_single_path_path_prefix_suppression(tmp_path: Path) -> None:
     """A prefix-keyed suppress only silences the matching subtree."""
-    # Arrange: .skilllint.json suppresses LK002 only under "skills/inner"
-    (tmp_path / ".skilllint.json").write_text(json.dumps({"ignore": {"skills/inner": ["LK002"]}}), encoding="utf-8")
+    # Arrange: .skilllint.json suppresses FM007 only under "skills/inner"
+    (tmp_path / ".skilllint.json").write_text(json.dumps({"ignore": {"skills/inner": ["FM007"]}}), encoding="utf-8")
     inner_dir = tmp_path / "skills" / "inner"
     outer_dir = tmp_path / "skills" / "outer"
     inner_file = _make_skill(inner_dir)
     outer_file = _make_skill(outer_dir)
 
-    def _lk002_codes(path: Path) -> set[str]:
+    def _fm007_codes(path: Path) -> set[str]:
         results = validate_single_path(path, check=True, fix=False, verbose=False)
         return {
             str(issue.code)
             for validator_results in results.values()
             for _, vr in validator_results
             for issue in (vr.errors + vr.warnings + vr.info)
-            if str(issue.code) == "LK002"
+            if str(issue.code) == "FM007"
         }
 
     # Assert inner: suppressed
-    assert _lk002_codes(inner_file) == set()
+    assert _fm007_codes(inner_file) == set()
     # Assert outer: not suppressed
-    assert "LK002" in _lk002_codes(outer_file)
+    assert "FM007" in _fm007_codes(outer_file)
 
 
 def test_validate_single_path_per_run_cache_shared_across_calls(tmp_path: Path) -> None:
@@ -324,7 +327,7 @@ def test_validate_single_path_per_run_cache_shared_across_calls(tmp_path: Path) 
     # Arrange
     skill_dir = tmp_path / "smoke-skill"
     skill_file = _make_skill(skill_dir)
-    (tmp_path / ".skilllint.json").write_text(json.dumps({"ignore": {"": ["LK002"]}}), encoding="utf-8")
+    (tmp_path / ".skilllint.json").write_text(json.dumps({"ignore": {"": ["FM007"]}}), encoding="utf-8")
     cache: dict[str, tuple[IgnoreConfig, Path | None]] = {}
 
     # Act — two calls share the same cache
@@ -341,5 +344,5 @@ def test_validate_single_path_per_run_cache_shared_across_calls(tmp_path: Path) 
         for _, vr in validator_results
         for issue in (vr.errors + vr.warnings + vr.info)
     }
-    # LK002 should still be suppressed because the cache is used
-    assert "LK002" not in all_codes
+    # FM007 should still be suppressed because the cache is used
+    assert "FM007" not in all_codes

--- a/packages/skilllint/tests/test_internal_link_validator.py
+++ b/packages/skilllint/tests/test_internal_link_validator.py
@@ -445,3 +445,193 @@ See [absolute](/absolute/path/file.md).
         # Absolute paths should be ignored
         assert result.passed is True
         assert len(result.errors) == 0
+
+
+class TestClaudeVariableSubstitution:
+    """Test ${CLAUDE_*} substitution before the LK001 existence check.
+
+    Reproduces issue #111: LK001 flagged
+    ``[text](${CLAUDE_PLUGIN_ROOT}/docs/foo.md)`` as a broken link because it
+    treated the literal ``${CLAUDE_PLUGIN_ROOT}`` string as a filesystem path.
+    Claude Code documents four substitution variables
+    (code.claude.com/docs/en/skills.md#available-string-substitutions):
+    ``${CLAUDE_SKILL_DIR}``, ``${CLAUDE_PROJECT_DIR}``,
+    ``${CLAUDE_PLUGIN_ROOT}``, and ``${CLAUDE_PLUGIN_DATA}``.
+    """
+
+    def test_claude_skill_dir_resolves_to_existing_file(self, tmp_path: Path) -> None:
+        """${CLAUDE_SKILL_DIR} resolves to the SKILL.md directory and passes
+        when the target exists there."""
+        skill_dir = tmp_path / "my-skill"
+        docs_dir = skill_dir / "docs"
+        docs_dir.mkdir(parents=True)
+        (docs_dir / "foo.md").write_text("# Foo\n")
+
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text("""---
+description: Test skill
+---
+
+See [foo](${CLAUDE_SKILL_DIR}/docs/foo.md) for details.
+""")
+
+        validator = InternalLinkValidator()
+        result = validator.validate(skill_md)
+
+        assert result.passed is True
+        assert not any(issue.code == "LK001" for issue in result.errors)
+
+    def test_claude_skill_dir_missing_target_still_reports_lk001(self, tmp_path: Path) -> None:
+        """${CLAUDE_SKILL_DIR} is always resolvable, so a genuinely missing
+        target must still be reported."""
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir(parents=True)
+
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text("""---
+description: Test skill
+---
+
+See [missing](${CLAUDE_SKILL_DIR}/docs/missing.md) for details.
+""")
+
+        validator = InternalLinkValidator()
+        result = validator.validate(skill_md)
+
+        assert result.passed is False
+        assert any(issue.code == "LK001" for issue in result.errors)
+
+    def test_claude_plugin_root_resolves_when_plugin_json_present(self, tmp_path: Path) -> None:
+        """${CLAUDE_PLUGIN_ROOT} resolves via find_plugin_dir and passes
+        when the target exists relative to the plugin root."""
+        plugin_dir = tmp_path / "my-plugin"
+        claude_plugin_dir = plugin_dir / ".claude-plugin"
+        claude_plugin_dir.mkdir(parents=True)
+        (claude_plugin_dir / "plugin.json").write_text('{"name": "my-plugin"}', encoding="utf-8")
+
+        docs_dir = plugin_dir / "docs"
+        docs_dir.mkdir()
+        (docs_dir / "foo.md").write_text("# Foo\n")
+
+        skill_dir = plugin_dir / "skills" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text("""---
+description: Test skill
+---
+
+See [foo](${CLAUDE_PLUGIN_ROOT}/docs/foo.md) for details.
+""")
+
+        validator = InternalLinkValidator()
+        result = validator.validate(skill_md)
+
+        assert result.passed is True
+        assert not any(issue.code == "LK001" for issue in result.errors)
+
+    def test_claude_plugin_root_skipped_when_no_plugin_json_found(self, tmp_path: Path) -> None:
+        """${CLAUDE_PLUGIN_ROOT} is skipped (not reported broken) when no
+        plugin.json exists anywhere above the skill -- skilllint has no basis
+        for asserting the target is broken when it cannot determine the
+        plugin root."""
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir(parents=True)
+
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text("""---
+description: Test skill
+---
+
+See [foo](${CLAUDE_PLUGIN_ROOT}/docs/foo.md) for details.
+""")
+
+        validator = InternalLinkValidator()
+        result = validator.validate(skill_md)
+
+        assert result.passed is True
+        assert not any(issue.code == "LK001" for issue in result.errors)
+
+    def test_claude_project_dir_always_skipped(self, tmp_path: Path) -> None:
+        """${CLAUDE_PROJECT_DIR} targets an install-time location skilllint
+        cannot determine from the plugin source tree -- always skipped."""
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir(parents=True)
+
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text("""---
+description: Test skill
+---
+
+See [foo](${CLAUDE_PROJECT_DIR}/scripts/foo.sh) for details.
+""")
+
+        validator = InternalLinkValidator()
+        result = validator.validate(skill_md)
+
+        assert result.passed is True
+        assert not any(issue.code == "LK001" for issue in result.errors)
+
+    def test_claude_plugin_data_always_skipped(self, tmp_path: Path) -> None:
+        """${CLAUDE_PLUGIN_DATA} targets the plugin's persistent data
+        directory, which does not exist in the plugin source -- always
+        skipped."""
+        plugin_dir = tmp_path / "my-plugin"
+        claude_plugin_dir = plugin_dir / ".claude-plugin"
+        claude_plugin_dir.mkdir(parents=True)
+        (claude_plugin_dir / "plugin.json").write_text('{"name": "my-plugin"}', encoding="utf-8")
+
+        skill_dir = plugin_dir / "skills" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text("""---
+description: Test skill
+---
+
+See [cache](${CLAUDE_PLUGIN_DATA}/cache/foo.json) for details.
+""")
+
+        validator = InternalLinkValidator()
+        result = validator.validate(skill_md)
+
+        assert result.passed is True
+        assert not any(issue.code == "LK001" for issue in result.errors)
+
+    def test_unknown_claude_variable_skipped(self, tmp_path: Path) -> None:
+        """An unrecognized ${...} token is skipped -- skilllint has no basis
+        for asserting an unknown variable's expansion is broken."""
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir(parents=True)
+
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text("""---
+description: Test skill
+---
+
+See [foo](${SOME_UNKNOWN_VAR}/docs/foo.md) for details.
+""")
+
+        validator = InternalLinkValidator()
+        result = validator.validate(skill_md)
+
+        assert result.passed is True
+        assert not any(issue.code == "LK001" for issue in result.errors)
+
+    def test_mixed_known_and_unknown_variables_skipped(self, tmp_path: Path) -> None:
+        """A link mixing a resolvable variable with an unknown one is skipped
+        entirely -- skilllint cannot assert the unknown half is broken."""
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir(parents=True)
+
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text("""---
+description: Test skill
+---
+
+See [foo](${CLAUDE_SKILL_DIR}/${SOME_UNKNOWN_VAR}/foo.md) for details.
+""")
+
+        validator = InternalLinkValidator()
+        result = validator.validate(skill_md)
+
+        assert result.passed is True
+        assert not any(issue.code == "LK001" for issue in result.errors)

--- a/packages/skilllint/tests/test_internal_link_validator.py
+++ b/packages/skilllint/tests/test_internal_link_validator.py
@@ -2,7 +2,7 @@
 
 Tests:
 - Broken link detection (LK001)
-- Missing ./ prefix warnings (LK002)
+- ${CLAUDE_*} substitution before existence check
 - External link filtering
 - Path resolution
 """
@@ -193,68 +193,6 @@ See [linked](./references/linked.md).
 
         assert result.passed is True
         assert not any(issue.code == "LK001" for issue in result.errors)
-
-
-class TestMissingPrefixWarning:
-    """Test warning for links without ./ prefix (LK002)."""
-
-    def test_link_without_prefix_warning(self, tmp_path: Path) -> None:
-        """Test warning when link missing ./ prefix (LK002).
-
-        Tests: Missing ./ prefix detection
-        How: Create link without ./ prefix, validate
-        Why: Ensure LK002 warning raised for missing prefix
-        """
-        skill_dir = tmp_path / "test-skill"
-        skill_dir.mkdir()
-        refs_dir = skill_dir / "references"
-        refs_dir.mkdir()
-        (refs_dir / "existing.md").write_text("# Reference\n")
-
-        skill_md = skill_dir / "SKILL.md"
-        skill_md.write_text("""---
-description: Test skill
----
-
-# Test Skill
-
-See [no prefix](references/existing.md) for details.
-""")
-
-        validator = InternalLinkValidator()
-        result = validator.validate(skill_md)
-
-        # Should have warning
-        assert result.passed is True
-        assert any(issue.code == "LK002" for issue in result.warnings)
-
-    def test_multiple_links_without_prefix(self, tmp_path: Path) -> None:
-        """Test multiple warnings for links without prefix.
-
-        Tests: Multiple missing prefix warnings
-        How: Create multiple links without ./ prefix, validate
-        Why: Ensure all missing prefixes reported
-        """
-        skill_dir = tmp_path / "test-skill"
-        skill_dir.mkdir()
-        refs_dir = skill_dir / "references"
-        refs_dir.mkdir()
-        (refs_dir / "ref1.md").write_text("# Ref 1\n")
-        (refs_dir / "ref2.md").write_text("# Ref 2\n")
-
-        skill_md = skill_dir / "SKILL.md"
-        skill_md.write_text("""---
-description: Test skill
----
-
-See [ref1](references/ref1.md) and [ref2](references/ref2.md).
-""")
-
-        validator = InternalLinkValidator()
-        result = validator.validate(skill_md)
-
-        lk002_warnings = [w for w in result.warnings if w.code == "LK002"]
-        assert len(lk002_warnings) >= 2
 
 
 class TestExternalLinkFiltering:

--- a/packages/skilllint/tests/test_namespace_reference_validator.py
+++ b/packages/skilllint/tests/test_namespace_reference_validator.py
@@ -964,9 +964,11 @@ class TestNR002PathTraversal:
     plugin boundary even though a well-formed reference never contains
     those characters.
 
-    Source: https://agentskills.io/specification.md — plugin boundary is a
-    portability and security constraint; each plugin is a self-contained
-    unit and should only reference files within its own directory tree.
+    Source: https://code.claude.com/docs/en/plugins-reference.md#path-traversal-limitations
+    — Claude Code rejects a component path that resolves outside the plugin
+    root (e.g. ``../shared-utils``). The `/` and `\\` checks derive from the
+    same doc's plugin-init reference (#plugin-init): a plugin `<name>`
+    "cannot contain spaces or path separators".
     """
 
     def test_parent_traversal_in_name_emits_nr002(self, tmp_path: Path) -> None:

--- a/packages/skilllint/tests/test_nr_series.py
+++ b/packages/skilllint/tests/test_nr_series.py
@@ -1,0 +1,44 @@
+"""Unit tests for NR-series rule registration metadata (nr_series.py).
+
+Covers the NR002 citation fix: NR002's authority previously cited
+``https://agentskills.io/specification.md``, a page that documents nothing
+about path traversal, plugin boundaries, escaping, or symlinks (verified via
+``grep -ci 'traversal|outside|boundary|escape|symlink'`` returning 0 against
+the cached specification). NR002's authority must instead cite
+``code.claude.com/docs/en/plugins-reference``, which documents the "Path
+traversal limitations" section this rule actually enforces.
+"""
+
+from __future__ import annotations
+
+from skilllint.plugin_validator import NamespaceReferenceValidator
+from skilllint.rule_registry import RULE_REGISTRY
+
+
+class TestNR002Authority:
+    """NR002's authority metadata must cite a source that documents the
+    plugin path-traversal boundary it enforces."""
+
+    def test_nr002_authority_origin_is_code_claude_com(self) -> None:
+        """NR002 authority.origin must be code.claude.com, not agentskills.io."""
+        entry = RULE_REGISTRY["NR002"]
+        assert entry.authority is not None
+        assert entry.authority.origin == "code.claude.com"
+
+    def test_nr002_authority_reference_cites_path_traversal_limitations(self) -> None:
+        """NR002 authority.reference must point at the real path-traversal section."""
+        entry = RULE_REGISTRY["NR002"]
+        assert entry.authority is not None
+        assert entry.authority.reference is not None
+        assert "plugins-reference" in entry.authority.reference
+        assert "path-traversal-limitations" in entry.authority.reference
+
+    def test_nr002_docstring_does_not_cite_agentskills_specification(self) -> None:
+        """The fabricated agentskills.io/specification.md citation must be gone."""
+        entry = RULE_REGISTRY["NR002"]
+        assert "agentskills.io/specification" not in entry.docstring
+
+    def test_validator_method_docstring_does_not_cite_agentskills_specification(self) -> None:
+        """The real detection method's docstring must not carry the fabricated citation either."""
+        doc = NamespaceReferenceValidator._check_nr002_traversal.__doc__ or ""
+        assert "agentskills.io/specification" not in doc

--- a/plugins/agentskills-skilllint/README.md
+++ b/plugins/agentskills-skilllint/README.md
@@ -72,7 +72,7 @@ The skill includes a [full rule catalog](./skills/skilllint/references/rule-cata
 | FM001–FM010 | YAML frontmatter validity |
 | SK001–SK009 | Skill name, description, and token budget |
 | AS001–AS009 | SKILL.md conformance with the AgentSkills open standard (AS007 removed) |
-| LK001–LK002 | Internal markdown links |
+| LK001 | Internal markdown links |
 | PD001–PD003 | Progressive disclosure directory structure |
 | PL001–PL006 | Plugin manifest (`plugin.json`) |
 | HK001–HK005 | hooks.json configuration |

--- a/plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md
+++ b/plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md
@@ -70,7 +70,6 @@ Validate internal markdown links in SKILL.md and agent files.
 | Rule | Severity | Auto-fix | Description |
 |------|----------|----------|-------------|
 | LK001 | error | no | Internal link target file does not exist on disk |
-| LK002 | warning | no | Internal link target exists but the anchor fragment (#section) does not match any heading |
 
 **LK001 fix:** Verify the linked file path is correct. Links in `skills/<name>/SKILL.md` are relative to the skill directory, not the plugin root.
 


### PR DESCRIPTION
Three independent link/reference fixes, rebased onto current `main` (post-#108, which replaced per-series `_*_DOCS_BASE` constants with the shared `rule_reference(code)` helper). Conflicting hunks were resolved toward `main` for URL plumbing and toward the commit for the substantive fix.

## 1. `fix(nr)` — correct the NR002 citation

NR002's `authority={"reference": ...}` pointed at a URL that does not document path traversal. It now cites the real path-traversal source via a dedicated `_NR002_PATH_TRAVERSAL_URL` constant. The rebase kept that constant (a genuine authority citation) and dropped the commit's `_NR_DOCS_BASE` (generic docs plumbing that #108 removed).

## 2. `fix(lk)` — delete LK002

LK002 ("relative link missing `./` prefix") had no sourced justification and fired on the specs it claimed to enforce:

- AgentSkills' own worked example: `[the reference guide](references/REFERENCE.md)`
- Anthropic's skills doc: `[reference.md](reference.md)`

Both use bare relative links with no `./` prefix. The real upstream `./`-prefix requirement applies to `plugin.json` manifest path fields — a different thing, already covered by PL004.

Removed: `check_lk002`, its registry entry, the LK002-emitting block in `InternalLinkValidator.validate`, `ErrorCode.LK002` and its module-level alias, and the catalog rows in `README.md`, `plugins/agentskills-skilllint/README.md`, `plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md`, and `docs/ignore-config.md`. A tombstone paragraph in `lk_series.py`'s module docstring records why.

**Test swap:** `test_ignore_config_discovery.py` used LK002 as a convenient always-firing warning to exercise the generic `.skilllint.json` suppression mechanism — ~33 references with nothing to do with LK002's meaning. Those now use **FM007**, another warning-severity rule reachable through the Pydantic list-type-mismatch path. The suppression tests are unchanged in intent.

**Compatibility:** `_is_suppressed` matches codes by plain string membership, so a stale `"LK002"` entry in an existing `.skilllint.json` is inert rather than an error.

## 3. `fix(lk)` — resolve `${CLAUDE_*}` substitution variables before LK001

Closes #111.

LK001 reported `[text](${CLAUDE_PLUGIN_ROOT}/docs/foo.md)` as broken because it treated the literal `${CLAUDE_PLUGIN_ROOT}` string as a path component. `InternalLinkValidator` now substitutes documented variables before the existence check:

- `${CLAUDE_SKILL_DIR}` → the directory containing `SKILL.md`
- `${CLAUDE_PLUGIN_ROOT}` → resolved via `find_plugin_dir`, the same lookup `HookValidator` already uses for this variable in hook commands

Source: `code.claude.com/docs/en/skills.md#available-string-substitutions`.

### Reviewer confirmation requested — skip vs. report

The remaining two documented variables, **`${CLAUDE_PROJECT_DIR}`** and **`${CLAUDE_PLUGIN_DATA}`**, are **skipped rather than reported**. This is an inference, stated here explicitly so it can be confirmed rather than left implicit in the diff:

> Both target install-time locations — the invoking project root, and the plugin's persistent data directory — which do not exist in a plugin *source* tree. skilllint therefore has no basis for resolving them, and equally no basis for asserting they are broken. Reporting them would produce false positives on every correct usage.

Any other unexpanded `${...}` token is skipped on the same reasoning: it is not a documented substitution variable, so skilllint cannot claim its target is missing. `${CLAUDE_PLUGIN_ROOT}` is also skipped when `find_plugin_dir` finds no plugin root.

If the preferred behaviour is instead a `warning` for unresolvable variables, that is a one-line change to `_resolve_claude_variables`.

## Validation

- `uv run pytest packages/skilllint/tests/ -q` — 1138 passed, 10 skipped, 83.07% coverage
- `uv run ruff format --check .` — 120 files already formatted
- `uv run ruff check --no-fix .` — all checks passed
- `uv run ty check packages/` — all checks passed
- Repo-wide sweep confirms zero conflict markers survived the rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJeBLNA9ybmQvv5REMDkrc
