### PR TITLE
feat(receiving-pr-reviews): add a checks command for PR CI status

### DIFF
--- a/.agents/skills/receiving-pr-reviews/SKILL.md
+++ b/.agents/skills/receiving-pr-reviews/SKILL.md
@@ -19,6 +19,14 @@ description: Work through every unresolved review thread on a PR to completion �
 
 2. For each unresolved thread or unresponded review: read it, validate the claim locally, assess against the change goal and repository instructions.
 3. Implement, commit, and push a fix only when it improves the product — push before replying, so the SHA named in the reply is inspectable and resolving the thread never outruns what is actually on the remote.
+
+   Confirm that push's CI with `checks` rather than hand-writing a polling loop:
+
+   ```bash
+   uv run ./.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py checks --pr <N> [--timeout-seconds 270]
+   ```
+
+   `status` is `passed`, `failed`, `pending`, or `none` — `pending` is not green. Without `--timeout-seconds` this is one snapshot; with it, the command sleeps `--interval-seconds` between polls and returns as soon as the verdict settles. Read the whole object rather than extracting one field: `none` alongside a non-empty `reviewability.blockers` means checks *cannot* start — GitHub runs no workflow on a draft or conflicting PR — which is what an apparently stalled PR usually is, and no amount of waiting will change it.
 4. Reply on that thread with the disposition — conclusion, evidence, commit SHA, or why no change was warranted:
 
    ```bash
@@ -44,10 +52,11 @@ description: Work through every unresolved review thread on a PR to completion �
 
 <gotchas>
 
-- `fetch`/`watch`/`reply` detect this checkout's own repository via `gh repo view`; pass `--github owner/repo` to target a different one, or when detection fails.
+- `fetch`/`watch`/`checks`/`reply` detect this checkout's own repository via `gh repo view`; pass `--github owner/repo` to target a different one, or when detection fails.
 - `--gh-timeout-seconds` is unbounded by default on `fetch` and `watch`. One snapshot is seven sequential `gh api` calls, some of them paginating a large PR, so choose a bound against your own network. Inside `watch` it applies to the first fetch only; each poll is bounded by the time left before `--timeout-seconds`.
 - `reply`'s `--comment-id` is a comment's `databaseId` and `resolve`'s `--thread-id` is a thread's `id` — both come straight from step 1's output. When a thread already has more than one comment, pass the *first* comment's `databaseId`: `comments` is in creation order, and GitHub rejects a reply targeted at another reply.
 - A `reviews_with_body`/`unresponded_reviews` entry is not a thread, so it cannot be replied to or resolved through this script. Address it and post the response on the PR itself per step 6.
+- `checks` grades only the checks GitHub marks required for the PR whenever any is (`required_only: true`), so a red non-required check never reads as `failed`. `contexts_truncated: true` means the head commit reports more than one page of checks and the verdict is incomplete.
 - `watch`'s defaults — a 90-second poll interval, a 270-second timeout per call — stay under the 5-minute prompt-cache TTL floor that applies in every Claude billing mode. Cover a longer window by looping calls, not by raising `--timeout-seconds`.
 - `watch` stops polling once less than one interval remains before its deadline, so its last observed state can be up to one interval stale. The next call's own first fetch covers that stretch.
 - Every check inside `watch` is a fresh `gh` snapshot with no baseline, so a call whose first fetch already has outstanding work returns immediately. Calling `watch` right after a `resolve` or a plain `fetch` is safe.

--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_gh.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_gh.py
@@ -3,8 +3,10 @@
 Every function here shells out to `gh` (GitHub CLI) rather than talking to the GitHub API
 directly, relying on `gh`'s own authentication. `build_fetch_result` is the one function the CLI
 layer (`pr_review_threads.py`) calls directly — it composes the seven independent `gh` calls below
-into one `FetchResult` snapshot, fresh every time it runs. `run_gh` is exported too: the CLI
-layer's `reply`/`resolve` commands call it directly for their own single-shot `gh` invocations.
+into one `FetchResult` snapshot, fresh every time it runs. `build_checks_result` is its
+counterpart for CI state — two `gh` calls composed into one `ChecksResult`. `run_gh` is
+exported too: the CLI layer's `reply`/`resolve` commands call it directly for their own
+single-shot `gh` invocations.
 """
 
 from __future__ import annotations
@@ -15,8 +17,13 @@ import shutil
 import subprocess
 import time
 from datetime import datetime
+from typing import Literal
 
 from pr_review_models import (
+    CheckContext,
+    CheckContextsConnection,
+    CheckRunContext,
+    ChecksResult,
     FetchResult,
     ForcePushEvent,
     IssueComment,
@@ -106,6 +113,44 @@ query($o: String!, $r: String!, $pr: Int!) {
 }
 """
 
+# `isRequired(pullRequestNumber:)` is GitHub's own server-side answer to "does this check gate
+# merging this PR", computed from whatever branch protection rule or ruleset covers the base
+# branch. Asking for it here is what keeps `_verdict` free of a hardcoded check-name list, and it
+# needs none of the admin permission the branch-protection REST endpoint requires. Verified against
+# this repository's own API (2026-08-31): PR #166 returns `isRequired: true` for exactly the six
+# contexts this repo's branch protection requires, and `false` for the eight it does not.
+#
+# `statusCheckRollup` is null on a head commit with no checks at all, and `contexts` is a
+# connection — `_fetch_check_contexts` surfaces its `hasNextPage` as `contexts_truncated` rather
+# than paginating, so a caller is told when a verdict is incomplete instead of being handed a
+# silently partial one.
+_CHECKS_QUERY = """
+query($o: String!, $r: String!, $pr: Int!) {
+  repository(owner: $o, name: $r) {
+    pullRequest(number: $pr) {
+      commits(last: 1) {
+        nodes {
+          commit {
+            statusCheckRollup {
+              contexts(first: 100) {
+                totalCount
+                pageInfo { hasNextPage }
+                nodes {
+                  __typename
+                  ... on CheckRun { name status conclusion isRequired(pullRequestNumber: $pr) }
+                  ... on StatusContext { context state isRequired(pullRequestNumber: $pr) }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
 # Absolute `gh` path, resolved once at import time — ruff's start-process-with-partial-path (S607)
 # requires a resolved path rather than a bare command name. Falls back to the literal "gh" when
 # `shutil.which` can't find it, so a missing binary still surfaces as a normal FileNotFoundError
@@ -119,6 +164,18 @@ _GH = shutil.which("gh") or "gh"
 # This repository has no source for that number (CLAUDE.md, "No invented constraints"), so `fetch`
 # and `watch` expose `--gh-timeout-seconds` instead, unbounded by default, and `watch` additionally
 # bounds each *poll* by its own `--timeout-seconds` deadline, which the caller chose.
+
+# GitHub: "Required status checks must have a `successful`, `skipped`, or `neutral` status before
+# collaborators can make changes to a protected branch."
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches
+# (cached under .claude/vendor/sources/, accessed 2026-08-31). That one sentence is the only source
+# for both sets below: a check run's conclusion satisfies a required check iff it is one of these
+# three, and a commit status satisfies it iff it is `SUCCESS`.
+_PASSING_CHECK_CONCLUSIONS = frozenset({"SUCCESS", "SKIPPED", "NEUTRAL"})
+# A commit status that has not reached a verdict yet, as opposed to one that reached a failing one:
+# `EXPECTED` is a status GitHub knows to expect but has not received, `PENDING` one still running.
+_UNFINISHED_STATUS_STATES = frozenset({"EXPECTED", "PENDING"})
+
 
 _ISSUE_COMMENT_ADAPTER: TypeAdapter[list[IssueComment]] = TypeAdapter(list[IssueComment])
 _REACTION_ADAPTER: TypeAdapter[list[Reaction]] = TypeAdapter(list[Reaction])
@@ -678,5 +735,124 @@ def build_fetch_result(
         unresolved=unresolved,
         unresolved_count=len(unresolved),
         codex_approved=codex_approved,
+        reviewability=_reviewability(head_state),
+    )
+
+
+def _fetch_check_contexts(
+    owner: str, repo: str, pr: int, *, gh_timeout: float | None
+) -> CheckContextsConnection | None:
+    """Fetch the checks reported against the PR's head commit, or `None` if it has none at all.
+
+    Reads the head commit through GraphQL's `commits(last: 1)` for the same reason
+    `_fetch_head_state` does — the REST commits endpoint's documented 250-commit cap makes its last
+    element unreliable as "the current head" — and asks GitHub itself which of the resulting checks
+    are required for this PR (see `_CHECKS_QUERY`).
+
+    Args:
+        owner: Repository owner login.
+        repo: Repository name.
+        pr: Pull request number.
+        gh_timeout: Seconds to bound the underlying `gh` call to, or `None` for no bound — see
+            `run_gh`.
+
+    Returns:
+        The head commit's `statusCheckRollup.contexts` connection, or `None` when the commit has no
+        rollup at all — GitHub returns a null `statusCheckRollup` when nothing has ever reported a
+        check or status against it.
+
+    Raises:
+        IndexError: the PR has no commits at all — see `_fetch_head_state`.
+    """
+    raw = run_gh(
+        ["api", "graphql", "-f", f"query={_CHECKS_QUERY}", "-f", f"o={owner}", "-f", f"r={repo}", "-F", f"pr={pr}"],
+        timeout=gh_timeout,
+    )
+    commit = json.loads(raw)["data"]["repository"]["pullRequest"]["commits"]["nodes"][-1]["commit"]
+    rollup = commit["statusCheckRollup"]
+    if rollup is None:
+        return None
+    return CheckContextsConnection.model_validate(rollup["contexts"])
+
+
+def _check_outcome(context: CheckContext) -> Literal["passed", "failed", "pending"]:
+    """Grade one check against the rule GitHub applies to a required check.
+
+    A check run is graded in two steps because GitHub splits its lifecycle from its verdict: it is
+    unfinished until `status` reaches `COMPLETED`, and only then does its `conclusion` decide.
+    A `COMPLETED` run whose conclusion is not one of the three GitHub accepts — including a value
+    this script has never seen — is `"failed"`: it has finished, and it does not satisfy the rule.
+    A commit status carries a single `state` instead, so it is graded in one step.
+
+    Args:
+        context: One check run or commit status from the head commit's rollup.
+
+    Returns:
+        `"passed"`, `"failed"`, or `"pending"` — see `_PASSING_CHECK_CONCLUSIONS` for the source of
+        the passing set.
+    """
+    if isinstance(context, CheckRunContext):
+        if context.status != "COMPLETED":
+            return "pending"
+        return "passed" if context.conclusion in _PASSING_CHECK_CONCLUSIONS else "failed"
+    if context.state in _UNFINISHED_STATUS_STATES:
+        return "pending"
+    return "passed" if context.state == "SUCCESS" else "failed"
+
+
+def build_checks_result(
+    owner: str, repo: str, pr: int, *, deadline: float | None = None, gh_timeout: float | None = None
+) -> ChecksResult:
+    """Fetch and assemble one PR's CI verdict, plus whether the PR can run checks at all.
+
+    Makes two `gh` calls, each bounded by `gh_timeout_budget(deadline)` exactly as
+    `build_fetch_result`'s seven are: the head commit's check rollup, and the PR head state that
+    `_reviewability` reads. The second call exists so a `none` verdict is never ambiguous — a draft
+    or conflicting PR gets no workflow runs, and the same `reviewability` object `fetch` already
+    reports says so rather than a second, parallel signal invented here.
+
+    Only the checks GitHub marks required for this PR are graded when any is marked required: a
+    failing check that does not gate the merge is not a failure of the PR. When none is marked
+    required there is no smaller set to grade, so every reported check is, and `required_only` says
+    which of the two happened.
+
+    Args:
+        owner: Repository owner login.
+        repo: Repository name.
+        pr: Pull request number.
+        deadline: A `time.monotonic()` timestamp the caller wants both `gh` invocations to respect
+            — see `gh_timeout_budget`. `None` means no deadline.
+        gh_timeout: Per-call bound applied when `deadline` is `None`; `None` means no bound.
+
+    Returns:
+        The verdict over the graded checks, the names of any that failed or are still running, and
+        the PR's reviewability.
+    """
+    contexts_connection = _fetch_check_contexts(owner, repo, pr, gh_timeout=gh_timeout_budget(deadline, gh_timeout))
+    head_state = _fetch_head_state(owner, repo, pr, gh_timeout=gh_timeout_budget(deadline, gh_timeout))
+    reported = contexts_connection.nodes if contexts_connection is not None else []
+    required = [context for context in reported if context.isRequired]
+    graded = required or reported
+    # A list of pairs rather than a dict: two workflows may report a check of the same name, and a
+    # dict would silently drop one of them from the verdict.
+    outcomes = [(context.name, _check_outcome(context)) for context in graded]
+    failed = [name for name, outcome in outcomes if outcome == "failed"]
+    pending = [name for name, outcome in outcomes if outcome == "pending"]
+    status: Literal["passed", "failed", "pending", "none"]
+    if not graded:
+        status = "none"
+    elif failed:
+        status = "failed"
+    elif pending:
+        status = "pending"
+    else:
+        status = "passed"
+    return ChecksResult(
+        status=status,
+        required_only=bool(required),
+        total=len(graded),
+        failed=failed,
+        pending=pending,
+        contexts_truncated=contexts_connection is not None and contexts_connection.pageInfo.hasNextPage,
         reviewability=_reviewability(head_state),
     )

--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_models.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_models.py
@@ -11,12 +11,16 @@ documents and what a caller already parses.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
 __all__ = [
     "Author",
+    "CheckContext",
+    "CheckContextsConnection",
+    "CheckRunContext",
+    "ChecksResult",
     "CommentNode",
     "FetchResult",
     "ForcePushEvent",
@@ -28,6 +32,7 @@ __all__ = [
     "RepoIdentity",
     "ReviewNode",
     "Reviewability",
+    "StatusContextNode",
     "UnresolvedThread",
     "WatchResult",
 ]
@@ -262,6 +267,71 @@ class PullRequestHeadState(GitHubResponseModel):
     commits: HeadCommitsConnection
 
 
+class CheckRunContext(GitHubResponseModel):
+    """One CI check run on the PR's head commit, in the shape GitHub's GraphQL API returns it.
+
+    A check run is what a GitHub Actions job (or any Checks API app) reports. `status` is the
+    run's lifecycle state — `COMPLETED` once it has finished, and one of `REQUESTED`, `QUEUED`,
+    `WAITING`, `PENDING`, `IN_PROGRESS` while it has not — and `conclusion` is its verdict, `None`
+    until it completes. Both stay plain strings rather than enums for the same reason
+    `PullRequestHeadState.mergeable` does: GitHub can add a state at any time, and an unrecognized
+    one must reach the caller as data instead of failing validation.
+
+    `isRequired` is GitHub's own answer to "does this check gate merging this PR", computed
+    server-side from whatever branch protection rule or ruleset applies to the PR's base branch —
+    so `pr_review_gh._verdict` never needs a hardcoded list of check names, and never needs the
+    admin-only branch-protection REST endpoint.
+
+    `typename` carries GraphQL's `__typename` under a Python-legal name so
+    `pr_review_gh._check_outcome` can tell a check run from a commit status: the two live in the
+    same `contexts` connection and grade differently.
+    """
+
+    typename: Literal["CheckRun"] = Field(alias="__typename")
+    name: str
+    status: str
+    conclusion: str | None
+    isRequired: bool
+
+
+class StatusContextNode(GitHubResponseModel):
+    """One commit status on the PR's head commit, in the shape GitHub's GraphQL API returns it.
+
+    The older, pre-Checks-API mechanism: an external service posts a state against the commit.
+    `state` is one of `EXPECTED`, `PENDING`, `SUCCESS`, `ERROR`, `FAILURE` — a single field, with
+    no separate lifecycle/verdict split, which is exactly why this is a separate model from
+    `CheckRunContext` rather than the same one with optional fields.
+
+    `name` is populated from GraphQL's `context` field (the status's own name) so both members of
+    the `CheckContext` union expose the one field `ChecksResult` reports.
+    """
+
+    typename: Literal["StatusContext"] = Field(alias="__typename")
+    name: str = Field(alias="context")
+    state: str
+    isRequired: bool
+
+
+# Discriminated on `__typename` rather than tried in order: GitHub tells us which shape each node
+# is, so a node that matches neither must fail validation loudly instead of silently landing in
+# whichever member happens to accept it.
+CheckContext = Annotated[CheckRunContext | StatusContextNode, Field(discriminator="typename")]
+
+
+class CheckContextsConnection(GitHubResponseModel):
+    """The `statusCheckRollup.contexts` connection on the PR's head commit.
+
+    `pr_review_gh._fetch_check_contexts` subscripts the fixed
+    `data.repository.pullRequest.commits.nodes[-1].commit.statusCheckRollup` path out of the
+    response before validating this — same boundary handling, and same rationale, as
+    `ReviewThreadsConnection`.
+    """
+
+    totalCount: int
+    pageInfo: PageInfo
+    nodes: list[CheckContext]
+
+
 class Reviewability(BaseModel):
     """Whether this PR is in a state where reviews can happen at all.
 
@@ -290,6 +360,46 @@ class Reviewability(BaseModel):
     mergeable: str
     merge_state_status: str
     blockers: list[str]
+
+
+class ChecksResult(BaseModel):
+    """Result of `checks`: one verdict on the PR's CI, plus why it may not be able to run at all.
+
+    `status` is the whole answer, and the four values are deliberately distinct so a pending run
+    and a green run can never be confused:
+
+    - `passed` — every check the verdict covers has finished successfully.
+    - `failed` — at least one has finished unsuccessfully. Terminal until a new push.
+    - `pending` — none failed, but at least one has not finished yet.
+    - `none` — the PR's head commit reports no checks at all.
+
+    `required_only` says what "the checks the verdict covers" means: `True` when at least one check
+    is marked required for this PR (only those are graded — a failing non-required check never
+    blocks the merge, so it must not read as `failed`), `False` when none is, in which case every
+    reported check is graded because there is no smaller set to grade.
+
+    `failed` and `pending` name the graded checks in those states; a passing check is a name the
+    caller does not need, so `total` reports how many the verdict covers instead of listing them.
+    `contexts_truncated` is `True` when the head commit reports more than one page of checks and
+    this verdict is therefore incomplete — the same honest-truncation signal as
+    `UnresolvedThread.comments_truncated`.
+
+    `reviewability` is the *same* `Reviewability` `FetchResult` carries, derived from the same
+    helper: a draft or conflicting PR gets no workflow runs at all, so `none` there means "checks
+    cannot start", not "this repository has no CI". Read `status` and `reviewability.blockers`
+    together — that pairing is the entire reason both are in one small object.
+
+    Assembled by `pr_review_gh.build_checks_result` from already-validated values, so it is an
+    output shape rather than an ingress one — see `GitHubResponseModel`.
+    """
+
+    status: Literal["passed", "failed", "pending", "none"]
+    required_only: bool
+    total: int
+    failed: list[str]
+    pending: list[str]
+    contexts_truncated: bool
+    reviewability: Reviewability
 
 
 class ForcePushEvent(GitHubResponseModel):

--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py
@@ -16,15 +16,17 @@ unresponded review (auto-paginated, filtered before it reaches an agent's contex
 review comment, and resolving a review thread. Every operation shells out to `gh` (GitHub CLI)
 rather than talking to the GitHub API directly, relying on `gh`'s own authentication. A fourth
 command, `watch`, blocks this process on an internal polling loop so a caller never needs a
-separate resumption mechanism to re-check a PR later.
+separate resumption mechanism to re-check a PR later. A fifth, `checks`, reports whether the PR's
+required CI checks have passed, and can wait on the same bounded schedule for a still-running one.
 
-`fetch`'s I/O and `FetchResult`/`WatchResult` assembly live in `pr_review_gh.py`; the data
-contracts live in `pr_review_models.py`. This module is the CLI presentation layer: it parses
-arguments, drives `watch`'s polling loop, and prints results.
+`fetch`'s and `checks`'s I/O and their `FetchResult`/`WatchResult`/`ChecksResult` assembly live in
+`pr_review_gh.py`; the data contracts live in `pr_review_models.py`. This module is the CLI
+presentation layer: it parses arguments, drives the polling loops, and prints results.
 
 Usage:
     uv run pr_review_threads.py fetch --pr 3208
     uv run pr_review_threads.py watch --pr 3208
+    uv run pr_review_threads.py checks --pr 3208
     uv run pr_review_threads.py reply --pr 3208 --comment-id 123456 --body "Fixed in abc123."
     uv run pr_review_threads.py resolve --thread-id PRRT_kwDO...
 """
@@ -36,11 +38,11 @@ import time
 from typing import Annotated
 
 import typer
-from pr_review_gh import RESOLVE_THREAD_MUTATION, build_fetch_result, detect_repo_identity, run_gh
+from pr_review_gh import RESOLVE_THREAD_MUTATION, build_checks_result, build_fetch_result, detect_repo_identity, run_gh
 from pr_review_models import WatchResult
 from pydantic import ValidationError
 
-app = typer.Typer(help="GitHub PR review-thread operations (fetch/watch/reply/resolve) via gh.")
+app = typer.Typer(help="GitHub PR review operations (fetch/watch/checks/reply/resolve) via gh.")
 
 # Anthropic's raw prompt-cache API defaults to a 5-minute TTL in every billing mode; a 1-hour TTL
 # is opt-in only (https://platform.claude.com/docs/en/build-with-claude/prompt-caching, accessed
@@ -49,7 +51,8 @@ app = typer.Typer(help="GitHub PR review-thread operations (fetch/watch/reply/re
 # sessions stay on the 5-minute default throughout. Sizing `watch`'s defaults to the 5-minute
 # floor keeps one call's turn cached under every billing mode. Cover a longer watching window by
 # looping `watch` calls (receiving-pr-reviews SKILL.md step 7), not by raising `--timeout-seconds`.
-_DEFAULT_WATCH_INTERVAL_SECONDS = 90
+# `checks` polls on the same interval, for the same reason.
+_DEFAULT_POLL_INTERVAL_SECONDS = 90
 # 270 is deliberately under the 5-minute prompt-cache TTL (every Claude billing mode) — a
 # watch call blocking this long still returns before the caller's context falls out of cache.
 _DEFAULT_WATCH_TIMEOUT_SECONDS = 270
@@ -170,7 +173,7 @@ def watch(
     github: GithubOption = None,
     interval_seconds: Annotated[
         int, typer.Option(min=1, help="Seconds to sleep between polls. Must be positive.")
-    ] = _DEFAULT_WATCH_INTERVAL_SECONDS,
+    ] = _DEFAULT_POLL_INTERVAL_SECONDS,
     timeout_seconds: Annotated[
         int,
         typer.Option(
@@ -289,6 +292,72 @@ def watch(
         raise typer.Exit(code=1)
     result = WatchResult(timed_out=not current.has_outstanding_work(), state=current)
     typer.echo(result.model_dump_json())
+
+
+@app.command()
+def checks(
+    pr: Annotated[int, typer.Option(help="Pull request number.")],
+    *,
+    github: GithubOption = None,
+    interval_seconds: Annotated[
+        int, typer.Option(min=1, help="Seconds to sleep between polls while checks are still running.")
+    ] = _DEFAULT_POLL_INTERVAL_SECONDS,
+    timeout_seconds: Annotated[
+        int,
+        typer.Option(
+            min=0,
+            help="Wait up to this many seconds for a still-running result to settle. 0 (the default) takes one snapshot.",
+        ),
+    ] = 0,
+    gh_timeout_seconds: Annotated[
+        float | None,
+        typer.Option(
+            min=0,
+            help="Seconds to bound the first `gh` calls to. Unbounded by default; polls are bounded by --timeout-seconds.",
+        ),
+    ] = None,
+) -> None:
+    """Report whether the PR's required CI checks have passed, optionally waiting for them.
+
+    Prints compact JSON: `status` (`passed` / `failed` / `pending` / `none`), `required_only`,
+    `total`, the `failed` and `pending` check names, `contexts_truncated`, and the same
+    `reviewability` object `fetch` reports. Read the whole thing — it is small on purpose. In
+    particular `status: "none"` on a PR with `reviewability.blockers` means checks *cannot start*
+    (GitHub runs no workflows on a draft or a conflicting PR), not that the repository has no CI,
+    which is otherwise indistinguishable and is why a PR can appear to stall indefinitely.
+
+    With `--timeout-seconds 0` (the default) this is a single snapshot. Given a timeout it polls,
+    sleeping `--interval-seconds` between attempts, and returns as soon as `status` is anything but
+    `pending` — or when the window ends, in which case `status` is still `pending` and the caller
+    can issue another call. A `pending` result and a `passed` result are distinct values, so a
+    caller can never mistake one for the other.
+
+    Waiting stops immediately when `reviewability.blockers` is non-empty: no check can start, so
+    there is nothing for the window to observe. Use `--interval-seconds`/`--timeout-seconds` rather
+    than an ad-hoc shell polling loop — an unpaced loop exhausts GitHub's secondary rate limit long
+    before the primary quota shows any sign of it.
+
+    A `gh` failure mid-wait propagates and exits non-zero rather than being retried inline: unlike
+    `watch`, this command is short and re-running it costs one snapshot.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    owner, repo = _owner_repo(github, gh_timeout=gh_timeout_seconds)
+    # The first fetch is not deadline-bounded, for the same reason as `watch`'s: with
+    # `--timeout-seconds 0` the deadline is already spent, and bounding it would starve the
+    # documented immediate snapshot into a `TimeoutExpired`.
+    current = build_checks_result(owner, repo, pr, gh_timeout=gh_timeout_seconds)
+    while current.status == "pending" and not current.reviewability.blockers:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        time.sleep(min(interval_seconds, remaining))
+        if remaining <= interval_seconds:
+            # That sleep consumed the rest of the window; `gh_timeout_budget` would bound the poll
+            # to nothing. Report the last state fetched rather than spawn a doomed call — same
+            # cutoff, and same rationale, as `watch`.
+            break
+        current = build_checks_result(owner, repo, pr, deadline=deadline, gh_timeout=gh_timeout_seconds)
+    typer.echo(current.model_dump_json())
 
 
 @app.command()

--- a/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
@@ -44,7 +44,7 @@ import json
 import subprocess
 import time
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import pr_review_gh
 import pr_review_models
@@ -1324,3 +1324,308 @@ def test_watch_fails_loudly_when_only_final_poll_fails(mocker: MockerFixture) ->
     assert "the last of 2 poll(s) this window failed" in result.output
     with pytest.raises(json.JSONDecodeError):
         json.loads(result.output)
+
+
+# --- checks: verdict over the checks GitHub marks required ------------------------------------
+
+
+def _check_run(
+    name: str, *, status: str = "COMPLETED", conclusion: str | None = "SUCCESS", required: bool = True
+) -> dict[str, object]:
+    """One `CheckRun` node as the checks query returns it."""
+    return {"__typename": "CheckRun", "name": name, "status": status, "conclusion": conclusion, "isRequired": required}
+
+
+def _status_context(name: str, *, state: str = "SUCCESS", required: bool = True) -> dict[str, object]:
+    """One `StatusContext` node as the checks query returns it — `context`, not `name`."""
+    return {"__typename": "StatusContext", "context": name, "state": state, "isRequired": required}
+
+
+def _checks_raw(nodes: list[dict[str, object]] | None, *, has_next_page: bool = False) -> str:
+    """The checks query's raw response. `nodes=None` is a head commit with no rollup at all."""
+    rollup = (
+        None
+        if nodes is None
+        else {"contexts": {"totalCount": len(nodes), "pageInfo": {"hasNextPage": has_next_page}, "nodes": nodes}}
+    )
+    return json.dumps({
+        "data": {"repository": {"pullRequest": {"commits": {"nodes": [{"commit": {"statusCheckRollup": rollup}}]}}}}
+    })
+
+
+def _head_state_raw(*, is_draft: bool = False, mergeable: str = "MERGEABLE", merge_state_status: str = "CLEAN") -> str:
+    """The head-state query's raw response, defaulting to a reviewable PR."""
+    return json.dumps({
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "isDraft": is_draft,
+                    "mergeable": mergeable,
+                    "mergeStateStatus": merge_state_status,
+                    "commits": {"nodes": [{"commit": {"committedDate": "2026-01-01T12:00:00Z"}}]},
+                }
+            }
+        }
+    })
+
+
+def _invoke_checks(mocker: MockerFixture, checks_raw: str, head_state_raw: str) -> dict[str, object]:
+    """Run `checks` against one canned pair of `gh` responses and return the parsed JSON."""
+    mocker.patch.object(pr_review_gh, "run_gh", side_effect=[checks_raw, head_state_raw])
+    result = runner.invoke(app, ["checks", "--pr", "3208"])
+    assert result.exit_code == 0, result.output
+    parsed: dict[str, object] = json.loads(result.output)
+    return parsed
+
+
+def test_checks_passes_when_every_required_check_succeeded(mocker: MockerFixture) -> None:
+    """A failing check that does not gate the merge must not turn the verdict red.
+
+    Two required checks succeeded and one non-required check failed — GitHub would let this PR
+    merge, so `status` is `passed` and the non-required failure is not listed.
+    """
+    data = _invoke_checks(
+        mocker,
+        _checks_raw([
+            _check_run("Tests"),
+            _status_context("CodeRabbit"),
+            _check_run("Release Benchmark", conclusion="FAILURE", required=False),
+        ]),
+        _head_state_raw(),
+    )
+
+    assert data["status"] == "passed"
+    assert data["required_only"] is True
+    assert data["total"] == 2
+    assert data["failed"] == []
+    assert data["pending"] == []
+    assert data["contexts_truncated"] is False
+    assert data["reviewability"] == {
+        "is_draft": False,
+        "mergeable": "MERGEABLE",
+        "merge_state_status": "CLEAN",
+        "blockers": [],
+    }
+
+
+def test_checks_reports_a_failed_required_check_by_name(mocker: MockerFixture) -> None:
+    """One failing required check makes the verdict `failed`, and names it."""
+    data = _invoke_checks(
+        mocker, _checks_raw([_check_run("Tests", conclusion="FAILURE"), _check_run("Prek hooks")]), _head_state_raw()
+    )
+
+    assert data["status"] == "failed"
+    assert data["failed"] == ["Tests"]
+
+
+def test_checks_pending_and_passed_are_distinct_states(mocker: MockerFixture) -> None:
+    """A required check still running reports `pending`, never `passed`, and is named."""
+    data = _invoke_checks(
+        mocker,
+        _checks_raw([_check_run("Tests"), _check_run("Prek hooks", status="IN_PROGRESS", conclusion=None)]),
+        _head_state_raw(),
+    )
+
+    assert data["status"] == "pending"
+    assert data["pending"] == ["Prek hooks"]
+    assert data["failed"] == []
+
+
+def test_checks_failure_outranks_a_still_running_check(mocker: MockerFixture) -> None:
+    """A failed required check is terminal even while another is still running."""
+    data = _invoke_checks(
+        mocker,
+        _checks_raw([
+            _check_run("Tests", conclusion="FAILURE"),
+            _check_run("Prek hooks", status="QUEUED", conclusion=None),
+        ]),
+        _head_state_raw(),
+    )
+
+    assert data["status"] == "failed"
+    assert data["pending"] == ["Prek hooks"]
+
+
+def test_checks_grades_every_check_when_none_is_marked_required(mocker: MockerFixture) -> None:
+    """With no branch protection marking anything required, every reported check is graded."""
+    data = _invoke_checks(
+        mocker,
+        _checks_raw([_check_run("Tests", conclusion="FAILURE", required=False), _check_run("Lint", required=False)]),
+        _head_state_raw(),
+    )
+
+    assert data["status"] == "failed"
+    assert data["required_only"] is False
+    assert data["total"] == 2
+
+
+def test_checks_reports_none_when_the_head_commit_has_no_rollup(mocker: MockerFixture) -> None:
+    """A head commit nothing has ever reported against yields `none`, not `passed`."""
+    data = _invoke_checks(mocker, _checks_raw(None), _head_state_raw())
+
+    assert data["status"] == "none"
+    assert data["total"] == 0
+    assert data["required_only"] is False
+
+
+def test_checks_explains_an_empty_verdict_on_a_conflicting_pr(mocker: MockerFixture) -> None:
+    """`none` on a conflicting PR carries the blocker saying checks cannot start at all.
+
+    This is the case that otherwise looks like a repository with no CI, and the reason a PR can
+    appear to stall indefinitely: GitHub runs no workflows while the branch conflicts.
+    """
+    data = _invoke_checks(mocker, _checks_raw(None), _head_state_raw(mergeable="CONFLICTING"))
+
+    assert data["status"] == "none"
+    reviewability = data["reviewability"]
+    assert isinstance(reviewability, dict)
+    assert reviewability["blockers"] == ["conflicting: reviews will not run until the merge conflicts are resolved"]
+
+
+def test_checks_flags_a_truncated_context_page(mocker: MockerFixture) -> None:
+    """More than one page of checks means the verdict is incomplete, and says so."""
+    data = _invoke_checks(mocker, _checks_raw([_check_run("Tests")], has_next_page=True), _head_state_raw())
+
+    assert data["contexts_truncated"] is True
+
+
+def test_checks_keeps_both_checks_that_share_a_name(mocker: MockerFixture) -> None:
+    """Two workflows reporting the same check name are graded separately, not collapsed."""
+    data = _invoke_checks(
+        mocker, _checks_raw([_check_run("Tests", conclusion="FAILURE"), _check_run("Tests")]), _head_state_raw()
+    )
+
+    assert data["total"] == 2
+    assert data["failed"] == ["Tests"]
+
+
+@pytest.mark.parametrize(
+    ("node", "expected"),
+    [
+        (_check_run("c", conclusion="SUCCESS"), "passed"),
+        (_check_run("c", conclusion="SKIPPED"), "passed"),
+        (_check_run("c", conclusion="NEUTRAL"), "passed"),
+        (_check_run("c", conclusion="FAILURE"), "failed"),
+        (_check_run("c", conclusion="TIMED_OUT"), "failed"),
+        (_check_run("c", conclusion="CANCELLED"), "failed"),
+        (_check_run("c", conclusion="ACTION_REQUIRED"), "failed"),
+        (_check_run("c", conclusion="A_CONCLUSION_THIS_SCRIPT_HAS_NEVER_SEEN"), "failed"),
+        (_check_run("c", status="QUEUED", conclusion=None), "pending"),
+        (_check_run("c", status="IN_PROGRESS", conclusion=None), "pending"),
+        (_check_run("c", status="WAITING", conclusion=None), "pending"),
+        (_status_context("c", state="SUCCESS"), "passed"),
+        (_status_context("c", state="PENDING"), "pending"),
+        (_status_context("c", state="EXPECTED"), "pending"),
+        (_status_context("c", state="ERROR"), "failed"),
+        (_status_context("c", state="FAILURE"), "failed"),
+    ],
+)
+def test_check_outcome_grades_against_githubs_required_check_rule(node: dict[str, object], expected: str) -> None:
+    """Only `SUCCESS`/`SKIPPED`/`NEUTRAL` (and a status's `SUCCESS`) satisfy a required check.
+
+    A completed run with any other conclusion — including one this script does not recognize — has
+    finished without satisfying the rule, so it is `failed` rather than optimistically `passed`.
+    """
+    context = pr_review_models.CheckContextsConnection.model_validate({
+        "totalCount": 1,
+        "pageInfo": {"hasNextPage": False},
+        "nodes": [node],
+    }).nodes[0]
+
+    assert pr_review_gh._check_outcome(context) == expected
+
+
+def test_check_contexts_reject_an_unknown_node_type() -> None:
+    """A rollup node that is neither shape fails validation loudly rather than being guessed at."""
+    with pytest.raises(ValidationError):
+        pr_review_models.CheckContextsConnection.model_validate({
+            "totalCount": 1,
+            "pageInfo": {"hasNextPage": False},
+            "nodes": [{"__typename": "SomethingElse", "name": "c", "isRequired": True}],
+        })
+
+
+# --- checks: the bounded wait ------------------------------------------------------------------
+
+
+# `ChecksResult.status`'s own value set, named once so the wait-loop tests can be parametrized over
+# it without widening to `str` and needing a type-checker suppression at the constructor.
+_CheckStatus = Literal["passed", "failed", "pending", "none"]
+
+
+def _checks_result(status: _CheckStatus, *, blockers: list[str] | None = None) -> pr_review_models.ChecksResult:
+    """Build a minimal `ChecksResult` for the wait-loop tests."""
+    return pr_review_models.ChecksResult(
+        status=status,
+        required_only=True,
+        total=1,
+        failed=[],
+        pending=[],
+        contexts_truncated=False,
+        reviewability=Reviewability(
+            is_draft=bool(blockers), mergeable="MERGEABLE", merge_state_status="CLEAN", blockers=blockers or []
+        ),
+    )
+
+
+@pytest.mark.parametrize("status", ["passed", "failed", "none"])
+def test_checks_returns_without_sleeping_once_settled(status: _CheckStatus, mocker: MockerFixture) -> None:
+    """Any non-pending verdict ends the wait immediately — there is nothing left to wait for."""
+    build_mock = mocker.patch.object(pr_review_threads, "build_checks_result", return_value=_checks_result(status))
+    sleep_mock = mocker.patch.object(pr_review_threads.time, "sleep")
+
+    result = runner.invoke(app, ["checks", "--pr", "3208", "--interval-seconds", "1", "--timeout-seconds", "40"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["status"] == status
+    build_mock.assert_called_once()
+    sleep_mock.assert_not_called()
+
+
+def test_checks_waits_until_a_running_check_settles(mocker: MockerFixture) -> None:
+    """A pending verdict is re-polled, with a real sleep between attempts, until it settles."""
+    mocker.patch.object(
+        pr_review_threads, "build_checks_result", side_effect=[_checks_result("pending"), _checks_result("passed")]
+    )
+    sleep_mock = mocker.patch.object(pr_review_threads.time, "sleep")
+
+    # As in `test_watch_polls_until_thread_becomes_unresolved`: timeout must exceed interval, since
+    # the loop stops once less than one interval remains and mocked sleep consumes no wall clock.
+    result = runner.invoke(app, ["checks", "--pr", "3208", "--interval-seconds", "1", "--timeout-seconds", "40"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["status"] == "passed"
+    sleep_mock.assert_called_once_with(1)
+
+
+def test_checks_reports_still_pending_when_the_window_ends(mocker: MockerFixture) -> None:
+    """A window that ends with checks still running reports `pending` — never `passed`."""
+    mocker.patch.object(pr_review_threads, "build_checks_result", return_value=_checks_result("pending"))
+
+    result = runner.invoke(app, ["checks", "--pr", "3208", "--interval-seconds", "1", "--timeout-seconds", "0"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["status"] == "pending"
+
+
+def test_checks_stops_waiting_when_the_pr_cannot_run_checks(mocker: MockerFixture) -> None:
+    """A blocked PR ends the wait at once: no check can start, so no window can observe one."""
+    build_mock = mocker.patch.object(
+        pr_review_threads,
+        "build_checks_result",
+        return_value=_checks_result("pending", blockers=["draft: reviewers are not requested until the PR is ready"]),
+    )
+    sleep_mock = mocker.patch.object(pr_review_threads.time, "sleep")
+
+    result = runner.invoke(app, ["checks", "--pr", "3208", "--interval-seconds", "1", "--timeout-seconds", "40"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["status"] == "pending"
+    build_mock.assert_called_once()
+    sleep_mock.assert_not_called()
+
+
+def test_checks_rejects_a_non_positive_interval() -> None:
+    result = runner.invoke(app, ["checks", "--pr", "3208", "--interval-seconds", "0"])
+
+    assert result.exit_code != 0


### PR DESCRIPTION
## Why

Two real failures in one session:

- With no way to ask whether a PR's checks were green, an agent hand-wrote three ad-hoc `until …; do :; done` polling loops. One used a shell glob that never matched, one a jq filter that could never be satisfied, and one had no sleep at all — which exhausted GitHub's secondary rate limit while the primary buckets still read 5000/5000.
- A PR sat apparently stalled for 30+ minutes. The cause was that its branch conflicted with `main`, and GitHub runs no workflows on a conflicting PR. The script's existing `reviewability` field already reported that; the caller had piped the output through a field extractor and discarded it.

## What

A fifth subcommand rather than a new field on `fetch`: check state is orthogonal to review threads, and `watch` polls `fetch` on an interval — adding two `gh` calls there would tax every poll for data that command's stop condition never reads.

```
uv run ./.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py checks --pr 166
{"status":"passed","required_only":true,"total":6,"failed":[],"pending":[],
 "contexts_truncated":false,
 "reviewability":{"is_draft":false,"mergeable":"MERGEABLE","merge_state_status":"CLEAN","blockers":[]}}
