### PR TITLE
fix(PL006): stop --fix from silently rewriting valid marketplace.json

### DIFF
--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -271,8 +271,8 @@ def safe_load_yaml_with_colon_fix(fm_text: str) -> tuple[dict | None, str | None
 
 
 SKILL_FRONTMATTER_SCHEMA_URL = "https://code.claude.com/docs/en/skills.md#frontmatter-reference"
-# PLUGIN_MANIFEST_SCHEMA_URL, MARKETPLACE_MANIFEST_SCHEMA_URL, and MARKETPLACE_JSON_ROOT_KEYS
-# are rule data and live in rules/pl_series.py.
+# PLUGIN_MANIFEST_SCHEMA_URL, MARKETPLACE_MANIFEST_SCHEMA_URL, MARKETPLACE_JSON_ROOT_KEYS and
+# MARKETPLACE_METADATA_RELOCATABLE_KEYS are rule data and live in rules/pl_series.py.
 
 # FILTER_TYPE_MAP and DEFAULT_SCAN_PATTERNS live in scan_runtime.py
 # and are re-imported at the top of this module.

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -80,7 +80,6 @@ from skilllint.rules.lk_series import check_lk001
 from skilllint.rules.nr_series import check_nr001, check_nr002
 from skilllint.rules.pd_series import check_pd001, check_pd002, check_pd003
 from skilllint.rules.pl_series import (
-    analyze_marketplace_root_keys,
     check_pl001,
     check_pl002,
     check_pl003,
@@ -272,8 +271,8 @@ def safe_load_yaml_with_colon_fix(fm_text: str) -> tuple[dict | None, str | None
 
 
 SKILL_FRONTMATTER_SCHEMA_URL = "https://code.claude.com/docs/en/skills.md#frontmatter-reference"
-# PLUGIN_MANIFEST_SCHEMA_URL, MARKETPLACE_MANIFEST_SCHEMA_URL, MARKETPLACE_JSON_ROOT_KEYS and
-# MARKETPLACE_METADATA_RELOCATABLE_KEYS are rule data and live in rules/pl_series.py.
+# PLUGIN_MANIFEST_SCHEMA_URL, MARKETPLACE_MANIFEST_SCHEMA_URL, and MARKETPLACE_JSON_ROOT_KEYS
+# are rule data and live in rules/pl_series.py.
 
 # FILTER_TYPE_MAP and DEFAULT_SCAN_PATTERNS live in scan_runtime.py
 # and are re-imported at the top of this module.
@@ -3056,45 +3055,6 @@ class PluginRegistrationValidator:
 # ============================================================================
 
 
-def _fix_marketplace_json_metadata_keys(plugin_dir: Path) -> list[str]:
-    """Move MARKETPLACE_METADATA_RELOCATABLE_KEYS from root into ``metadata``.
-
-    Returns:
-        One-line summaries of changes written to ``marketplace.json``.
-    """
-    mp_path = plugin_dir / ".claude-plugin" / "marketplace.json"
-    if not mp_path.exists():
-        raise NotImplementedError("No marketplace.json to fix.")
-    raw = msgspec.json.decode(mp_path.read_bytes())
-    if not isinstance(raw, dict):
-        raise NotImplementedError("marketplace.json root must be a JSON object.")
-    relocatable, unknown = analyze_marketplace_root_keys(raw)
-    if unknown:
-        raise NotImplementedError(
-            "Cannot auto-fix marketplace.json: unrecognized top-level keys must be removed manually: "
-            + ", ".join(unknown)
-        )
-    if not relocatable:
-        raise NotImplementedError("No misplaced marketplace metadata keys to move.")
-    meta_raw = raw.get("metadata")
-    if meta_raw is None:
-        metadata: dict[str, YamlValue] = {}
-    elif isinstance(meta_raw, dict):
-        metadata = dict(meta_raw)
-    else:
-        raise NotImplementedError("marketplace.json `metadata` must be an object to apply fixes.")
-    for k in relocatable:
-        metadata[k] = raw[k]
-    new_root: dict[str, YamlValue] = {}
-    for key in ("name", "owner", "plugins"):
-        if key in raw:
-            new_root[key] = raw[key]
-    new_root["metadata"] = metadata
-    out = msgspec.json.format(msgspec.json.encode(new_root), indent=2).decode() + "\n"
-    mp_path.write_text(out, encoding="utf-8")
-    return [f"Moved {', '.join(relocatable)} under metadata in {mp_path}"]
-
-
 class PluginStructureValidator:
     """Validates plugin structure using claude CLI.
 
@@ -3229,26 +3189,30 @@ class PluginStructureValidator:
         """Check if validator supports auto-fixing.
 
         Returns:
-            True (marketplace.json metadata keys can be relocated under ``metadata``).
+            False. A relocation auto-fix once moved marketplace.json root keys
+            into ``metadata``; it silently rewrote files that already carried
+            documented root-level ``description``/``version`` fields and was
+            removed rather than repaired (skilllint#114).
         """
-        return True
+        return False
 
     def fix(self, path: Path) -> list[str]:
-        """Relocate misplaced marketplace.json root keys into ``metadata``.
+        """Auto-fix marketplace.json layout issues (not supported).
 
         Args:
             path: Path to plugin directory or file within plugin
 
         Returns:
-            Human-readable descriptions of fixes applied
+            Never returns (always raises)
 
         Raises:
-            NotImplementedError: No fixable marketplace layout, or not a plugin directory
+            NotImplementedError: PL006 findings must be corrected by hand; see
+                ``can_fix`` for why the relocation auto-fix was removed.
         """
-        plugin_dir = find_plugin_dir(path)
-        if plugin_dir is None:
-            raise NotImplementedError("Not inside a plugin directory (no .claude-plugin/plugin.json).")
-        return _fix_marketplace_json_metadata_keys(plugin_dir)
+        raise NotImplementedError(
+            "marketplace.json layout issues (PL006) have no auto-fix. An earlier "
+            "relocation fix silently rewrote valid files and was removed (skilllint#114)."
+        )
 
     def _get_claude_path(self) -> str | None:
         """Get full path to claude CLI if available.

--- a/packages/skilllint/rules/pl_series.py
+++ b/packages/skilllint/rules/pl_series.py
@@ -6,10 +6,11 @@ ValidationIssue objects.
 PL001-PL006 detection lives here.  ``PluginStructureValidator`` in
 ``plugin_validator.py`` is a thin wrapper: it locates the plugin directory,
 runs the ``claude plugin validate`` subprocess, calls these rule functions,
-and packages the result into a ``ValidationResult``.  The auto-fix
-(``_fix_marketplace_json_metadata_keys``) stays on the validator side because
-it mutates files; it calls ``analyze_marketplace_root_keys`` from this module
-so detection and repair cannot drift apart.
+and packages the result into a ``ValidationResult``.  PL006 has no auto-fix:
+an earlier relocation fix (``_fix_marketplace_json_metadata_keys``) moved
+documented root fields into ``metadata`` and silently rewrote valid
+``marketplace.json`` files; it was deleted rather than repaired
+(github.com/bitflight-devops/skilllint#114).
 
 Detection sources per code — the PL family has two, and several codes use
 both:
@@ -65,16 +66,29 @@ if TYPE_CHECKING:
 PLUGIN_MANIFEST_SCHEMA_URL = "https://code.claude.com/docs/en/plugins-reference.md#plugin-manifest-schema"
 # Claude Code marketplace.json top-level keys (not plugin-manifest fields at root)
 MARKETPLACE_MANIFEST_SCHEMA_URL = "https://code.claude.com/docs/en/plugin-marketplaces.md#marketplace-schema"
-MARKETPLACE_JSON_ROOT_KEYS: frozenset[str] = frozenset({"name", "owner", "plugins", "metadata"})
-# Same field names as plugin.json metadata, but must live under `metadata` on marketplace.json
-MARKETPLACE_METADATA_RELOCATABLE_KEYS: frozenset[str] = frozenset({
-    "repository",
-    "homepage",
-    "license",
-    "author",
-    "keywords",
-    "description",
-    "version",
+# Documented marketplace.json root keys. Source: cached via
+# `skilllint docs fetch <MARKETPLACE_MANIFEST_SCHEMA_URL>` into
+# .claude/vendor/sources/plugin-marketplaces-*.md, section "Marketplace schema"
+# > "Required fields" / "Optional fields".
+#
+# Historical note (github.com/bitflight-devops/skilllint#114): a writer keyed
+# off this constant once existed (`_fix_marketplace_json_metadata_keys` in
+# plugin_validator.py) and relocated any key outside this set into `metadata`.
+# It silently rewrote valid marketplace.json files that carried documented
+# root-level `description`/`version`, so it was deleted rather than repaired.
+# Widening this set is safe only because no writer consumes it anymore --
+# do not reintroduce one keyed off this list without reading that history
+# (`git log -p` on this constant).
+MARKETPLACE_JSON_ROOT_KEYS: frozenset[str] = frozenset({
+    "name",  # Required fields -- marketplace identifier
+    "owner",  # Required fields -- maintainer info object (see "Owner fields")
+    "plugins",  # Required fields -- list of available plugins
+    "metadata",  # Optional fields -- accepts description/version for backward compatibility
+    "$schema",  # Optional fields -- JSON Schema URL, ignored by Claude Code at load time
+    "description",  # Optional fields -- brief marketplace description
+    "version",  # Optional fields -- marketplace manifest version
+    "allowCrossMarketplaceDependenciesOn",  # Optional fields -- cross-marketplace dependency allowlist
+    "renames",  # Optional fields -- former plugin name -> current name (or null) map
 })
 
 # Patterns matched against combined stdout/stderr of `claude plugin validate`.
@@ -112,23 +126,19 @@ def _make_issue(
     )
 
 
-def analyze_marketplace_root_keys(data: dict[str, YamlValue]) -> tuple[list[str], list[str]]:
-    """Classify misplaced top-level keys in marketplace.json.
+def analyze_marketplace_root_keys(data: dict[str, YamlValue]) -> list[str]:
+    """Find unrecognized top-level keys in marketplace.json.
 
-    Shared with ``_fix_marketplace_json_metadata_keys`` in ``plugin_validator.py``
-    so PL006 detection and its auto-fix always agree on which keys are in scope.
+    PL006's only detection source; there is no accompanying auto-fix (see the
+    module docstring and the comment on ``MARKETPLACE_JSON_ROOT_KEYS``).
 
     Args:
         data: Parsed marketplace.json root object.
 
     Returns:
-        (relocatable, unknown) — keys to move under ``metadata``, and keys that are not
-        recognized at root and are not auto-relocated (require manual removal or rename).
+        Sorted root keys that are not in ``MARKETPLACE_JSON_ROOT_KEYS``.
     """
-    misplaced = [k for k in data if k not in MARKETPLACE_JSON_ROOT_KEYS]
-    relocatable = sorted(k for k in misplaced if k in MARKETPLACE_METADATA_RELOCATABLE_KEYS)
-    unknown = sorted(k for k in misplaced if k not in MARKETPLACE_METADATA_RELOCATABLE_KEYS)
-    return relocatable, unknown
+    return sorted(k for k in data if k not in MARKETPLACE_JSON_ROOT_KEYS)
 
 
 def _claude_error_message(code: str, output: str) -> str:
@@ -184,7 +194,8 @@ def _claude_error_suggestion(code: str) -> str:  # noqa: PLR0911
             return "Verify all referenced files exist at specified paths"
         case "PL006":
             return (
-                "Keep only name, owner, plugins, and metadata at the marketplace root; "
+                "Keep only documented marketplace root keys (name, owner, plugins, metadata, "
+                "$schema, description, version, allowCrossMarketplaceDependenciesOn, renames); "
                 f"see {MARKETPLACE_MANIFEST_SCHEMA_URL}"
             )
         case _:
@@ -236,13 +247,14 @@ def claude_validation_failure_issue(stdout: str, stderr: str) -> ValidationIssue
             severity="error",
             message=(
                 "marketplace.json: top-level keys rejected by `claude plugin validate` "
-                "(Claude Code allows only `name`, `owner`, `plugins`, and `metadata` at the catalog root)"
+                "(see the Claude Code marketplace schema for the documented root keys)"
             ),
             code="PL006",
             suggestion=(
-                "Plugin-manifest fields such as `repository`, `homepage`, and `license` belong under "
-                f"`metadata`, not beside `plugins`. Reference: {MARKETPLACE_MANIFEST_SCHEMA_URL}. "
-                f"Run `skilllint check --fix` to relocate known fields. CLI output: {detail}"
+                "Plugin-manifest fields such as `repository`, `homepage`, and `license` are not "
+                "documented marketplace root keys and must be removed or renamed manually "
+                "(there is no auto-fix). "
+                f"Reference: {MARKETPLACE_MANIFEST_SCHEMA_URL}. CLI output: {detail}"
             ),
         )
     return _make_issue(
@@ -530,11 +542,11 @@ def check_pl005(claude_output: str) -> list[ValidationIssue]:
 def check_pl006(plugin_dir: Path) -> list[ValidationIssue]:
     """## PL006 — marketplace.json has invalid top-level keys
 
-    The ``marketplace.json`` file contains plugin-manifest fields (such as
-    ``repository``, ``homepage``, or ``license``) at the catalog root.  The
-    Claude Code marketplace schema allows only ``name``, ``owner``,
-    ``plugins``, and ``metadata`` at the top level.  All other fields must
-    be nested under ``metadata``.
+    The ``marketplace.json`` file contains a top-level key that is not part
+    of the documented Claude Code marketplace schema: ``name``, ``owner``,
+    ``plugins``, ``metadata``, ``$schema``, ``description``, ``version``,
+    ``allowCrossMarketplaceDependenciesOn``, or ``renames`` (see
+    ``MARKETPLACE_JSON_ROOT_KEYS``).
 
     Detection is **direct**: ``.claude-plugin/marketplace.json`` is read and
     decoded, then its root keys are classified by
@@ -549,24 +561,17 @@ def check_pl006(plugin_dir: Path) -> list[ValidationIssue]:
 
     Missing ``marketplace.json`` is not an issue — most plugins have none.
 
-    **Fix:** Move the offending fields under a ``metadata`` object, or run
-    the auto-fix:
-
-    ```bash
-    skilllint check --fix <plugin-dir>
-    ```
-
-    Manual correction:
+    **Fix:** There is no auto-fix (github.com/bitflight-devops/skilllint#114:
+    an earlier relocation fix silently rewrote valid files carrying documented
+    root fields).  Remove or rename the unrecognized key by hand:
 
     ```json
     {
       "name": "my-catalog",
-      "owner": "my-org",
+      "owner": {"name": "my-org"},
       "plugins": [],
       "metadata": {
-        "repository": "https://github.com/my-org/my-plugin",
-        "homepage": "https://my-org.github.io/my-plugin",
-        "license": "MIT"
+        "repository": "https://github.com/my-org/my-plugin"
       }
     }
     ```
@@ -611,29 +616,22 @@ def check_pl006(plugin_dir: Path) -> list[ValidationIssue]:
                 suggestion=f"See: {MARKETPLACE_MANIFEST_SCHEMA_URL}",
             )
         ]
-    relocatable, unknown = analyze_marketplace_root_keys(raw)
-    if not relocatable and not unknown:
+    unknown = analyze_marketplace_root_keys(raw)
+    if not unknown:
         return []
-    parts: list[str] = []
-    if relocatable:
-        parts.append("move these fields under a `metadata` object: " + ", ".join(f"`{k}`" for k in relocatable))
-    if unknown:
-        parts.append("remove or rename unrecognized top-level keys: " + ", ".join(f"`{k}`" for k in unknown))
-    detail = "; ".join(parts)
+    keys = ", ".join(f"`{k}`" for k in unknown)
     suggestion = (
-        "Claude Code marketplace manifests only allow top-level `name`, `owner`, `plugins`, "
-        f"and optional `metadata`. {detail.capitalize()}. "
+        "Claude Code marketplace manifests only allow top-level `name`, `owner`, `plugins`, `metadata`, "
+        "`$schema`, `description`, `version`, `allowCrossMarketplaceDependenciesOn`, and `renames`. "
+        f"Remove or rename: {keys}. There is no auto-fix; correct the file by hand. "
         f"Reference: {MARKETPLACE_MANIFEST_SCHEMA_URL}"
     )
-    if relocatable and not unknown:
-        suggestion += " Run `skilllint check --fix` on the plugin directory to move them automatically."
     return [
         _make_issue(
             field="marketplace.json",
             severity="error",
             message=(
-                f"marketplace.json violates the Claude Code marketplace schema: {detail}. "
-                "Plugin-manifest fields must not appear beside `plugins` at the catalog root."
+                f"marketplace.json violates the Claude Code marketplace schema: unrecognized top-level key(s): {keys}."
             ),
             code="PL006",
             suggestion=suggestion,
@@ -644,7 +642,6 @@ def check_pl006(plugin_dir: Path) -> list[ValidationIssue]:
 __all__ = [
     "MARKETPLACE_JSON_ROOT_KEYS",
     "MARKETPLACE_MANIFEST_SCHEMA_URL",
-    "MARKETPLACE_METADATA_RELOCATABLE_KEYS",
     "PLUGIN_MANIFEST_SCHEMA_URL",
     "analyze_marketplace_root_keys",
     "check_pl001",

--- a/packages/skilllint/rules/pl_series.py
+++ b/packages/skilllint/rules/pl_series.py
@@ -91,6 +91,31 @@ MARKETPLACE_JSON_ROOT_KEYS: frozenset[str] = frozenset({
     "renames",  # Optional fields -- former plugin name -> current name (or null) map
 })
 
+# Root keys with no documented marketplace-root or root-`metadata` meaning, but that
+# ARE documented fields elsewhere in the Claude Code plugin ecosystem: the plugin
+# manifest schema (PLUGIN_MANIFEST_SCHEMA_URL, "Standard fields") and, identically,
+# each marketplace `plugins[]` entry (MARKETPLACE_MANIFEST_SCHEMA_URL, "Optional plugin
+# fields" > "Standard metadata fields"). A user who puts one of these at the
+# marketplace root almost certainly meant it as real information, not garbage --
+# telling them to delete it destroys data a rename/remove instruction should not.
+#
+# The `metadata` destination is NOT itself independently spec-verified: a live
+# `claude plugin validate` v2.1.251 run puts `metadata.repository` in the exact same
+# "Unknown field ... Claude Code ignores it at load time" warning bucket as a bare
+# root `repository` -- moving it there does not silence the CLI. This set and its
+# `metadata` destination are inherited from the deleted `_fix_marketplace_json_
+# metadata_keys` / original `MARKETPLACE_METADATA_RELOCATABLE_KEYS`
+# (github.com/bitflight-devops/skilllint#114); `metadata` is suggested only as a
+# manual home strictly less destructive than deletion, not because upstream
+# recognizes these keys there (github.com/bitflight-devops/skilllint#141 review).
+MARKETPLACE_METADATA_RELOCATABLE_KEYS: frozenset[str] = frozenset({
+    "author",
+    "homepage",
+    "repository",
+    "license",
+    "keywords",
+})
+
 # Patterns matched against combined stdout/stderr of `claude plugin validate`.
 # Source: PluginStructureValidator._parse_claude_errors, plugin_validator.py.
 _CLAUDE_ERROR_PATTERNS: dict[str, str] = {
@@ -126,19 +151,27 @@ def _make_issue(
     )
 
 
-def analyze_marketplace_root_keys(data: dict[str, YamlValue]) -> list[str]:
-    """Find unrecognized top-level keys in marketplace.json.
+def analyze_marketplace_root_keys(data: dict[str, YamlValue]) -> tuple[list[str], list[str]]:
+    """Classify misplaced top-level keys in marketplace.json.
 
     PL006's only detection source; there is no accompanying auto-fix (see the
-    module docstring and the comment on ``MARKETPLACE_JSON_ROOT_KEYS``).
+    module docstring and the comment on ``MARKETPLACE_JSON_ROOT_KEYS``). The
+    classification exists purely to word the diagnostic accurately -- telling a
+    user to delete a recognized field (see ``MARKETPLACE_METADATA_RELOCATABLE_KEYS``)
+    would destroy data a move-to-``metadata`` instruction should not.
 
     Args:
         data: Parsed marketplace.json root object.
 
     Returns:
-        Sorted root keys that are not in ``MARKETPLACE_JSON_ROOT_KEYS``.
+        (relocatable, unknown) -- root keys recognized elsewhere in the plugin
+        ecosystem that a user should move under ``metadata`` by hand, and root
+        keys with no such recognition that a user should remove or rename.
     """
-    return sorted(k for k in data if k not in MARKETPLACE_JSON_ROOT_KEYS)
+    misplaced = [k for k in data if k not in MARKETPLACE_JSON_ROOT_KEYS]
+    relocatable = sorted(k for k in misplaced if k in MARKETPLACE_METADATA_RELOCATABLE_KEYS)
+    unknown = sorted(k for k in misplaced if k not in MARKETPLACE_METADATA_RELOCATABLE_KEYS)
+    return relocatable, unknown
 
 
 def _claude_error_message(code: str, output: str) -> str:
@@ -252,8 +285,9 @@ def claude_validation_failure_issue(stdout: str, stderr: str) -> ValidationIssue
             code="PL006",
             suggestion=(
                 "Plugin-manifest fields such as `repository`, `homepage`, and `license` are not "
-                "documented marketplace root keys and must be removed or renamed manually "
-                "(there is no auto-fix). "
+                "documented marketplace root keys, but they hold real data -- move them under "
+                "`metadata` by hand rather than deleting them. Remove or rename any other, "
+                "genuinely unrecognized key. There is no auto-fix. "
                 f"Reference: {MARKETPLACE_MANIFEST_SCHEMA_URL}. CLI output: {detail}"
             ),
         )
@@ -563,18 +597,27 @@ def check_pl006(plugin_dir: Path) -> list[ValidationIssue]:
 
     **Fix:** There is no auto-fix (github.com/bitflight-devops/skilllint#114:
     an earlier relocation fix silently rewrote valid files carrying documented
-    root fields).  Remove or rename the unrecognized key by hand:
+    root fields).  Correct the file by hand, and correct it two different ways
+    depending on the key (see ``MARKETPLACE_METADATA_RELOCATABLE_KEYS``):
 
-    ```json
-    {
-      "name": "my-catalog",
-      "owner": {"name": "my-org"},
-      "plugins": [],
-      "metadata": {
-        "repository": "https://github.com/my-org/my-plugin"
+    - A key recognized elsewhere in the plugin ecosystem (``author``,
+      ``homepage``, ``repository``, ``license``, ``keywords``) almost
+      certainly holds real data -- move it under ``metadata`` instead of
+      deleting it:
+
+      ```json
+      {
+        "name": "my-catalog",
+        "owner": {"name": "my-org"},
+        "plugins": [],
+        "metadata": {
+          "repository": "https://github.com/my-org/my-plugin"
+        }
       }
-    }
-    ```
+      ```
+
+    - A genuinely unrecognized key (a typo, or a field with no meaning
+      anywhere in the schema) should be removed or renamed.
 
     Args:
         plugin_dir: Plugin root directory containing ``.claude-plugin/``.
@@ -616,23 +659,29 @@ def check_pl006(plugin_dir: Path) -> list[ValidationIssue]:
                 suggestion=f"See: {MARKETPLACE_MANIFEST_SCHEMA_URL}",
             )
         ]
