### PR TITLE
refactor: drop the leading underscore from GitHubResponseModel

### DIFF
--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py
@@ -92,7 +92,7 @@ mutation($threadId: ID!) {
 """
 
 
-class _GitHubResponseModel(BaseModel):
+class GitHubResponseModel(BaseModel):
     """Base for every model that ingests a raw GitHub GraphQL response.
 
     `strict=True` so a producer-shape mismatch — GitHub or `gh` returning a string where the
@@ -105,11 +105,11 @@ class _GitHubResponseModel(BaseModel):
     model_config = ConfigDict(strict=True)
 
 
-class _Author(_GitHubResponseModel):
+class _Author(GitHubResponseModel):
     login: str
 
 
-class CommentNode(_GitHubResponseModel):
+class CommentNode(GitHubResponseModel):
     """A single review comment, in the shape GitHub's GraphQL API returns it.
 
     Field names mirror the GraphQL schema exactly (`databaseId`, not
@@ -127,31 +127,31 @@ class CommentNode(_GitHubResponseModel):
     author: _Author | None
 
 
-class _PageInfo(_GitHubResponseModel):
+class _PageInfo(GitHubResponseModel):
     hasNextPage: bool
 
 
-class _CommentsConnection(_GitHubResponseModel):
+class _CommentsConnection(GitHubResponseModel):
     totalCount: int
     pageInfo: _PageInfo
     nodes: list[CommentNode]
 
 
-class _ReviewThreadNode(_GitHubResponseModel):
+class _ReviewThreadNode(GitHubResponseModel):
     id: str
     isResolved: bool
     path: str
     comments: _CommentsConnection
 
 
-class _ReviewThreadsConnection(_GitHubResponseModel):
+class _ReviewThreadsConnection(GitHubResponseModel):
     """One page's `reviewThreads` connection, nested inside `_PullRequestThreadsPage`."""
 
     totalCount: int
     nodes: list[_ReviewThreadNode]
 
 
-class _PullRequestThreadsPage(_GitHubResponseModel):
+class _PullRequestThreadsPage(GitHubResponseModel):
     """One page of `_UNRESOLVED_THREADS_QUERY`, already unwrapped from `data.repository.pullRequest`.
 
     `_fetch_pages` pulls this dict straight out of each slurped page by subscripting the fixed
@@ -173,7 +173,7 @@ class _PullRequestThreadsPage(_GitHubResponseModel):
     reviewThreads: _ReviewThreadsConnection
 
 
-class ReviewNode(_GitHubResponseModel):
+class ReviewNode(GitHubResponseModel):
     """A top-level review submission, in the shape GitHub's GraphQL API returns it.
 
     Distinct from a review *comment* (`CommentNode`): this is the review object itself —
@@ -192,7 +192,7 @@ class ReviewNode(_GitHubResponseModel):
     body: str
 
 
-class _ReviewsConnection(_GitHubResponseModel):
+class _ReviewsConnection(GitHubResponseModel):
     """One page's `reviews` connection, already unwrapped — see `_PullRequestThreadsPage`."""
 
     totalCount: int


### PR DESCRIPTION
Rename only, no behaviour change. 10 references, one file.

`GitHubResponseModel` is the declared ingress boundary — every model built from raw `gh` output inherits it to get `ConfigDict(strict=True)`. That makes it the name a reader looks for to answer "what is validated strictly, and why", so marking it module-private hid the one thing in the file that documents the contract.

## Verification

```
uv run pytest .agents/skills/receiving-pr-reviews/scripts/ -q  → 21 passed
uv run ruff check .                                            → All checks passed!
uv run ty check .agents/skills/receiving-pr-reviews/scripts/   → All checks passed!
```

(The scoped pytest run also prints a coverage failure — that is the known `fail_under=60` gate reacting to a narrow run, not a test failure.)

## Noted, not changed here

The file is inconsistent about this: `Author`, `PageInfo`, `CommentsConnection`, `ReviewThreadNode`, `ReviewThreadsConnection`, `PullRequestThreadsPage` and `ReviewsConnection` still carry underscores, while `CommentNode`, `ReviewNode`, `UnresolvedThread`, `Reviewability`, `FetchResult` and `WatchResult` do not — with no evident rule separating them. Left alone deliberately: this file is currently converging with the `claude_skills` copy across three PRs, and a broad rename mid-flight would add another variant to reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJeBLNA9ybmQvv5REMDkrc