### PR TITLE
docs: remove the output rule, superseded by a plugin hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,15 +61,6 @@ Before declaring success, confirm:
 
 # Project-specific: skilllint
 
-## Writing output
-
-Write in ASD-STE100 structure: one instruction per sentence, active voice,
-present tense, no synonyms for the same concept. Keep procedural sentences to
-20 words and descriptive sentences to 25.
-
-Put the bottom line first. After each task, state what the user can act on
-before you give the supporting detail.
-
 ## Verifying a change
 
 ```sh


### PR DESCRIPTION
Removes the `## Writing output` section added in #161.

The rule now ships as a hook in a plugin. The hook applies to every repo. A copy in this repo applies to one repo and drifts from the hook.

Single source of truth. No behaviour change here.

## Verification

```
prek run markdownlint-cli2 --files AGENTS.md → Passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJeBLNA9ybmQvv5REMDkrc