### PR TITLE
fix: address third Codex pass on PR #119

### DIFF
--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py
@@ -343,18 +343,22 @@ def _fetch_review_pages(owner: str, repo: str, pr: int, *, gh_timeout: float | N
     ]
 
 
-def _thread_activity_key(thread: UnresolvedThread) -> tuple[int, tuple[int, ...]]:
-    """Return a value that changes whenever a thread gains a comment.
+def _thread_activity_key(thread: UnresolvedThread) -> tuple[int, tuple[tuple[int, str], ...]]:
+    """Return a value that changes whenever a thread's comments change.
+
+    Three kinds of change have to register, and no single component catches all three:
+    a reply adds an id; an *edit* to an existing comment changes neither its `databaseId`
+    nor the count, so the body is needed; and a reply past the query's
+    `comments(first: 100)` page cannot change the id/body tuple at all, so the untruncated
+    `comments_total` is needed.
 
     Args:
         thread: An unresolved thread from a `fetch` snapshot.
 
     Returns:
-        `(comments_total, comment databaseIds)`. The count catches replies past the query's
-        100-comment page, where the id tuple is capped and cannot change; the ids catch the
-        ordinary case without depending on GitHub keeping `totalCount` exact.
+        `(comments_total, ((databaseId, body), ...))`.
     """
-    return thread.comments_total, tuple(comment.databaseId for comment in thread.comments)
+    return thread.comments_total, tuple((comment.databaseId, comment.body) for comment in thread.comments)
 
 
 def _gh_timeout_budget(deadline: float | None, gh_timeout: float | None) -> float | None:
@@ -543,21 +547,28 @@ def watch(
         # `deadline` (see `_gh_timeout_budget`), re-measured between them rather than split from
         # a fixed reservation.
         poll_attempts += 1
+        # `watch` is meant to run unattended, often backgrounded (see the receiving-pr-reviews
+        # skill's own gotchas on polling a backgrounded call for its own result); crashing on a
+        # single bad poll loses the whole call's result. Both handlers below record the outcome
+        # and let the loop continue toward `deadline` on its own schedule.
         try:
             current = _build_fetch_result(owner, repo, pr, deadline=deadline)
             last_poll_ok = True
-        except (subprocess.TimeoutExpired, subprocess.CalledProcessError):
-            # A failure with time still on the clock is a genuine transient `gh` failure (network
-            # hiccup, momentary GitHub error) and leaves the tail of the window unconfirmed. A
-            # failure at or past `deadline` is the window ending instead — `_gh_timeout_budget`
+        except subprocess.TimeoutExpired:
+            # A timeout is the one failure the clock can explain: `_gh_timeout_budget`
             # deliberately shrinks each call to the time left, so the last poll of a window is
-            # *expected* to be cut short — which is the same honest "no time left to check again"
-            # this command already reports when it stops before attempting a poll at all.
+            # *expected* to be cut short. At or past `deadline` that is the same honest "no time
+            # left to check again" this command reports when it stops before polling at all.
+            # With time still on the clock it is a real network stall and leaves the tail
+            # unconfirmed.
             last_poll_ok = time.monotonic() >= deadline
-            # `watch` is meant to run unattended, often backgrounded (see the receiving-pr-reviews
-            # skill's own gotchas on polling a backgrounded call for its own result); crashing
-            # here loses the whole call's result instead of just this one poll. Treat it as no
-            # fresh data this poll and let the loop continue toward `deadline` on its own schedule.
+            continue
+        except subprocess.CalledProcessError:
+            # A non-zero exit is an authentication, rate-limit, API or GraphQL error. The
+            # deadline cannot cause it and cannot excuse it, so it is a failed poll whatever the
+            # clock says — reporting `timed_out: true` off stale state here would tell a caller
+            # the PR is clean when nothing was actually checked.
+            last_poll_ok = False
             continue
         new_thread_ids = {
             thread.id

--- a/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
@@ -319,10 +319,10 @@ def test_watch_fails_loudly_when_every_poll_fails(mocker: MockerFixture) -> None
     )
     mocker.patch.object(pr_review_threads.time, "sleep")
     # 0.0 (deadline = 0.0 + 100). Iter 1: 0.0 (remaining=100 > the 10s interval) → poll raises
-    # TimeoutExpired, handler reads 10.0 (< deadline → a real failure). Iter 2: 20.0 (remaining=80)
-    # → poll raises CalledProcessError, handler reads 30.0 (< deadline). Then 105.0 → remaining
-    # negative, loop ends naturally.
-    mocker.patch.object(pr_review_threads.time, "monotonic", side_effect=[0.0, 0.0, 10.0, 20.0, 30.0, 105.0])
+    # TimeoutExpired, whose handler reads 10.0 (< deadline → a real failure). Iter 2: 20.0
+    # (remaining=80) → poll raises CalledProcessError, whose handler reads no clock at all: a
+    # non-zero exit is never excused by the deadline. Then 105.0 → remaining negative, loop ends.
+    mocker.patch.object(pr_review_threads.time, "monotonic", side_effect=[0.0, 0.0, 10.0, 20.0, 105.0])
 
     result = runner.invoke(app, ["watch", "--pr", "3208", "--interval-seconds", "10", "--timeout-seconds", "100"])
 
@@ -409,6 +409,67 @@ def test_watch_rejects_a_non_positive_interval() -> None:
     result = runner.invoke(app, ["watch", "--pr", "3208", "--interval-seconds", "0"])
 
     assert result.exit_code != 0
+
+
+def test_watch_reports_an_edit_to_an_existing_comment(mocker: MockerFixture) -> None:
+    """Editing an unresolved comment counts as new activity.
+
+    Regression coverage for the Codex finding that an edit changes neither the comment's
+    `databaseId` nor the thread's `comments_total`, so an id-and-count key saw no change.
+    """
+    before = {"databaseId": 11, "body": "first pass", "line": 1, "originalLine": 1, "author": {"login": "codex"}}
+    after = before | {"body": "edited after more thought"}
+    thread = {"id": "T1", "path": "a.py", "comments_total": 1, "comments_truncated": False}
+    baseline = FetchResult.model_validate({
+        "reviews_count": 0,
+        "reviews_with_body": [],
+        "threads_count": 1,
+        "unresolved": [thread | {"comments": [before]}],
+        "unresolved_count": 1,
+    })
+    edited = FetchResult.model_validate({
+        "reviews_count": 0,
+        "reviews_with_body": [],
+        "threads_count": 1,
+        "unresolved": [thread | {"comments": [after]}],
+        "unresolved_count": 1,
+    })
+    mocker.patch.object(pr_review_threads, "_build_fetch_result", side_effect=[baseline, edited])
+    mocker.patch.object(pr_review_threads.time, "sleep")
+
+    result = runner.invoke(app, ["watch", "--pr", "3208", "--interval-seconds", "1", "--timeout-seconds", "20"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["timed_out"] is False
+    assert data["new_thread_ids"] == ["T1"]
+
+
+def test_watch_fails_loudly_on_a_nonzero_gh_exit_at_the_deadline(mocker: MockerFixture) -> None:
+    """A non-zero `gh` exit is a failed poll whatever the clock says.
+
+    Regression coverage for the Codex finding that the deadline-aware classification was applied to
+    `CalledProcessError` as well as `TimeoutExpired`. Only a timeout can be explained by the
+    shrinking budget; an authentication, rate-limit, API or GraphQL error cannot, so reporting
+    `timed_out: true` from stale state would tell a caller the PR is clean when nothing was checked.
+    """
+    baseline = FetchResult(reviews_count=0, reviews_with_body=[], threads_count=0, unresolved=[], unresolved_count=0)
+    mocker.patch.object(
+        pr_review_threads,
+        "_build_fetch_result",
+        side_effect=[baseline, subprocess.CalledProcessError(1, ["gh"])],
+    )
+    mocker.patch.object(pr_review_threads.time, "sleep")
+    # 0.0 (deadline=100). Iter 1: 0.0 (remaining=100 > the 10s interval) -> poll raises; the handler
+    # reads 100.0, which would have excused a TimeoutExpired but must not excuse this.
+    mocker.patch.object(pr_review_threads.time, "monotonic", side_effect=[0.0, 0.0, 100.0, 100.0])
+
+    result = runner.invoke(app, ["watch", "--pr", "3208", "--interval-seconds", "10", "--timeout-seconds", "100"])
+
+    assert result.exit_code != 0
+    assert "the last of 1 poll(s) this window failed" in result.output
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(result.output)
 
 
 def test_watch_rejects_a_negative_timeout() -> None:

--- a/packages/skilllint/tests/test_hooks_json_ingest.py
+++ b/packages/skilllint/tests/test_hooks_json_ingest.py
@@ -89,9 +89,13 @@ def test_hooks_value_string_is_not_coerced(tmp_path: Path) -> None:
     assert result.message == "'hooks' value must be an object"
 
 
-@given(st.dictionaries(st.text(max_size=16), st.integers(), max_size=8))
+@given(st.dictionaries(st.text(), st.integers()))
 def test_arbitrary_hooks_mapping_round_trips(mapping: dict[str, int]) -> None:
     """Any JSON object under ``hooks`` is returned unchanged, never raising.
