### PR TITLE
docs: adopt universal working rules in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,12 +63,7 @@ Before declaring success, confirm:
 
 ## Changing dependencies
 
-```sh
-uv remove --group <group> <pkg>...
-uv add    --group <group> <pkg>...
-```
-
-Never hand-edit a version string.
+`uv remove` then `uv add` — never hand-edit a version string.
 
 ## Running skilllint during development
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,15 @@ Before declaring success, confirm:
 
 # Project-specific: skilllint
 
+## Writing output
+
+Write in ASD-STE100 structure: one instruction per sentence, active voice,
+present tense, no synonyms for the same concept. Keep procedural sentences to
+20 words and descriptive sentences to 25.
+
+Put the bottom line first. After each task, state what the user can act on
+before you give the supporting detail.
+
 ## Verifying a change
 
 ```sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,16 @@ Before declaring success, confirm:
 
 # Project-specific: skilllint
 
+## Verifying a change
+
+```sh
+uv run prek run --all-files   # ruff, ruff-format, ty, actionlint, markdownlint, shellcheck, ...
+uv run pytest                 # not a prek hook
+```
+
+Run these, not the individual tools — the hook set is the gate, and a subset of
+it passing is not evidence.
+
 ## Changing dependencies
 
 `uv remove` then `uv add` — never hand-edit a version string.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ uv remove --group <group> <pkg>...
 uv add    --group <group> <pkg>...
 ```
 
-Never hand-edit a version string; never `uv tool install`.
+Never hand-edit a version string.
 
 ## Running skilllint during development
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,25 +63,17 @@ Before declaring success, confirm:
 
 ## Changing dependencies
 
-Dependencies change through `uv` only. Never hand-edit a version string in
-`pyproject.toml`, and never `uv tool install`.
-
-To move a pinned tool to its current release, remove and re-add it so the
-floor and the lockfile move together in one step:
-
-```
-uv remove --group dev ruff ty
-uv add --group dev ruff ty
-prek autoupdate
+```sh
+uv remove --group <group> <pkg>...
+uv add    --group <group> <pkg>...   # floors and uv.lock move together
 ```
 
-`uv add` updates `uv.lock`, which must be committed with the change. Editing
-the version string by hand leaves the lockfile behind, and any CI step running
-`uv run --locked` fails on the mismatch rather than on anything real.
+Never hand-edit a version string; never `uv tool install`. `uv add` regenerates
+`uv.lock` and a hand edit does not, so CI's `uv run --locked` then fails on the
+mismatch rather than on anything real. Commit the lock with the change.
 
-A toolchain bump and the fixes it requires belong in the same pull request.
-A bump alone reds CI; compatibility fixes alone address a failure the repo
-cannot reproduce, so neither half is reviewable without the other.
+A toolchain bump ships with the fixes it requires — the bump alone reds CI, the
+fixes alone address a failure the repo cannot reproduce.
 
 ## Running skilllint during development
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,11 +69,7 @@ uv add    --group <group> <pkg>...   # floors and uv.lock move together
 ```
 
 Never hand-edit a version string; never `uv tool install`. `uv add` regenerates
-`uv.lock` and a hand edit does not, so CI's `uv run --locked` then fails on the
-mismatch rather than on anything real. Commit the lock with the change.
-
-A toolchain bump ships with the fixes it requires — the bump alone reds CI, the
-fixes alone address a failure the repo cannot reproduce.
+`uv.lock`; a hand edit does not. Commit the lock with the change.
 
 ## Running skilllint during development
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,11 +65,10 @@ Before declaring success, confirm:
 
 ```sh
 uv remove --group <group> <pkg>...
-uv add    --group <group> <pkg>...   # floors and uv.lock move together
+uv add    --group <group> <pkg>...
 ```
 
-Never hand-edit a version string; never `uv tool install`. `uv add` regenerates
-`uv.lock`; a hand edit does not. Commit the lock with the change.
+Never hand-edit a version string; never `uv tool install`.
 
 ## Running skilllint during development
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,66 @@
 # AGENTS.md
 
