### PR TITLE
chore(deps): bump pyproject-fmt hook to v1.1.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
 
   # TOML sorting and formatting
   - repo: https://github.com/bitflight-devops/pyproject-fmt
-    rev: v1.1.11
+    rev: v1.1.12
     hooks:
       - id: pypfmt
         name: Sort and format pyproject.toml with pypfmt


### PR DESCRIPTION
`uv run prek autoupdate`. One rev moved:

| hook repo | before | after |
|---|---|---|
| bitflight-devops/pyproject-fmt | v1.1.11 | v1.1.12 |

Unchanged: `sync-pre-commit-deps` v0.0.5, `pre-commit-hooks` v6.0.0, `actionlint` v1.7.12, `ruff-pre-commit` v0.16.5, `mirrors-oxlint` v1.80.0, `mirrors-oxfmt` v0.65.0, `markdownlint-cli2` v0.23.2, `pre-commit-shfmt` v2.2.0, `shellcheck-py` v0.11.0.1-1.

**Ruff dependency sync:** not needed. The ruff hook did not move; v0.16.5 already matches `ruff>=0.16.5` in `pyproject.toml` and `ruff 0.16.5` in `uv.lock`. Same for `ty` (0.0.75). No hook-vs-dependency drift here.

## Gate

Per AGENTS.md, the gate is `prek run --all-files` plus `pytest`. Baseline captured in a throwaway worktree on `origin/main` (6ce225a), then re-run on this branch.

| check | baseline (origin/main) | after |
|---|---|---|
| `prek run --all-files` | 19/19 runnable hooks pass | identical, hook for hook |
| `pytest` | 1474 passed, 10 skipped, 86.37% cov | 1474 passed, 10 skipped, 86.37% cov |

No hook modified a file on either side.

**Three node hooks could not run, on baseline or after.** prek's bundled Node 26.8.1 aborts on this machine: `dyld: Symbol not found: (__ZNSt3__122__libcpp_verbose_abortEPKcz)`, because macOS 12.7.6's `libc++.1.dylib` predates that symbol. That makes `oxlint`, `oxfmt` and `markdownlint-cli2` uninstallable locally at any rev — a machine fault reproduced on `origin/main` first, unrelated to this bump. None of their revs changed here, and CI runs them on its own Node.

All work was done in a throwaway `git worktree`, not the shared checkout — another session was editing this repo concurrently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJeBLNA9ybmQvv5REMDkrc