```

- **A pending run and a green run are different values.** `status` is `passed` / `failed` / `pending` / `none`.
- **Required checks come from GitHub, not a hardcoded list.** The head commit's rollup is queried with `isRequired(pullRequestNumber:)`, which GitHub computes server-side from whichever branch protection rule or ruleset covers the base branch — and unlike the branch-protection REST endpoint it needs no admin permission. Verified against this repo's PR #166: `true` for exactly the 6 required contexts, `false` for the other 8. Only those are graded, so a red non-required check never reads as `failed`.
- **Checks that cannot run are visible.** The same `Reviewability` object `fetch` already emits is included, from the same `_reviewability` helper — no second, parallel signal. `status: "none"` next to a non-empty `blockers` is "checks cannot start", not "no CI configured". Waiting also stops immediately when `blockers` is non-empty.
- **Waiting is bounded and paced.** `--timeout-seconds` defaults to `0` (one snapshot). Given a window, it sleeps `--interval-seconds` (default 90, the existing prompt-cache-sourced constant, renamed from `_DEFAULT_WATCH_INTERVAL_SECONDS` now that two commands share it) and stops once less than one interval remains — the same cutoff and rationale as `watch`.
- **Output stays compact** so a caller reads the whole thing instead of extracting one field: passing check names are not listed, `total` reports how many the verdict covers, and `contexts_truncated` flags an incomplete verdict beyond one page.

## Sourced values

| Value | Source |
| --- | --- |
| passing conclusions `SUCCESS` / `SKIPPED` / `NEUTRAL` | GitHub: "Required status checks must have a `successful`, `skipped`, or `neutral` status before collaborators can make changes to a protected branch." ([about-protected-branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches), cached under `.claude/vendor/sources/`) |
| 90s poll interval, `--timeout-seconds 0` default | existing `_DEFAULT_WATCH_INTERVAL_SECONDS` (5-minute prompt-cache TTL floor); `0` means "do not wait", not a duration |
| `commits(last: 1)` for the head commit | existing `_fetch_head_state` rationale — the REST commits endpoint's documented 250-commit cap |
| `contexts(first: 100)` | GraphQL connection page size, matching the existing `reviewThreads`/`comments` queries; overflow is surfaced as `contexts_truncated` rather than silently dropped |

No new timeout, retry count, or threshold was invented.

## Tests

24 added to the existing `test_pr_review_threads.py`, faked the same way the current tests do (`mocker.patch.object(pr_review_gh, "run_gh", side_effect=[…])` for the pipeline, `pr_review_threads.build_checks_result` for the wait loop): the required-only verdict, failed/pending/none, a blocked PR explaining an empty verdict, truncation, same-named checks not collapsing, a 16-case `_check_outcome` grading matrix including an unrecognized conclusion, discriminated-union rejection of an unknown node type, and the wait loop's early exits.

## Verification

`uv run prek run --all-files` passes, except that the three Node-based hooks (`oxfmt`, `oxlint`, `markdownlint-cli2`) cannot install on this machine — prek's vendored Node 26.8.1 aborts with a `dyld: Symbol not found: __ZNSt3__122__libcpp_verbose_abortEPKcz` against macOS 12's `libc++`. Pre-existing and unrelated to this diff (no JS/TS is touched); the one changed Markdown file was linted with the same pinned `markdownlint-cli2@0.23.2` under the system Node and is clean. `uv run pytest`: 1473 passed, 10 skipped; `tests/benchmarks/test_benchmark.py::test_io_scan_1000_skills_timing` flaked on wall-clock timing under full-suite parallel load and passes on its own.