+
+    The strategies are unbounded: the boundary imposes no size limit of its own, so capping
+    the generated mapping would be an invented constraint and would narrow the coverage this
+    property claims. Hypothesis's own default sizing governs instead.
 
     Uses ``tempfile`` rather than the ``tmp_path`` fixture because Hypothesis
     rejects function-scoped fixtures inside ``@given``.


### PR DESCRIPTION
Three findings Codex left on #119 after it was merged, so they come as a follow-up rather than another push to that branch. All three are in code #119 introduced.

## `_thread_activity_key` missed comment edits (P2)

An edit to an existing inline comment changes neither its `databaseId` nor the thread’s `comments_total`, so `watch` could keep reporting `timed_out: true` while revised feedback sat unread.

The key now carries each comment’s body as well. Three kinds of change have to register and no single component catches all three:

| change | what moves |
|---|---|
| reply | a new `databaseId` |
| edit | only the body |
| reply past `comments(first: 100)` | only the untruncated `comments_total` |

## A non-zero `gh` exit is no longer excused by the clock (P2)

#119 classified a poll that failed at or past `deadline` as the window ending rather than an unconfirmed tail — correct for `TimeoutExpired`, since `_gh_timeout_budget` deliberately shrinks each call to the time left, but it was applied to `CalledProcessError` too.

An authentication, rate-limit, API or GraphQL error is not caused by the deadline and is not excused by it. Emitting `timed_out: true` off stale state after one would tell a caller the PR is clean when nothing was checked. The handlers are now separate; only the timeout branch consults the clock.

## Unsourced `max_size` caps in the property tests (P1)

The Hypothesis strategies in `test_hooks_json_ingest.py` carried `max_size=16` and `max_size=8` with no spec, config value or library requirement behind them — the repository’s own “No invented constraints” rule — and they narrowed the coverage the property claims. Removed; Hypothesis’s own default sizing governs, and the docstring records why the strategy is unbounded.

## Verification

- `uv run pytest` — 1254 passed, 10 skipped
- `uv run ruff format --check .` / `uv run ruff check --no-fix .` — clean
- `uv run ty check packages/` and `uv run ty check .` — clean
- `uv run prek run` (hooks that install on this host) — clean

New regression tests: `test_watch_reports_an_edit_to_an_existing_comment`, `test_watch_fails_loudly_on_a_nonzero_gh_exit_at_the_deadline`.

Note: `.agents/skills/receiving-pr-reviews/` is vendored from `github.com/jamie-bitflight/claude_skills`. All three fixes should be ported upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)