### PR TITLE
test: guard provenance-registry.json python_constant locators

### DIFF
--- a/packages/skilllint/tests/test_provenance_registry_locators.py
+++ b/packages/skilllint/tests/test_provenance_registry_locators.py
@@ -17,18 +17,28 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).parent.parent.parent.parent
 REGISTRY_PATH = REPO_ROOT / "packages" / "skilllint" / "schemas" / "provenance-registry.json"
 
+# docs/design-rule-provenance-registry.md:155 documents assertion_location.source_type
+# as "python_constant | schema_json_field | schema_json_enum".
+_KNOWN_SOURCE_TYPES = frozenset({"python_constant", "schema_json_field", "schema_json_enum"})
+
 
 def test_provenance_registry_python_constant_locators_resolve() -> None:
     """Every python_constant assertion_location must import and resolve."""
     registry = json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
     for claim_id, claim in registry["claims"].items():
         location = claim["assertion_location"]
-        if location["source_type"] != "python_constant":
+        source_type = location["source_type"]
+        assert source_type in _KNOWN_SOURCE_TYPES, f"{claim_id}: unrecognized source_type '{source_type}'"
+        if source_type != "python_constant":
             continue
-        module_name = location["file"].removeprefix("packages/").removesuffix(".py").replace("/", ".")
+        recorded_file = location["file"]
+        assert (REPO_ROOT / recorded_file).is_file(), (
+            f"{claim_id}: assertion_location.file '{recorded_file}' does not exist"
+        )
+        module_name = recorded_file.removeprefix("packages/").removesuffix(".py").replace("/", ".")
         target = importlib.import_module(module_name)
         for part in location["symbol"].split("."):
             assert hasattr(target, part), (
-                f"{claim_id}: {location['file']} has no symbol '{location['symbol']}' (missing '{part}')"
+                f"{claim_id}: {recorded_file} has no symbol '{location['symbol']}' (missing '{part}')"
             )
             target = getattr(target, part)

--- a/packages/skilllint/tests/test_provenance_registry_locators.py
+++ b/packages/skilllint/tests/test_provenance_registry_locators.py
@@ -1,0 +1,34 @@
+"""Guard against provenance-registry.json locators pointing at nothing.
+
+packages/skilllint/schemas/provenance-registry.json asserts that specific
+Python symbols back specific rule claims, but nothing loads the registry, so
+nothing checks those assertions are true. During #102's review a human found
+four locators pointing at symbols that did not exist (see #136). This test
+imports every ``python_constant`` locator's module and resolves its symbol,
+so drift is caught by CI instead of by a reviewer reading JSON.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+REGISTRY_PATH = REPO_ROOT / "packages" / "skilllint" / "schemas" / "provenance-registry.json"
+
+
+def test_provenance_registry_python_constant_locators_resolve() -> None:
+    """Every python_constant assertion_location must import and resolve."""
+    registry = json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
+    for claim_id, claim in registry["claims"].items():
+        location = claim["assertion_location"]
+        if location["source_type"] != "python_constant":
+            continue
+        module_name = location["file"].removeprefix("packages/").removesuffix(".py").replace("/", ".")
+        target = importlib.import_module(module_name)
+        for part in location["symbol"].split("."):
+            assert hasattr(target, part), (
+                f"{claim_id}: {location['file']} has no symbol '{location['symbol']}' (missing '{part}')"
+            )
+            target = getattr(target, part)


### PR DESCRIPTION
## Summary

- `packages/skilllint/schemas/provenance-registry.json` has no reader, so nothing verifies its `assertion_location` claims are true — #102's review caught four broken locators only because a human read the JSON.
- Adds `packages/skilllint/tests/test_provenance_registry_locators.py`: loads the registry, and for every claim with `assertion_location.source_type == "python_constant"`, imports `assertion_location.file` as a module and resolves `assertion_location.symbol` via `getattr` (splitting on `.` to support dotted `Class.attr` paths, since that's the exact shape #102's review found broken).

## Per-defect disposition (against `origin/main` @ `30bc6d3`, includes #102)

All four were already fixed on `main`; none required a JSON or code change from this PR.

1. **`HookValidator.VALID_EVENT_TYPES` — not a symbol.** Not live. This locator was never in `provenance-registry.json`; `opinion-catalog.json`'s `HK002.valid_event_types` entry uses a free-text `references` array (not a structured `assertion_location`/`python_constant` locator, so it's outside this test's scope), and it already correctly says `packages/skilllint/rules/hk_series.py: VALID_EVENT_TYPES` — a real module-level `frozenset` (`hk_series.py:52`), not a `HookValidator` class attribute.
2. **`HookValidator.VALID_HOOK_TYPES` — not a symbol.** Same as above: not a `provenance-registry.json` locator, and the corresponding opinion-catalog reference already points at the real module-level `VALID_HOOK_TYPES` (`hk_series.py:78`).
3. **FM007's `symbol` was prose naming line 417; the constant was at 415.** Not live. `FM007.tool_field_names.assertion_location` now has `symbol: "_AGENTSKILLS_TOOL_FIELD_NAMES"` — a clean identifier, not prose — which resolves to `fm_series.py:51`.
4. **SK004's claim pointed at a parallel `1024` literal rather than the one in force.** Not live. `SK004.max_description_length.assertion_location` now points at `packages/skilllint/limits.py::DESCRIPTION_MAX_LENGTH` (value `1024`, `limits.py:122`), and carries `x-audited: 2026-08-30`. Resolves correctly.

No JSON or code changes were needed — the registry now only declares three `python_constant` claims (`FM010.max_name_length`, `FM007.tool_field_names`, `SK004.max_description_length`), and all three resolve cleanly.

## Test plan

- [x] `uv run pytest packages/skilllint/tests/test_provenance_registry_locators.py -q --no-cov` — 1 passed
- [x] Verified the test fails red: sabotaged a plain symbol (`_MAX_NAME_LENGTH` → `_NOT_A_REAL_SYMBOL`) and a dotted symbol (`HookValidator.VALID_EVENT_TYPES` against `plugin_validator.py`) in throwaway copies of the registry — both correctly raised `AssertionError`; registry restored byte-identical afterward (confirmed via `diff`)
- [x] `uv run ruff check packages/` — All checks passed
- [x] `uv run ruff format --check packages/` — 125 files already formatted
- [x] `uv run ty check packages/` — All checks passed
- [x] `uv run ruff check .` (whole repo, per AGENTS.md) — All checks passed
- [x] `uv run pytest packages/skilllint/tests/test_provenance_registry_locators.py packages/skilllint/tests/test_provider_validation.py packages/skilllint/tests/test_rule_truth.py -q --no-cov` — 50 passed

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJeBLNA9ybmQvv5REMDkrc