### PR TITLE
fix(ty): move script-mode extra-paths config into the script itself

### DIFF
--- a/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
@@ -7,6 +7,16 @@
 #   "pytest",
 #   "pytest-mock",
 # ]
+# [tool.ty.environment]
+# # ty 0.0.75 treats any file carrying PEP 723 inline script metadata as an
+# # isolated single-file script and ignores [tool.ty.environment].extra-paths
+# # from pyproject.toml entirely, so this table (not the one in pyproject.toml)
+# # is what ty actually reads for this file. Relative extra-paths declared here
+# # resolve relative to this script's own directory, not the invocation cwd or
+# # the project root -- "." is therefore this directory, which is where the
+# # sibling pr_review_threads module lives. Verified empirically; see the ty
+# # skill-mode finding recorded alongside this fix.
+# extra-paths = ["."]
 # ///
 """Tests for pr_review_threads.py.
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -119,13 +119,16 @@ repos:
 
       - id: ty
         name: ty check
-        # --extra-search-path: ty treats any file carrying PEP 723 inline script
-        # metadata (both receiving-pr-reviews scripts do, for `uv run --script`) as
-        # an isolated single-file script and ignores [tool.ty.environment].extra-paths
-        # from pyproject.toml for it entirely (verified against ty 0.0.75). The CLI
-        # flag is honored even in that mode, so it's the only way the hook resolves
-        # test_pr_review_threads.py's sibling `import pr_review_threads`.
-        entry: uv run -q ty check --extra-search-path .agents/skills/receiving-pr-reviews/scripts
+        # ty treats any file carrying PEP 723 inline script metadata (both
+        # receiving-pr-reviews scripts, for `uv run --script`) as an isolated
+        # single-file script and ignores [tool.ty.environment].extra-paths from
+        # pyproject.toml for it entirely (verified against ty 0.0.75). Rather than
+        # a caller-specific CLI flag here, the sibling-module search path for
+        # test_pr_review_threads.py's `import pr_review_threads` is declared in
+        # that script's own [tool.ty.environment] inline-metadata table, so it
+        # travels with the file for every caller (this hook, direct `ty check`,
+        # CI) instead of only this one.
+        entry: uv run -q ty check
         language: system
         types: [python]
         pass_filenames: true


### PR DESCRIPTION
## Summary

PR #154 fixed ty's inability to resolve `test_pr_review_threads.py`'s sibling `import pr_review_threads` by adding `--extra-search-path` to the prek `ty` hook's `entry:` line. That fix is caller-specific: it only applies when ty runs through that one hook. A direct `uv run ty check .agents/skills/receiving-pr-reviews/scripts/` still failed, and every other caller (CI, editors, a fresh contributor) would have to re-know the flag.

## The empirical question

PEP 723 script metadata is TOML and accepts arbitrary `[tool.*]` tables. Does ty read its configuration from the script's own inline metadata when it's in script mode?

**Yes** — verified against `ty 0.0.75`. A `[tool.ty.environment]` table placed inside the `# /// script ... # ///` block is honored, and relative `extra-paths` declared there resolve **relative to the script's own directory**, not the invocation cwd and not the project root.

Proof of the resolution base: setting `extra-paths = [".agents/skills/receiving-pr-reviews/scripts"]` (the repo-root-relative form) inside the script's own metadata produced:

```
error[invalid-script-metadata]: .../scripts/.agents/skills/receiving-pr-reviews/scripts does not point to a directory
```

— ty appended that value onto the script's own directory, proving the base is `dirname(script)`. `extra-paths = ["."]` is therefore correct: it *is* the sibling directory `pr_review_threads.py` lives in.

## What changed

- Moved the `[tool.ty.environment]` / `extra-paths = ["."]` config into `test_pr_review_threads.py`'s own PEP 723 metadata block, with a comment recording the finding (base = script's own directory, not cwd/project root).
- Removed `--extra-search-path` from the prek `ty` hook's `entry:` line — the hook now runs plain `uv run -q ty check`, since the config now travels with the file.
- Updated the explanatory comment on the hook to point at the new location.

## Verification

```
uv run ty check .agents/skills/receiving-pr-reviews/scripts/   → All checks passed!  (no flag)
uv run ty check packages/                                       → All checks passed!
uv run ruff check . && uv run ruff format --check .             → All checks passed! / 398 files already formatted
uv run pytest -q                                                 → 1379 passed, 10 skipped, 86.37% coverage
uv run pytest .agents/skills/receiving-pr-reviews/scripts/ -q   → 17 passed (coverage-gate FAIL is pre-existing,
                                                                     unrelated to this change -- reproduced on
                                                                     unmodified main too)
uv run --script .agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
                                                                  → resolves deps, imports pr_review_threads, exit 0
prek run --files .pre-commit-config.yaml .agents/skills/receiving-pr-reviews/scripts/*.py
                                                                  → all hooks passed, including "ty check"
```

ty version tested: `ty 0.0.75 (a553dcc1a 2026-08-26)` — this finding is version-specific per the original PR #154 finding; re-verify if ty's script-mode handling changes.

## Test plan

- [x] `uv run ty check .agents/skills/receiving-pr-reviews/scripts/` passes without any flag
- [x] `uv run ty check packages/` unaffected
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run pytest -q` — full suite green
- [x] `uv run --script .../test_pr_review_threads.py` still resolves and runs
- [x] `uv run pytest .../scripts/ -q` still collects and passes all 17 tests
- [x] `prek run` on the hook config and the two scripts — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJeBLNA9ybmQvv5REMDkrc