-    unknown = analyze_marketplace_root_keys(raw)
-    if not unknown:
+    relocatable, unknown = analyze_marketplace_root_keys(raw)
+    if not relocatable and not unknown:
         return []
-    keys = ", ".join(f"`{k}`" for k in unknown)
+    parts: list[str] = []
+    if relocatable:
+        relocatable_keys = ", ".join(f"`{k}`" for k in relocatable)
+        parts.append(f"move these under `metadata` by hand (there is no auto-fix): {relocatable_keys}")
+    if unknown:
+        unknown_keys = ", ".join(f"`{k}`" for k in unknown)
+        parts.append(f"remove or rename these unrecognized top-level keys: {unknown_keys}")
+    detail = "; ".join(parts)
     suggestion = (
         "Claude Code marketplace manifests only allow top-level `name`, `owner`, `plugins`, `metadata`, "
         "`$schema`, `description`, `version`, `allowCrossMarketplaceDependenciesOn`, and `renames`. "
-        f"Remove or rename: {keys}. There is no auto-fix; correct the file by hand. "
-        f"Reference: {MARKETPLACE_MANIFEST_SCHEMA_URL}"
+        # Capitalize only the leading letter -- str.capitalize() would lowercase a
+        # user's own camelCase key name embedded later in `detail`.
+        f"{detail[:1].upper()}{detail[1:]}. Reference: {MARKETPLACE_MANIFEST_SCHEMA_URL}"
     )
     return [
         _make_issue(
             field="marketplace.json",
             severity="error",
-            message=(
-                f"marketplace.json violates the Claude Code marketplace schema: unrecognized top-level key(s): {keys}."
-            ),
+            message=f"marketplace.json violates the Claude Code marketplace schema: {detail}.",
             code="PL006",
             suggestion=suggestion,
         )
@@ -642,6 +691,7 @@ def check_pl006(plugin_dir: Path) -> list[ValidationIssue]:
 __all__ = [
     "MARKETPLACE_JSON_ROOT_KEYS",
     "MARKETPLACE_MANIFEST_SCHEMA_URL",
+    "MARKETPLACE_METADATA_RELOCATABLE_KEYS",
     "PLUGIN_MANIFEST_SCHEMA_URL",
     "analyze_marketplace_root_keys",
     "check_pl001",

--- a/packages/skilllint/tests/test_plugin_structure_validator.py
+++ b/packages/skilllint/tests/test_plugin_structure_validator.py
@@ -6,11 +6,12 @@ Tests:
 - Error parsing from claude output
 - Subprocess security (no shell=True)
 - Timeout handling
-- marketplace.json layout (PL006) and --fix relocation
+- marketplace.json layout (PL006); no auto-fix exists (skilllint#114)
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 from typing import TYPE_CHECKING
@@ -22,23 +23,29 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
-from skilllint.plugin_validator import PL006, PluginStructureValidator
+from skilllint.plugin_validator import PL006, PluginStructureValidator, validate_single_path
 
 
 class TestPluginStructureValidatorBasic:
     """Test basic PluginStructureValidator functionality."""
 
     def test_validator_instantiation(self) -> None:
-        """Test PluginStructureValidator can be instantiated."""
+        """Test PluginStructureValidator can be instantiated.
+
+        PL006 has no auto-fix (skilllint#114): a relocation fix once moved
+        marketplace.json root keys into `metadata` and silently rewrote valid
+        files, so `can_fix()` is permanently False.
+        """
         validator = PluginStructureValidator()
         assert validator is not None
-        assert validator.can_fix() is True
+        assert validator.can_fix() is False
 
     def test_fix_raises_not_implemented(self, tmp_path: Path) -> None:
-        """Test fix() raises NotImplementedError when nothing to fix.
+        """Test fix() always raises NotImplementedError.
 
-        Tests: fix() requires a plugin dir with fixable marketplace.json
-        How: Call fix() without marketplace.json, expect NotImplementedError
+        Tests: fix() has no implementation left to invoke (skilllint#114)
+        How: Call fix() on a plugin dir, expect NotImplementedError regardless
+        of marketplace.json contents
         """
         plugin_dir = tmp_path / "test-plugin"
         plugin_dir.mkdir()
@@ -457,7 +464,7 @@ class TestEdgeCases:
 
 
 class TestMarketplaceJsonLayout:
-    """marketplace.json root keys (PL006) and --fix relocation."""
+    """marketplace.json root keys (PL006). No auto-fix exists (skilllint#114)."""
 
     def test_pl006_misplaced_keys_skips_claude_subprocess(self, mocker: MockerFixture, tmp_path: Path) -> None:
         """Disallowed marketplace root keys fail fast with PL006; do not invoke claude."""
@@ -488,33 +495,59 @@ class TestMarketplaceJsonLayout:
         assert any(e.code == PL006 for e in result.errors)
         mock_run.assert_not_called()
 
-    def test_fix_moves_relocatable_keys_to_metadata(self, tmp_path: Path) -> None:
-        """fix() moves repository, homepage, license under metadata."""
+    def test_pl006_accepts_documented_root_fields(self, tmp_path: Path) -> None:
+        """Documented root fields ($schema, description, version, renames, ...) pass PL006."""
         plugin_dir = tmp_path / "test-plugin"
         plugin_dir.mkdir()
         claude_plugin = plugin_dir / ".claude-plugin"
         claude_plugin.mkdir()
         (claude_plugin / "plugin.json").write_text('{"name": "test"}')
         marketplace = {
+            "$schema": "https://code.claude.com/docs/en/plugin-marketplaces.md#marketplace-schema",
             "name": "cat",
+            "description": "A test marketplace",
+            "version": "1.0.0",
             "owner": {"name": "x"},
             "plugins": [],
-            "repository": "https://example.com/r",
-            "homepage": "https://example.com",
-            "license": "MIT",
+            "allowCrossMarketplaceDependenciesOn": [],
+            "renames": {},
         }
         (claude_plugin / "marketplace.json").write_text(json.dumps(marketplace))
 
         validator = PluginStructureValidator()
-        fixes = validator.fix(plugin_dir)
-        assert len(fixes) == 1
-        assert "repository" in fixes[0]
+        result = validator.validate(plugin_dir)
 
-        data = json.loads((claude_plugin / "marketplace.json").read_text(encoding="utf-8"))
-        assert data["metadata"]["repository"] == "https://example.com/r"
-        assert data["metadata"]["homepage"] == "https://example.com"
-        assert data["metadata"]["license"] == "MIT"
-        assert "repository" not in data
+        assert not any(e.code == PL006 for e in result.errors)
+
+    def test_fix_leaves_documented_marketplace_json_byte_identical(self, tmp_path: Path) -> None:
+        """`--fix` must not rewrite a marketplace.json with documented root fields.
+
+        Regression test for skilllint#114: root-level `description`/`version`
+        (both documented-valid) were being silently relocated under `metadata`
+        by an auto-fix that has since been removed. Proof is byte-identity:
+        hash the file, run the `--fix` code path, hash again.
+        """
+        plugin_dir = tmp_path / "test-plugin"
+        plugin_dir.mkdir()
+        claude_plugin = plugin_dir / ".claude-plugin"
+        claude_plugin.mkdir()
+        (claude_plugin / "plugin.json").write_text('{"name": "test"}')
+        marketplace_path = claude_plugin / "marketplace.json"
+        marketplace_path.write_text(
+            json.dumps({
+                "name": "cat",
+                "description": "A test marketplace",
+                "version": "1.0.0",
+                "owner": {"name": "x"},
+                "plugins": [],
+            })
+        )
+        before = hashlib.sha256(marketplace_path.read_bytes()).hexdigest()
+
+        validate_single_path(plugin_dir, check=False, fix=True, verbose=False)
+
+        after = hashlib.sha256(marketplace_path.read_bytes()).hexdigest()
+        assert after == before
 
     def test_claude_output_marketplace_unrecognized_keys_maps_to_pl006(
         self, mocker: MockerFixture, tmp_path: Path

--- a/packages/skilllint/tests/test_plugin_structure_validator.py
+++ b/packages/skilllint/tests/test_plugin_structure_validator.py
@@ -495,6 +495,48 @@ class TestMarketplaceJsonLayout:
         assert any(e.code == PL006 for e in result.errors)
         mock_run.assert_not_called()
 
+    def test_pl006_recognized_field_suggests_move_to_metadata(self, tmp_path: Path) -> None:
+        """A root key recognized elsewhere in the plugin ecosystem (`repository`) gets
+        move-under-`metadata` guidance, not delete-it guidance (skilllint#141 review:
+        the old auto-fix moved this field, so telling users to delete it loses data).
+        """
+        plugin_dir = tmp_path / "test-plugin"
+        plugin_dir.mkdir()
+        claude_plugin = plugin_dir / ".claude-plugin"
+        claude_plugin.mkdir()
+        (claude_plugin / "plugin.json").write_text('{"name": "test"}')
+        marketplace = {"name": "cat", "owner": {"name": "x"}, "plugins": [], "repository": "https://example.com/r"}
+        (claude_plugin / "marketplace.json").write_text(json.dumps(marketplace))
+
+        validator = PluginStructureValidator()
+        result = validator.validate(plugin_dir)
+
+        pl006 = [e for e in result.errors if e.code == PL006]
+        assert len(pl006) == 1
+        assert pl006[0].suggestion is not None
+        assert "metadata" in pl006[0].suggestion
+        assert "`repository`" in pl006[0].suggestion
+        assert "remove or rename these unrecognized" not in pl006[0].suggestion
+
+    def test_pl006_unknown_key_still_suggests_remove_or_rename(self, tmp_path: Path) -> None:
+        """A genuinely unrecognized root key (a typo) still gets remove-or-rename guidance."""
+        plugin_dir = tmp_path / "test-plugin"
+        plugin_dir.mkdir()
+        claude_plugin = plugin_dir / ".claude-plugin"
+        claude_plugin.mkdir()
+        (claude_plugin / "plugin.json").write_text('{"name": "test"}')
+        marketplace = {"name": "cat", "owner": {"name": "x"}, "plugins": [], "pluginz": "typo"}
+        (claude_plugin / "marketplace.json").write_text(json.dumps(marketplace))
+
+        validator = PluginStructureValidator()
+        result = validator.validate(plugin_dir)
+
+        pl006 = [e for e in result.errors if e.code == PL006]
+        assert len(pl006) == 1
+        assert pl006[0].suggestion is not None
+        assert "remove or rename" in pl006[0].suggestion.lower()
+        assert "`pluginz`" in pl006[0].suggestion
+
     def test_pl006_accepts_documented_root_fields(self, tmp_path: Path) -> None:
         """Documented root fields ($schema, description, version, renames, ...) pass PL006."""
         plugin_dir = tmp_path / "test-plugin"

--- a/plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md
+++ b/plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md
@@ -97,7 +97,7 @@ Validate `plugin.json` structure.
 | PL003 | error | no | Required `name` field is missing from `plugin.json` |
 | PL004 | error | no | A path in `plugin.json` does not start with `./` |
 | PL005 | error | no | Referenced file in `plugin.json` does not exist |
-| PL006 | error | yes | `marketplace.json` root keys violate [Claude Code marketplace schema](https://code.claude.com/docs/en/plugin-marketplaces.md#marketplace-schema); known plugin-manifest fields can move under `metadata` (`skilllint check --fix`) |
+| PL006 | error | no | `marketplace.json` has an unrecognized top-level key; see [Claude Code marketplace schema](https://code.claude.com/docs/en/plugin-marketplaces.md#marketplace-schema) for the documented root keys (no auto-fix; skilllint#114) |
 
 ---
 


### PR DESCRIPTION
## Summary

- `skilllint check --fix` was silently relocating documented root-level `description`/`version` fields in `marketplace.json` into `metadata`, with no output and exit 0.
- Deletes the relocation auto-fix first (`_fix_marketplace_json_metadata_keys`, `PluginStructureValidator.fix`/`can_fix`) — its `NotImplementedError` guard on unknown keys was the only thing stopping the hardcoded `("name", "owner", "plugins")` rebuild from dropping `$schema`/`renames`/other unlisted keys, so this had to go before the allowlist widened.
- Widens `MARKETPLACE_JSON_ROOT_KEYS` to the full documented marketplace root-key set (`name`, `owner`, `plugins`, `metadata`, `$schema`, `description`, `version`, `allowCrossMarketplaceDependenciesOn`, `renames`), each key commented with its source in the vendored marketplace-schema doc.
- `PluginStructureValidator.can_fix()` now returns `False`, so the amplifier (`--fix` invoking every validator's `fix()` regardless of whether it reported anything) can no longer run this writer on files PL006 never flagged.
- Severity stays `error` per the issue's explicit constraint.

## RED (before the fix)

```
FAILED packages/skilllint/tests/test_plugin_structure_validator.py::TestMarketplaceJsonLayout::test_pl006_accepts_documented_root_fields - assert not True
FAILED packages/skilllint/tests/test_plugin_structure_validator.py::TestMarketplaceJsonLayout::test_fix_leaves_documented_marketplace_json_byte_identical - AssertionError: assert '3563d855d431a6e73f21cdd288ff199d36c94f89fc2a343ebc86749088eec9c0' == '023c5c43e39aa74192af6d9f03d84437296023409bcd922c92566149d2dc729c'
  - 023c5c43e39aa74192af6d9f03d84437296023409bcd922c92566149d2dc729c
  + 3563d855d431a6e73f21cdd288ff199d36c94f89fc2a343ebc86749088eec9c0
========================= 2 failed, 2 passed in 7.45s ==========================
```

Also (before the fix): `TestPluginStructureValidatorBasic::test_validator_instantiation` — `assert True is False`, `can_fix()` returning `True`.

## GREEN (after the fix)

```
21 passed in 6.89s
```

Full suite: `1223 passed, 10 skipped in 80.39s`, coverage 85.40% (threshold 60%).

## Live-CLI verification (real files, temp dirs, `--fix` runs in place)

```
$ sha256sum marketplace.json   # documented root fields ($schema, description, version, owner, plugins, renames)
62216ae6...

$ skilllint check <dir>        # exit 0, no PL006
$ skilllint check --fix <dir>  # exit 0

$ sha256sum marketplace.json   # unchanged
62216ae6...

$ skilllint check <dir-with-unknown-key "pluginz">
[PL006] marketplace.json: ... unrecognized top-level key(s): `pluginz`.
  → ... Remove or rename: `pluginz`. There is no auto-fix; correct the file by hand. ...
exit 1
```

## Test plan

- [x] RED test committed and shown failing before the fix (above)
- [x] `uv run pytest packages/skilllint/tests/ -q` — 1223 passed, 10 skipped
- [x] `uv run ruff check . && uv run ruff format --check .` — all checks passed (whole repo)
- [x] `uv run ty check packages/` — all checks passed
- [x] Byte-identity round-trip proof via real CLI in a temp dir (`--fix` is in-place, never run on a fixture in the repo)

## Findings that contradict the issue / design brief (reported, not acted on)

- **Severity**: running `claude plugin validate` v2.1.251 (>= the v2.1.239 floor the design brief asked for) against a marketplace.json with a genuinely unrecognized root key (`pluginz`) returns a **warning**, not an error:
  ```
  ⚠ Found 1 warning:
    ❯ pluginz: Unknown field 'pluginz' — did you mean 'plugins'? Claude Code ignores unrecognized fields at load time, so this field has no effect.
  ```
  This contradicts the design brief's claim (based on a captured stderr fixture in this repo's own tests) that the marketplace validator emits an *error* for unrecognized root keys, and contradicts my own severity-resolution experiment's "if it warns, downgrade" branch. Per the issue's explicit "do not relitigate" constraint on severity, PL006 stays `error` in this PR; flagging it here per the task's request to report contradictions rather than silently reconciling them.
- **`owner` field format**: the same live `claude plugin validate` run also rejected `"owner": "my-org"` (a bare string) with `owner: Invalid input: expected object, received string` — the schema requires `owner` to be an object (`{"name": ..., "email"?: ..., "url"?: ...}`). The pre-existing `check_pl006` docstring example used a bare string for `owner`; fixed that example inline as part of this diff, but this is a separate, pre-existing documentation gap unrelated to PL006's root-key allowlist.
- No `CHANGELOG.md` exists in this repo, so the design brief's suggested changelog entry for already-mangled files (pointing at `git log -p` on `MARKETPLACE_JSON_ROOT_KEYS`) is documented instead as an inline comment on the constant itself, not a new file.

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJeBLNA9ybmQvv5REMDkrc