### PR TITLE
docs: state the gh --repo flag as host-conditional

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,8 @@ global copy goes stale and shadows the source you're editing.
    gh api repos/{owner}/{repo}/pulls/<pr-number>/comments
    ```
 
+4. **Check that `gh` resolves the repository** — `gh repo view --json nameWithOwner`. Some hosts route the git remote through a local proxy (`127.0.0.1`), which `gh` cannot recognise as GitHub. Pass `--repo <owner>/<repo>` explicitly on those hosts. It is not needed where the command above returns the right answer.
+
 ## Benchmark workflow
 
 - Triggers on: PRs targeting `main`, or `workflow_dispatch` (once the file is on `main`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ global copy goes stale and shadows the source you're editing.
    gh api repos/{owner}/{repo}/pulls/<pr-number>/comments
    ```
 
-4. **Check that `gh` resolves the repository** — `gh repo view --json nameWithOwner`. Some hosts route the git remote through a local proxy (`127.0.0.1`), which `gh` cannot recognise as GitHub. Pass `--repo <owner>/<repo>` explicitly on those hosts. It is not needed where the command above returns the right answer.
+4. **`gh` auto-detects the repo unless a `127.0.0.1` proxy hides it — check with `gh repo view`, then pass `--repo`.**
 
 ## Benchmark workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,20 +83,18 @@ global copy goes stale and shadows the source you're editing.
 
 ## After pushing to a branch
 
-1. **Check CI pipelines** — use `gh run list --repo bitflight-devops/skilllint --limit 10` to see recent runs. If the benchmark or test workflow hasn't triggered (e.g. the workflow file only exists on the branch, not yet on `main`), open a PR to get it running.
+1. **Check CI pipelines** — use `gh run list --limit 10` to see recent runs. If the benchmark or test workflow hasn't triggered (e.g. the workflow file only exists on the branch, not yet on `main`), open a PR to get it running.
 
 2. **Trigger workflow_dispatch manually** — only works if the workflow exists on the default branch. Use:
    ```
-   gh workflow run <workflow-file>.yml --repo bitflight-devops/skilllint --ref <branch>
+   gh workflow run <workflow-file>.yml --ref <branch>
    ```
 
 3. **Check for PR review comments** — after a PR is open, poll with:
    ```
-   gh pr checks --repo bitflight-devops/skilllint <pr-number>
-   gh api repos/bitflight-devops/skilllint/pulls/<pr-number>/comments
+   gh pr checks <pr-number>
+   gh api repos/{owner}/{repo}/pulls/<pr-number>/comments
    ```
-
-4. **Always use `--repo bitflight-devops/skilllint`** with `gh` commands — the git remote points to a local proxy (`127.0.0.1`) which `gh` cannot auto-detect as GitHub.
 
 ## Benchmark workflow
 


### PR DESCRIPTION
The rule said to **always** pass `--repo bitflight-devops/skilllint`, because the git remote points at a `127.0.0.1` proxy that `gh` cannot detect.

That proxy exists on **some hosts only**. On this host:

```
$ git remote get-url origin
git@github.com:bitflight-devops/skilllint.git

$ gh repo view --json nameWithOwner --jq .nameWithOwner
bitflight-devops/skilllint

$ git config --get-regexp "url|remote" | grep -c 127.0.0.1
0
```

So the flag is redundant here and required elsewhere. Neither "always" nor "never" is correct.

## Change

The rule now names the check that decides:

> **Check that `gh` resolves the repository** — `gh repo view --json nameWithOwner`. Some hosts route the git remote through a local proxy (`127.0.0.1`), which `gh` cannot recognise as GitHub. Pass `--repo <owner>/<repo>` explicitly on those hosts. It is not needed where the command above returns the right answer.

The three example commands drop the hardcoded `--repo`, since the rule above now governs when to add it.

## Note on my first version of this PR

I tested `gh` on one host, found detection worked, and deleted the rule as false. That generalised a single-host result into a universal claim — the same error the rule itself contained, pointed the other way. The rule is host-specific, so the fix is a condition, not a deletion.

## Verification

```
prek run markdownlint-cli2 --files AGENTS.md → Passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJeBLNA9ybmQvv5REMDkrc