+Universal working rules for repository tasks. Project-specific instructions override these where they conflict.
+
+## Before Editing
+
+1. **Define success.** State the required outcome, acceptance criteria, preserved behavior, constraints, and non-goals.
+2. **Establish the boundary.** Identify owners, consumers, inputs, outputs, dependencies, interfaces, and affected environments.
+3. **Separate evidence from inference.** Current code, tests, file placement, wiring, counts, versions, and other observed state describe what exists; they do not prove intended ownership, durable design intent, or the correct change location.
+4. **Surface consequential uncertainty.** State assumptions and competing interpretations. Resolve uncertainty that could change scope, compatibility, ownership, or architecture before editing.
+5. **Choose the smallest viable change.** Prefer existing abstractions and established dependencies over new code. Compare viable approaches by evidence, blast radius, trade-offs, maintenance cost, and reversibility.
+
+## Claims and Evidence
+
+The rules above govern changes. These govern statements — in a reply, an issue, a commit message, a code comment, or a brief handed to a subagent.
+
+- **A claim about the world needs a command.** Do not state a fact about this codebase, another repository, a library, or a tool's behavior unless something run in the current session established it. Where no check was run, mark the claim unverified in the same sentence.
+- **A subagent's characterization is not evidence.** It is a claim with the same standing as your own. Check the artifact it describes before repeating it or building on it.
+- **Contradicting evidence stops the work.** An empty grep, a truncated capture, a result that disagrees with the plan already in flight — resolve it before continuing. These are the cheapest signals available and the easiest to walk past.
+- **An unverified claim that reaches an issue, a commit, or a comment becomes a premise.** Later readers cannot distinguish it from a checked fact and will cite it as one. Correcting the claim later does not retract the work built on it — revisit that too.
+
+## While Editing
+
+- Change only what is required for the defined outcome.
+- Do not refactor, reformat, or clean unrelated code.
+- Match established repository conventions.
+- Remove only artifacts made obsolete by your change.
+- Do not add speculative flexibility, abstractions, fallbacks, or features.
+- Reassess the plan when evidence contradicts an assumption.
+
+## Verification
+
+- Validate each affected boundary independently.
+- Do not generalize success from one test, harness, environment, or consumer.
+- Prefer tests that demonstrate required behavior over implementation-detail tests.
+- Verify relevant regression, compatibility, static-analysis, and runtime checks.
+- Every changed line should be traceable to the requested outcome.
+
+## Before Commit
+
+Review the complete diff against this `AGENTS.md` before committing.
+
+- Confirm every changed line is required by the defined outcome and complies with the repository instructions above.
+- Identify every new constraint, threshold, default, prohibition, workflow step, fallback, abstraction, or policy introduced by the diff. Keep it only when its existence is justified by the user requirement, repository evidence, an applicable external contract, or measured behavior; otherwise remove or demote it to an explicitly labeled hypothesis or experiment parameter.
+- Remove unrelated cleanup, duplicated guidance, speculative flexibility, and implementation detail that does not earn its maintenance cost.
+- Re-run affected verification when the diff review changes behavior.
+
+Do not commit while a known unjustified constraint or instruction-compliance violation remains in the diff.
+
+## Completion
+
+Before declaring success, confirm:
+
+- acceptance criteria are demonstrated;
+- required checks pass;
+- no known affected boundary remains unverified;
+- no unnecessary changes remain in the diff;
+- remaining uncertainty, limitations, or follow-up work is stated explicitly.
+
+---
+
+# Project-specific: skilllint
+
 ## Running skilllint during development
 
 Always invoke the CLI via `uv run skilllint …` — it resolves to the editable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,28 @@ Before declaring success, confirm:
 
 # Project-specific: skilllint
 
+## Changing dependencies
+
+Dependencies change through `uv` only. Never hand-edit a version string in
+`pyproject.toml`, and never `uv tool install`.
+
+To move a pinned tool to its current release, remove and re-add it so the
+floor and the lockfile move together in one step:
+
+```
+uv remove --group dev ruff ty
+uv add --group dev ruff ty
+prek autoupdate
+```
+
+`uv add` updates `uv.lock`, which must be committed with the change. Editing
+the version string by hand leaves the lockfile behind, and any CI step running
+`uv run --locked` fails on the mismatch rather than on anything real.
+
+A toolchain bump and the fixes it requires belong in the same pull request.
+A bump alone reds CI; compatibility fixes alone address a failure the repo
+cannot reproduce, so neither half is reviewable without the other.
+
 ## Running skilllint during development
 
 Always invoke the CLI via `uv run skilllint …` — it resolves to the editable


### PR DESCRIPTION
Adds a universal ruleset above the existing project-specific guidance. **No existing section was removed** — all 198 lines of skilllint-specific content are preserved below a divider, consistent with the new preamble stating project instructions override.

## New sections

Before Editing · While Editing · Verification · Before Commit · Completion — supplied by the repo owner.

Plus one addition, **Claims and Evidence**, covering a gap in the source ruleset.

## Why that addition

The rest of the document governs **diffs**. This session's costliest failures were **assertions that never touched a file**:

- A comment in `pyproject.toml` claimed the `.agents/skills` directory was "vendored from claude_skills and maintained there". No sync existed. Two first-party files went unlinted for months and a real `D417` sat in one of them. The claim was then cited into #135 and #143, which made it read as corroborated — when both were downstream of the same unchecked sentence.
- Three claims about PyGithub were stated as fact and were wrong on inspection: that it is REST-only (it has 129 `graphql` references and four PR mutations), that its absence from `pyproject.toml` was evidence (the script is PEP 723 — deps live in its own block), and that switching would cost `gh`'s "ambient auth" (`gh` authenticates from `GITHUB_TOKEN`, which PyGithub reads too). Each made a viable design option look unavailable.

Existing rule 3, "Separate evidence from inference", guards against over-reading observed state. This guards against asserting with none — the inverse failure, and the one that actually occurred.

## Verification

```
prek run markdownlint-cli2 --files AGENTS.md → Passed
```

Section count 16; all twelve project-specific headings intact (`Running skilllint during development` through `Diagnostic discipline`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJeBLNA9ybmQvv5REMDkrc