### PR TITLE
ci: pin every uv invocation to the lockfile

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -49,7 +49,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Extract benchmark fixtures
         run: |
@@ -147,7 +147,7 @@ jobs:
 
       - name: Reinstall dependencies for base ref
         if: steps.base_ref_io.outputs.ref != ''
-        run: uv sync
+        run: uv sync --locked
 
       - name: Drop OS page cache (base ref)
         if: steps.base_ref_io.outputs.ref != ''
@@ -228,7 +228,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Drop OS page cache (CPU benchmark)
         run: echo 3 | sudo tee /proc/sys/vm/drop_caches || true
@@ -298,7 +298,7 @@ jobs:
 
       - name: Reinstall dependencies for base ref
         if: steps.base_ref_cpu.outputs.ref != ''
-        run: uv sync
+        run: uv sync --locked
 
       - name: Drop OS page cache (base CPU benchmark)
         if: steps.base_ref_cpu.outputs.ref != ''
@@ -361,7 +361,7 @@ jobs:
 
       - run: uv python install 3.12
 
-      - run: uv sync
+      - run: uv sync --locked
 
       - name: Generate benchmark comment
         run: |
@@ -401,7 +401,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Extract benchmark fixture
         run: unzip tests/fixtures/benchmark-plugin-1000-skills.zip -d /tmp/bench-plugin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,10 +33,10 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Run prek hooks on all files
-        run: uv run prek run --all-files
+        run: uv run --locked prek run --all-files
 
   format:
     name: Code Formatting
@@ -54,10 +54,10 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Check code formatting
-        run: uv run ruff format --check
+        run: uv run --locked ruff format --check
 
   lint:
     name: Code Linting
@@ -75,10 +75,10 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Lint code
-        run: uv run ruff check --output-format=github
+        run: uv run --locked ruff check --output-format=github
         continue-on-error: false
 
   typecheck-ty:
@@ -97,10 +97,10 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Type check with ty
-        run: uv run ty check packages/ --output-format github
+        run: uv run --locked ty check packages/ --output-format github
 
   test:
     name: Tests (Python ${{ matrix.python-version }})
@@ -122,14 +122,14 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Run tests with coverage
         timeout-minutes: 10
-        run: uv run pytest --cov=packages/skilllint --cov-report=xml --cov-report=term
+        run: uv run --locked pytest --cov=packages/skilllint --cov-report=xml --cov-report=term
 
       - name: Assert rules completeness
-        run: uv run python scripts/assert_rules_completeness.py
+        run: uv run --locked python scripts/assert_rules_completeness.py
 
       - name: Upload coverage XML
         uses: actions/upload-artifact@v7.0.1


### PR DESCRIPTION
All 17 `uv run` / `uv sync` calls in `test.yml` and `benchmark.yml` ran without `--locked`, so CI could resolve something other than `uv.lock` and lockfile drift produced no signal.

For comparison, `claude_skills` uses `--locked` on 19 invocations, including its blocking `ty check .` and ruff jobs.

## Verification

```
uv lock --check                 → Resolved 56 packages (in sync, so the flag is safe to add now)
prek run actionlint             → Passed
grep uv run|uv sync, unpinned   → none
```

11 invocations in `test.yml`, 6 in `benchmark.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJeBLNA9ybmQvv5REMDkrc