### PR TITLE
chore: add scripts/uvu so a dependency update is one call

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ it passing is not evidence.
 
 ## Changing dependencies
 
-`uv remove` then `uv add` — never hand-edit a version string.
+`scripts/uvu <uv-add-args> <package>...` — never hand-edit a version string.
 
 ## Running skilllint during development
 

--- a/scripts/uvu
+++ b/scripts/uvu
@@ -4,6 +4,9 @@
 #
 #   scripts/uvu --group dev ruff ty
 set -eu
-[ $# -gt 0 ] || { echo "usage: $0 [uv-add-args] <package>..." >&2; exit 2; }
+[ $# -gt 0 ] || {
+    echo "usage: $0 [uv-add-args] <package>..." >&2
+    exit 2
+}
 uv remove "$@"
 uv add "$@"

--- a/scripts/uvu
+++ b/scripts/uvu
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+# Update dependencies to their current release: remove, then re-add, so the
+# pyproject floor and uv.lock move together. Args are passed to both calls.
+#
+#   scripts/uvu --group dev ruff ty
+set -eu
+[ $# -gt 0 ] || { echo "usage: $0 [uv-add-args] <package>..." >&2; exit 2; }
+uv remove "$@"
+uv add "$@"


### PR DESCRIPTION
Remove-then-add is two commands, so an agent spends two turns on it. `scripts/uvu` makes it one:

```sh
scripts/uvu --group dev ruff ty
```

Args pass through to both calls. `set -eu`, and it exits 2 with a usage line on no args.

Also puts the rule somewhere **executable** rather than only somewhere readable — a script cannot drift from itself, a sentence describing it can. AGENTS.md now points at the command instead of restating it.

Note this PR carries the AGENTS.md line from #161; if #161 lands first this rebases to a one-line change.

## Verification

```
prek run shellcheck --files scripts/uvu      → Passed
prek run markdownlint-cli2 --files AGENTS.md → Passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJeBLNA9ybmQvv5REMDkrc