### PR TITLE
docs(ty): correct two inaccurate claims in the extra-paths comments

### DIFF
--- a/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
@@ -14,8 +14,8 @@
 # # is what ty actually reads for this file. Relative extra-paths declared here
 # # resolve relative to this script's own directory, not the invocation cwd or
 # # the project root -- "." is therefore this directory, which is where the
-# # sibling pr_review_threads module lives. Verified empirically; see the ty
-# # skill-mode finding recorded alongside this fix.
+# # sibling pr_review_threads module lives. Verified empirically against ty
+# # 0.0.75, from both the repo root and a nested cwd.
 # extra-paths = ["."]
 # ///
 """Tests for pr_review_threads.py.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -126,8 +126,9 @@ repos:
         # a caller-specific CLI flag here, the sibling-module search path for
         # test_pr_review_threads.py's `import pr_review_threads` is declared in
         # that script's own [tool.ty.environment] inline-metadata table, so it
-        # travels with the file for every caller (this hook, direct `ty check`,
-        # CI) instead of only this one.
+        # travels with the file for every caller (this hook, or any direct
+        # `ty check`) instead of only this one. CI type-checks `packages/`
+        # only, so this hook is the sole gate for these scripts.
         entry: uv run -q ty check
         language: system
         types: [python]


### PR DESCRIPTION
Found by `/code-review --effort high` on #157. Comment-only; no behaviour change.

## Two false claims

**`.pre-commit-config.yaml`** — the comment said the inline table makes the search path travel "for every caller (this hook, direct `ty check`, CI)". **CI never checks these files.** `.github/workflows/test.yml:103` runs `uv run ty check packages/ --output-format github`, and `.agents/` is outside that path. A maintainer reading this could drop or weaken the pre-commit hook believing CI still verifies the sibling import — when that hook is the *only* gate on these two scripts. Now scoped to "this hook, or any direct `ty check`", and states plainly that CI type-checks `packages/` only.

**`test_pr_review_threads.py`** — "see the ty skill-mode finding recorded alongside this fix" is a dangling reference. `.hermes/` contains no such finding and a repo-wide grep for `skill-mode` returns nothing. Replaced with the reproducible check ("Verified empirically against ty 0.0.75, from both the repo root and a nested cwd"), which is what a reader actually needs when a future ty release changes this behaviour.

## Verification the review performed on #157 itself

The behavioural claim was confirmed empirically, not taken on trust: stripping the inline table reproduces the original `unresolved-import` failure; `"."` resolves against the script directory from both repo root and a nested cwd; the removed flag served nothing else; multi-file invocation (what `pass_filenames: true` actually does) still honours per-file inline metadata; and `uv run --script` still exits 0.

No correctness bugs found in #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJeBLNA9ybmQvv5REMDkrc