### PR TITLE
chore(pre-commit): pin node to 24.16.0 in default_language_version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -150,5 +150,6 @@ repos:
 # Configuration for specific hooks
 default_language_version:
   python: python3
+  node: 24.16.0
 
 exclude: ^(\.?plan(ning)?/|\.claude/backlog/|\.claude/get-shit-done|\.claude/hooks/gsd-.*|\.gsd/|packages/skilllint/tests/fixtures/providers/.*/failing-examples/)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -150,6 +150,23 @@ repos:
 # Configuration for specific hooks
 default_language_version:
   python: python3
+  # prek downloads its own Node toolchain and prefers it over the one on PATH.
+  # The version it selects (26.8.1, measured 2026-08-31) cannot start on macOS
+  # 12.7.6 at all: `~/.cache/prek/tools/node/26.8.1/bin/node --version` aborts
+  # with `dyld: Symbol not found: (__ZNSt3__122__libcpp_verbose_abortEPKcz)`,
+  # because that libc++ predates the symbol. Every node hook -- oxlint, oxfmt,
+  # markdownlint-cli2 -- then fails at install time.
+  #
+  # `node: system` does NOT fix this. It stops prek downloading a toolchain but
+  # not preferring one already downloaded ("Automatic installation is disabled
+  # (language_version: system)"). Deleting the toolchain is not durable either:
+  # prek re-downloaded 26.8.1 within the hour, on the next hook rev bump.
+  # Pinning a version prek can resolve from PATH is what survives.
+  #
+  # 24.16.0 is the Node already on PATH here, so prek resolves it instead of
+  # downloading. Source: `node --version`. Verified on a GitHub runner -- the
+  # Prek hooks job passes oxlint, oxfmt and markdownlint-cli2 with this pin.
+  # Raise it to any version both prek can resolve and CI provides.
   node: 24.16.0
 
 exclude: ^(\.?plan(ning)?/|\.claude/backlog/|\.claude/get-shit-done|\.claude/hooks/gsd-.*|\.gsd/|packages/skilllint/tests/fixtures/providers/.*/failing-examples/)


### PR DESCRIPTION
Sets `node: 24.16.0` under `default_language_version` in `.pre-commit-config.yaml`.

## Why this version

24.16.0 is the Node that Volta provides at `/Users/jamienelson/.volta/bin/node`, and is the version proven to work where prek's bundled Node 26.8.1 could not start at all on macOS 12.7.6:

```
dyld: Symbol not found: (__ZNSt3__122__libcpp_verbose_abortEPKcz)
```

That libc++ predates the symbol.

## Why a pin and not `system`

Measured with forced-fresh prek env hashes: `node: system` stops prek **downloading** a toolchain but does not stop it **preferring** one already downloaded. Against the poisoned cache, `system` failed with the identical dyld error while `24.16.0` passed by resolving to Volta.

The broken toolchain has since been deleted, so hooks work today — but that fix lives in one machine's cache and does not travel to a new machine, a cleared cache, or a CI runner. The pin does.

## Verification

- prek resolves the pin to `/Users/jamienelson/.volta/tools/image/node/24.16.0/bin/node` (`v24.16.0`), measured with a `language: node` probe hook.
- Full `prek run --all-files` gate run before and after the change; identical result.

## Cost

CI reads this file too, so CI runners will install Node 24.16.0 instead of whatever they previously resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJeBLNA9ybmQvv5REMDkrc
