### PR TITLE
fix(pr-reviews): make `checks` wait through the states it was returning on

### DIFF
--- a/.agents/skills/receiving-pr-reviews/SKILL.md
+++ b/.agents/skills/receiving-pr-reviews/SKILL.md
@@ -50,6 +50,8 @@ description: Work through every unresolved review thread on a PR to completion �
 
    `timed_out: false` means `state.unresolved_count > 0`, `state.unresponded_reviews` is non-empty, or `state.codex_approved` is `true` — restart this skill from step 1 against whichever is true. `timed_out: true` means none of the three were true inside that one call's window, not that watching is done — issue another `watch` immediately to keep covering the window you intend to watch. Stop once one of the three conditions is met, or once the intended window is covered. `codex_approved: true` on its own, with `unresolved_count: 0` and `unresponded_reviews: []`, is a completion signal — do not re-enter step 1 for it.
 
+   A `codex_approved: false` is two different situations, and `state.codex_approval_stale` is what separates them. `false` there means Codex has not reacted at all: keep watching. `true` means Codex approved an earlier revision and your own push since then invalidated it — no further reaction is coming on its own, so stop watching and re-request a review (`gh pr comment`, or re-request Codex however this repo triggers it) instead of waiting out more windows. `state.codex_approved_at` and `state.latest_revision_at` are the timestamps behind that call, and quoting both is what makes the re-request self-explanatory.
+
 </workflow>
 
 <gotchas>

--- a/.agents/skills/receiving-pr-reviews/SKILL.md
+++ b/.agents/skills/receiving-pr-reviews/SKILL.md
@@ -26,7 +26,9 @@ description: Work through every unresolved review thread on a PR to completion �
    uv run ./.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py checks --pr <N> [--timeout-seconds 270]
    ```
 
-   `status` is `passed`, `failed`, `pending`, or `none` — `pending` is not green. Without `--timeout-seconds` this is one snapshot; with it, the command sleeps `--interval-seconds` between polls and returns as soon as the verdict settles. Read the whole object rather than extracting one field: `none` alongside a non-empty `reviewability.blockers` means checks *cannot* start — GitHub runs no workflow on a draft or conflicting PR — which is what an apparently stalled PR usually is, and no amount of waiting will change it.
+   `status` is `passed`, `failed`, `pending`, or `none` — `pending` is not green. Without `--timeout-seconds` this is one snapshot; with it, the command sleeps `--interval-seconds` between polls and returns as soon as the verdict settles. Read the whole object rather than extracting one field: `none` alongside `reviewability.mergeable: "CONFLICTING"` means checks *cannot* start — GitHub builds no merge ref for a conflicting PR, so no workflow runs — which is what an apparently stalled PR usually is, and no amount of waiting will change it. A **draft** PR is not that case: workflows do run on drafts unless a workflow opts out, so a draft blocker in `reviewability.blockers` says nothing about CI and `checks` keeps waiting through it.
+
+   A bare `none` right after a push is not yet an answer — GitHub returns the same empty result before it has registered the push's workflow runs as it does for a repo with no CI. `checks` re-polls a `none` once to tell them apart, so pass `--timeout-seconds` when you have just pushed rather than reading the first snapshot as final.
 4. Reply on that thread with the disposition — conclusion, evidence, commit SHA, or why no change was warranted:
 
    ```bash

--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_gh.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_gh.py
@@ -642,6 +642,26 @@ def _is_codex_thumbs_up(reaction: Reaction) -> bool:
     )
 
 
+def _latest_codex_approval_at(reactions: list[Reaction]) -> datetime | None:
+    """The timestamp of Codex's most recent approval reaction on the PR, if it has left one.
+
+    Separated from the "is it still current" comparison in `build_fetch_result` because those are
+    two independent questions, and collapsing them into a single boolean is what made a push that
+    invalidated an approval indistinguishable from Codex never having looked at the PR — opposite
+    situations calling for opposite actions.
+
+    `max` rather than "any": a PR accumulates a reaction per revision Codex approves, and they are
+    never removed, so only the most recent one can possibly still apply to what is on the branch.
+
+    Args:
+        reactions: Every reaction on the PR itself, from `_fetch_pr_reactions`.
+
+    Returns:
+        When Codex last left its "+1", or `None` if it never has.
+    """
+    return max((reaction.created_at for reaction in reactions if _is_codex_thumbs_up(reaction)), default=None)
+
+
 def gh_timeout_budget(deadline: float | None, gh_timeout: float | None) -> float | None:
     """Choose the timeout for one `gh` call.
 
@@ -703,6 +723,13 @@ def build_fetch_result(
     including a force-push that resets the branch back onto a pre-existing commit object whose own
     embedded date predates the reaction.
 
+    A reaction that fails only that timestamp test is reported as `codex_approval_stale` rather
+    than being silently folded into `codex_approved: False`: Codex did approve, but a later push
+    replaced the code it approved, so the caller has to re-request a review instead of waiting for
+    one. `codex_approved_at` and `latest_revision_at` carry the two timestamps the verdict was
+    computed from, so a caller can say *how* stale rather than only *that* it is — see
+    `FetchResult`.
+
     Args:
         owner: Repository owner login.
         repo: Repository name.
@@ -713,7 +740,8 @@ def build_fetch_result(
 
     Returns:
         Totals plus every currently-unresolved thread, every unresponded review, and whether
-        Codex's approval reaction is present right now for the current revision.
+        Codex's approval reaction is present right now for the current revision, for an older one,
+        or not at all.
     """
     thread_pages = _fetch_pages(owner, repo, pr, gh_timeout=gh_timeout_budget(deadline, gh_timeout))
     review_pages = _fetch_review_pages(owner, repo, pr, gh_timeout=gh_timeout_budget(deadline, gh_timeout))
@@ -744,9 +772,7 @@ def build_fetch_result(
         comment for comment in issue_comments if comment.user is not None and comment.user.login == authenticated_login
     ]
     unresponded_reviews = _unresponded_reviews(reviews_with_body, own_comments)
-    codex_approved = any(
-        _is_codex_thumbs_up(reaction) and reaction.created_at >= latest_revision_at for reaction in reactions
-    )
+    codex_approved_at = _latest_codex_approval_at(reactions)
 
     return FetchResult(
         reviews_count=review_pages[0].totalCount,
@@ -755,7 +781,13 @@ def build_fetch_result(
         threads_count=thread_pages[0].totalCount,
         unresolved=unresolved,
         unresolved_count=len(unresolved),
-        codex_approved=codex_approved,
+        # Present and at/after the current revision vs. present and before it: two conditions over
+        # the same timestamp, written out rather than derived from each other so the mutual
+        # exclusion `FetchResult` documents is visible here instead of inferred.
+        codex_approved=codex_approved_at is not None and codex_approved_at >= latest_revision_at,
+        codex_approval_stale=codex_approved_at is not None and codex_approved_at < latest_revision_at,
+        codex_approved_at=codex_approved_at,
+        latest_revision_at=latest_revision_at,
         reviewability=_reviewability(head_state),
     )
 

--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_gh.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_gh.py
@@ -21,7 +21,6 @@ from typing import Literal
 
 from pr_review_models import (
     CheckContext,
-    CheckContextsConnection,
     CheckRunContext,
     ChecksResult,
     FetchResult,
@@ -93,11 +92,30 @@ query($o: String!, $r: String!, $pr: Int!) {
 }
 """
 
-# `isDraft`/`mergeable`/`mergeStateStatus` are selected alongside the head commit rather than in a
-# query of their own: they live on the same `pullRequest` object, so asking for them here costs no
-# extra round trip, and `build_fetch_result` is already seven sequential `gh` calls deep. Verified
-# against this repository's own API (2026-08-30) that `mergeStateStatus` needs no preview `Accept`
-# header on `gh api graphql`.
+# One query for every PR-level field this script reads off the head: the three reviewability
+# fields, the head commit's date, and its check rollup. They all live on the same `pullRequest`
+# object, so asking for them together costs one round trip instead of two, and `build_fetch_result`
+# is already seven sequential `gh` calls deep.
+#
+# The rollup used to be fetched by a second query with its own `commits(last: 1)`. Neither query
+# selected `oid` and nothing compared them, so a push landing between the two calls produced a
+# `ChecksResult` pairing one head's checks with a different head's PR state. Selecting both from a
+# single `pullRequest` snapshot removes the race outright — cheaper than selecting `oid` in two
+# queries and comparing, and it deletes a `gh` call from `checks` rather than adding a retry.
+#
+# `isRequired(pullRequestNumber:)` is GitHub's own server-side answer to "does this check gate
+# merging this PR", computed from whatever branch protection rule or ruleset covers the base
+# branch. Asking for it here is what keeps `build_checks_result` free of a hardcoded check-name
+# list, and it needs none of the admin permission the branch-protection REST endpoint requires.
+# Verified against this repository's own API (2026-08-31): PR #166 returns `isRequired: true` for
+# exactly the six contexts this repo's branch protection requires, and `false` for the eight it
+# does not. Verified the same day that `mergeStateStatus` needs no preview `Accept` header on
+# `gh api graphql`.
+#
+# `statusCheckRollup` is null on a head commit with no checks at all, and `contexts` is a
+# connection — `build_checks_result` surfaces its `hasNextPage` as `contexts_truncated` rather
+# than paginating, so a caller is told when a verdict is incomplete instead of being handed a
+# silently partial one.
 _HEAD_STATE_QUERY = """
 query($o: String!, $r: String!, $pr: Int!) {
   repository(owner: $o, name: $r) {
@@ -106,31 +124,9 @@ query($o: String!, $r: String!, $pr: Int!) {
       mergeable
       mergeStateStatus
       commits(last: 1) {
-        nodes { commit { committedDate } }
-      }
-    }
-  }
-}
-"""
-
-# `isRequired(pullRequestNumber:)` is GitHub's own server-side answer to "does this check gate
-# merging this PR", computed from whatever branch protection rule or ruleset covers the base
-# branch. Asking for it here is what keeps `_verdict` free of a hardcoded check-name list, and it
-# needs none of the admin permission the branch-protection REST endpoint requires. Verified against
-# this repository's own API (2026-08-31): PR #166 returns `isRequired: true` for exactly the six
-# contexts this repo's branch protection requires, and `false` for the eight it does not.
-#
-# `statusCheckRollup` is null on a head commit with no checks at all, and `contexts` is a
-# connection — `_fetch_check_contexts` surfaces its `hasNextPage` as `contexts_truncated` rather
-# than paginating, so a caller is told when a verdict is incomplete instead of being handed a
-# silently partial one.
-_CHECKS_QUERY = """
-query($o: String!, $r: String!, $pr: Int!) {
-  repository(owner: $o, name: $r) {
-    pullRequest(number: $pr) {
-      commits(last: 1) {
         nodes {
           commit {
+            committedDate
             statusCheckRollup {
               contexts(first: 100) {
                 totalCount
@@ -480,6 +476,31 @@ def _reviewability(head_state: PullRequestHeadState) -> Reviewability:
     )
 
 
+def checks_blocked(reviewability: Reviewability) -> bool:
+    """Whether the PR's own state stops CI from running at all.
+
+    Only one of `Reviewability`'s two blockers does. A conflicting PR has no mergeable state for
+    GitHub to build `refs/pull/N/merge` from, so a `pull_request`-triggered workflow has nothing to
+    check out and no run is created — waiting on such a PR observes nothing, forever.
+
+    A **draft** PR does not stop workflows. `pull_request` fires on a draft for its default
+    activity types; a workflow skips drafts only when it opts out itself, by filtering
+    `types: [ready_for_review]` or guarding on `github.event.pull_request.draft`. This repository's
+    own `.github/workflows/test.yml` and `benchmark.yml` do neither — both trigger on a bare
+    `pull_request` with no `types:` filter and no draft guard (verified 2026-08-31) — so their runs
+    do start on a draft PR. The draft blocker is about *reviewers*, who are not requested until the
+    PR is marked ready, which is what `fetch` reads `blockers` for. Treating it as a checks blocker
+    made `checks` return the first snapshot instantly on every draft PR.
+
+    Args:
+        reviewability: The PR state derived by `_reviewability`.
+
+    Returns:
+        `True` when no check can start until the PR itself is fixed.
+    """
+    return reviewability.mergeable == "CONFLICTING"
+
+
 def _fetch_latest_force_push_at(owner: str, repo: str, pr: int, *, gh_timeout: float | None) -> datetime | None:
     """Fetch the timestamp of the PR's most recent force-push, if it has ever had one.
 
@@ -739,42 +760,6 @@ def build_fetch_result(
     )
 
 
-def _fetch_check_contexts(
-    owner: str, repo: str, pr: int, *, gh_timeout: float | None
-) -> CheckContextsConnection | None:
-    """Fetch the checks reported against the PR's head commit, or `None` if it has none at all.
-
-    Reads the head commit through GraphQL's `commits(last: 1)` for the same reason
-    `_fetch_head_state` does — the REST commits endpoint's documented 250-commit cap makes its last
-    element unreliable as "the current head" — and asks GitHub itself which of the resulting checks
-    are required for this PR (see `_CHECKS_QUERY`).
-
-    Args:
-        owner: Repository owner login.
-        repo: Repository name.
-        pr: Pull request number.
-        gh_timeout: Seconds to bound the underlying `gh` call to, or `None` for no bound — see
-            `run_gh`.
-
-    Returns:
-        The head commit's `statusCheckRollup.contexts` connection, or `None` when the commit has no
-        rollup at all — GitHub returns a null `statusCheckRollup` when nothing has ever reported a
-        check or status against it.
-
-    Raises:
-        IndexError: the PR has no commits at all — see `_fetch_head_state`.
-    """
-    raw = run_gh(
-        ["api", "graphql", "-f", f"query={_CHECKS_QUERY}", "-f", f"o={owner}", "-f", f"r={repo}", "-F", f"pr={pr}"],
-        timeout=gh_timeout,
-    )
-    commit = json.loads(raw)["data"]["repository"]["pullRequest"]["commits"]["nodes"][-1]["commit"]
-    rollup = commit["statusCheckRollup"]
-    if rollup is None:
-        return None
-    return CheckContextsConnection.model_validate(rollup["contexts"])
-
-
 def _check_outcome(context: CheckContext) -> Literal["passed", "failed", "pending"]:
     """Grade one check against the rule GitHub applies to a required check.
 
@@ -805,11 +790,11 @@ def build_checks_result(
 ) -> ChecksResult:
     """Fetch and assemble one PR's CI verdict, plus whether the PR can run checks at all.
 
-    Makes two `gh` calls, each bounded by `gh_timeout_budget(deadline)` exactly as
-    `build_fetch_result`'s seven are: the head commit's check rollup, and the PR head state that
-    `_reviewability` reads. The second call exists so a `none` verdict is never ambiguous — a draft
-    or conflicting PR gets no workflow runs, and the same `reviewability` object `fetch` already
-    reports says so rather than a second, parallel signal invented here.
+    Makes one `gh` call, bounded by `gh_timeout_budget(deadline)` exactly as
+    `build_fetch_result`'s seven are. The head commit's check rollup and the PR-level fields
+    `_reviewability` reads come out of the same `pullRequest` snapshot, so the verdict and the
+    state explaining it can never describe two different heads — see `_HEAD_STATE_QUERY` for the
+    race that split queries allowed.
 
     Only the checks GitHub marks required for this PR are graded when any is marked required: a
     failing check that does not gate the merge is not a failure of the PR. When none is marked
@@ -828,9 +813,9 @@ def build_checks_result(
         The verdict over the graded checks, the names of any that failed or are still running, and
         the PR's reviewability.
     """
-    contexts_connection = _fetch_check_contexts(owner, repo, pr, gh_timeout=gh_timeout_budget(deadline, gh_timeout))
     head_state = _fetch_head_state(owner, repo, pr, gh_timeout=gh_timeout_budget(deadline, gh_timeout))
-    reported = contexts_connection.nodes if contexts_connection is not None else []
+    rollup = head_state.commits.nodes[-1].commit.statusCheckRollup
+    reported = rollup.contexts.nodes if rollup is not None else []
     required = [context for context in reported if context.isRequired]
     graded = required or reported
     # A list of pairs rather than a dict: two workflows may report a check of the same name, and a
@@ -853,6 +838,6 @@ def build_checks_result(
         total=len(graded),
         failed=failed,
         pending=pending,
-        contexts_truncated=contexts_connection is not None and contexts_connection.pageInfo.hasNextPage,
+        contexts_truncated=rollup is not None and rollup.contexts.pageInfo.hasNextPage,
         reviewability=_reviewability(head_state),
     )

--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_models.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_models.py
@@ -455,6 +455,24 @@ class FetchResult(BaseModel):
     Every field here is derived from a single fresh set of `gh` calls (see
     `pr_review_gh.build_fetch_result`) — none of it is a diff against an earlier call's result,
     so reading any of these fields never depends on what call came before this one.
+
+    Codex's approval is reported as three fields rather than one, because a single boolean
+    collapses two states that call for opposite actions. Codex approves by leaving a `+1` reaction
+    on the PR, and that reaction approves the revision that existed when it landed — a later push
+    does not remove it, so the reaction alone would keep reading as approval indefinitely:
+
+    - `codex_approved` — a Codex `+1` is present **and** it postdates the current revision. The
+      approval applies to what is on the branch right now. Unchanged in meaning; this is the field
+      `has_outstanding_work` and the receiving-pr-reviews skill already read.
+    - `codex_approval_stale` — a Codex `+1` is present but predates the current revision. A push
+      landed after Codex approved, so the approval covers code that is no longer there and a fresh
+      review has to be requested. Distinct from *no* approval at all, where both booleans are
+      `False` and the answer is to keep waiting. The two are mutually exclusive by construction.
+    - `codex_approved_at` / `latest_revision_at` — the evidence behind the verdict: when the `+1`
+      landed (`None` when Codex has never reacted) and when the current revision came into being
+      (`pr_review_gh._latest_revision_at`: the later of the head commit's date and the most recent
+      force-push, since neither is sufficient alone). A caller reporting *why* an approval is stale
+      needs both, and both are already computed to decide the booleans.
     """
 
     reviews_count: int
@@ -464,6 +482,9 @@ class FetchResult(BaseModel):
     unresolved: list[UnresolvedThread]
     unresolved_count: int
     codex_approved: bool
+    codex_approval_stale: bool
+    codex_approved_at: datetime | None
+    latest_revision_at: datetime
     reviewability: Reviewability
 
     def has_outstanding_work(self) -> bool:

--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_models.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_models.py
@@ -24,7 +24,7 @@ __all__ = [
     "CommentNode",
     "FetchResult",
     "ForcePushEvent",
-    "GitHubCommitDate",
+    "HeadCommit",
     "HeadCommitNode",
     "IssueComment",
     "PullRequestHeadState",
@@ -32,6 +32,7 @@ __all__ = [
     "RepoIdentity",
     "ReviewNode",
     "Reviewability",
+    "StatusCheckRollup",
     "StatusContextNode",
     "UnresolvedThread",
     "WatchResult",
@@ -220,53 +221,6 @@ class Reaction(GitHubResponseModel):
     created_at: GitHubTimestamp
 
 
-class GitHubCommitDate(GitHubResponseModel):
-    """The `committedDate` field of a GraphQL `Commit` object."""
-
-    committedDate: GitHubTimestamp
-
-
-class HeadCommitNode(GitHubResponseModel):
-    """One commit from GraphQL's `pullRequest.commits(last: 1)` connection.
-
-    Requesting `last: 1` asks the server directly for the tail element — GraphQL's connection
-    pagination has no equivalent of the REST `/pulls/{pr}/commits` endpoint's documented 250-commit
-    hard cap, which made that endpoint's last-paginated-element unreliable as "the current head" on
-    a PR with more commits than the cap (see `pr_review_gh._fetch_latest_commit_date`).
-    """
-
-    commit: GitHubCommitDate
-
-
-class HeadCommitsConnection(GitHubResponseModel):
-    """The `commits(last: 1)` connection nested inside `PullRequestHeadState`."""
-
-    nodes: list[HeadCommitNode]
-
-
-class PullRequestHeadState(GitHubResponseModel):
-    """The PR-level fields `pr_review_gh._fetch_head_state` reads in one GraphQL query.
-
-    All four live on the same `pullRequest` object, so they cost one round trip together: the head
-    commit's date (for `codex_approved`'s staleness check) plus the three fields that say whether
-    this PR can be reviewed at all.
-
-    `mergeable` is `MERGEABLE`, `CONFLICTING`, or `UNKNOWN`; `mergeStateStatus` is one of `CLEAN`,
-    `DIRTY`, `BLOCKED`, `BEHIND`, `UNSTABLE`, `DRAFT`, `HAS_HOOKS`, or `UNKNOWN`. Both are kept as
-    plain strings rather than enums: GitHub can add a state at any time, and an unrecognized one
-    must reach the caller as data instead of failing validation on a PR that is otherwise fine.
-    Strict against that string type, though — `strict=True` via `GitHubResponseModel` means a
-    number or a null arriving where a state name belongs is rejected rather than stringified, and
-    `isDraft` must be a real boolean rather than `"false"`. None of the three is a timestamp, so
-    none needs the `GitHubTimestamp` relaxation.
-    """
-
-    isDraft: bool
-    mergeable: str
-    mergeStateStatus: str
-    commits: HeadCommitsConnection
-
-
 class CheckRunContext(GitHubResponseModel):
     """One CI check run on the PR's head commit, in the shape GitHub's GraphQL API returns it.
 
@@ -321,15 +275,91 @@ CheckContext = Annotated[CheckRunContext | StatusContextNode, Field(discriminato
 class CheckContextsConnection(GitHubResponseModel):
     """The `statusCheckRollup.contexts` connection on the PR's head commit.
 
-    `pr_review_gh._fetch_check_contexts` subscripts the fixed
-    `data.repository.pullRequest.commits.nodes[-1].commit.statusCheckRollup` path out of the
-    response before validating this — same boundary handling, and same rationale, as
-    `ReviewThreadsConnection`.
+    `pr_review_gh._fetch_check_contexts` used to subscript this out of its own response; it now
+    arrives already nested under `HeadCommit.statusCheckRollup`, validated in one pass with the
+    rest of the head state.
+
+    `pageInfo.hasNextPage` is surfaced to the caller as `ChecksResult.contexts_truncated` rather
+    than paginated, so a verdict computed over one page announces that it is incomplete instead of
+    being handed over as if it were whole.
     """
 
     totalCount: int
     pageInfo: PageInfo
     nodes: list[CheckContext]
+
+
+class StatusCheckRollup(GitHubResponseModel):
+    """The head commit's `statusCheckRollup`, GitHub's aggregate of everything reported on it.
+
+    Exists as its own model only because GitHub returns the whole rollup as null — not an empty
+    `contexts` connection — when nothing has ever reported against the commit. `HeadCommit` types
+    it `| None` so that null is ingested as the distinct state it is.
+    """
+
+    contexts: CheckContextsConnection
+
+
+class HeadCommit(GitHubResponseModel):
+    """The PR head commit's own fields: when it was committed, and what CI has reported on it.
+
+    Both are read in one query (see `pr_review_gh._HEAD_STATE_QUERY`). `committedDate` dates the
+    current revision for `codex_approved`'s staleness check; `statusCheckRollup` is what `checks`
+    grades. GitHub returns a null `statusCheckRollup` when nothing has ever reported a check or a
+    status against this commit — including the window right after a push, before GitHub has
+    registered the workflow runs the push triggers, which is why `checks` treats an empty verdict
+    as provisional rather than final (see `pr_review_threads.checks`).
+    """
+
+    committedDate: GitHubTimestamp
+    statusCheckRollup: StatusCheckRollup | None
+
+
+class HeadCommitNode(GitHubResponseModel):
+    """One commit from GraphQL's `pullRequest.commits(last: 1)` connection.
+
+    Requesting `last: 1` asks the server directly for the tail element — GraphQL's connection
+    pagination has no equivalent of the REST `/pulls/{pr}/commits` endpoint's documented 250-commit
+    hard cap, which made that endpoint's last-paginated-element unreliable as "the current head" on
+    a PR with more commits than the cap (see `pr_review_gh._fetch_head_state`).
+    """
+
+    commit: HeadCommit
+
+
+class HeadCommitsConnection(GitHubResponseModel):
+    """The `commits(last: 1)` connection nested inside `PullRequestHeadState`."""
+
+    nodes: list[HeadCommitNode]
+
+
+class PullRequestHeadState(GitHubResponseModel):
+    """Everything `pr_review_gh._fetch_head_state` reads about a PR, in one GraphQL query.
+
+    All of it lives on the same `pullRequest` object, so it costs one round trip together: the
+    three fields that say whether this PR can be reviewed at all, plus the head commit carrying
+    both its date (for `codex_approved`'s staleness check) and its check rollup (for `checks`).
+
+    Folding the rollup in here is what makes a `checks` verdict internally consistent. It used to
+    come from a second query with its own `commits(last: 1)`, and neither query selected `oid`, so
+    a push landing between the two produced a result pairing one head's checks with another head's
+    PR state. One query over one `pullRequest` snapshot cannot do that, and it costs `checks` one
+    fewer `gh` call than comparing two `oid`s would.
+
+    `mergeable` is `MERGEABLE`, `CONFLICTING`, or `UNKNOWN`; `mergeStateStatus` is one of `CLEAN`,
+    `DIRTY`, `BLOCKED`, `BEHIND`, `UNSTABLE`, `DRAFT`, `HAS_HOOKS`, or `UNKNOWN`. Both are kept as
+    plain strings rather than enums: GitHub can add a state at any time, and an unrecognized one
+    must reach the caller as data instead of failing validation on a PR that is otherwise fine.
+    Strict against that string type, though — `strict=True` via `GitHubResponseModel` means a
+    number or a null arriving where a state name belongs is rejected rather than stringified, and
+    `isDraft` must be a real boolean rather than `"false"`. Neither is a timestamp, so neither
+    needs the `GitHubTimestamp` relaxation.
+    """
+
+    isDraft: bool
+    mergeable: str
+    mergeStateStatus: str
+    commits: HeadCommitsConnection
 
 
 class Reviewability(BaseModel):
@@ -371,7 +401,11 @@ class ChecksResult(BaseModel):
     - `passed` — every check the verdict covers has finished successfully.
     - `failed` — at least one has finished unsuccessfully. Terminal until a new push.
     - `pending` — none failed, but at least one has not finished yet.
-    - `none` — the PR's head commit reports no checks at all.
+    - `none` — the PR's head commit reports no checks at all. Ambiguous on its own: GitHub returns
+      the same empty rollup in the seconds after a push, before it has registered the workflow
+      runs that push triggered, as it does for a repository with no CI whatsoever. `checks`
+      resolves that ambiguity by re-polling a `none` once rather than by reading it as final —
+      see `pr_review_threads.checks`.
 
     `required_only` says what "the checks the verdict covers" means: `True` when at least one check
     is marked required for this PR (only those are graded — a failing non-required check never
@@ -385,9 +419,10 @@ class ChecksResult(BaseModel):
     `UnresolvedThread.comments_truncated`.
 
     `reviewability` is the *same* `Reviewability` `FetchResult` carries, derived from the same
-    helper: a draft or conflicting PR gets no workflow runs at all, so `none` there means "checks
-    cannot start", not "this repository has no CI". Read `status` and `reviewability.blockers`
-    together — that pairing is the entire reason both are in one small object.
+    helper — but only one of its two blockers bears on CI. A conflicting PR gets no workflow runs,
+    so `none` alongside `mergeable: "CONFLICTING"` means "checks cannot start", not "this
+    repository has no CI". A *draft* PR does run workflows, so a draft blocker says nothing about
+    checks at all; `pr_review_gh.checks_blocked` is the one place that distinction is made.
 
     Assembled by `pr_review_gh.build_checks_result` from already-validated values, so it is an
     output shape rather than an ingress one — see `GitHubResponseModel`.

--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py
@@ -38,8 +38,15 @@ import time
 from typing import Annotated
 
 import typer
-from pr_review_gh import RESOLVE_THREAD_MUTATION, build_checks_result, build_fetch_result, detect_repo_identity, run_gh
-from pr_review_models import WatchResult
+from pr_review_gh import (
+    RESOLVE_THREAD_MUTATION,
+    build_checks_result,
+    build_fetch_result,
+    checks_blocked,
+    detect_repo_identity,
+    run_gh,
+)
+from pr_review_models import ChecksResult, WatchResult
 from pydantic import ValidationError
 
 app = typer.Typer(help="GitHub PR review operations (fetch/watch/checks/reply/resolve) via gh.")
@@ -159,7 +166,8 @@ def fetch(
     `reviewability.blockers` is non-empty when the PR itself is why nothing is outstanding: a draft
     gets no reviewers requested and a conflicting branch gets no review runs, so an empty
     `unresolved` array there means "nothing can happen yet", not "nothing to do". Read it before
-    concluding a PR is clean. An empty `blockers` means reviews can proceed.
+    concluding a PR is clean. An empty `blockers` means reviews can proceed. It is about *reviews*
+    — only the conflicting half of it also stops CI, which is what `checks` reads.
     """
     owner, repo = _owner_repo(github, gh_timeout=gh_timeout_seconds)
     result = build_fetch_result(owner, repo, pr, gh_timeout=gh_timeout_seconds)
@@ -294,6 +302,44 @@ def watch(
     typer.echo(result.model_dump_json())
 
 
+def _checks_unsettled(current: ChecksResult, *, none_grace_spent: bool) -> bool:
+    """Whether `checks` should keep polling, given the snapshot it just took.
+
+    Two of the four verdicts are terminal: `passed` and `failed` cannot change without a new push,
+    which this call is not waiting for. The other two are not, and they are not the same kind of
+    unsettled:
+
+    - `pending` is proof that a check context exists on the head commit and has not finished. It
+      polls for the caller's whole window — there is a real answer coming.
+    - `none` is ambiguous. GitHub returns a null `statusCheckRollup` both for a head commit whose
+      workflow runs it has not registered yet — the state in the seconds right after the push that
+      the receiving-pr-reviews skill tells the reader to run `checks` after — and for a repository
+      with no CI at all. Returning that first snapshot as final made `--timeout-seconds` a no-op
+      exactly when it was needed most.
+
+    A `none` therefore gets exactly one re-poll of grace. That bound introduces no duration of its
+    own: the wait is one `--interval-seconds`, the unit the caller already chose as "how long
+    between observations", and the caller's `--timeout-seconds` still caps it. One observation
+    after a wait is the least that can tell the two cases apart — a registration gap has closed
+    into a real verdict by then, while a repository with no CI still reports `none` and settles
+    there instead of spinning out the whole window on an answer that will never change.
+
+    Args:
+        current: The most recent snapshot taken.
+        none_grace_spent: Whether a re-poll starting from a `none` has already been taken.
+
+    Returns:
+        `True` when another poll could still change the verdict.
+    """
+    if checks_blocked(current.reviewability):
+        # Only the conflicting blocker stops CI; a draft PR still runs workflows. See
+        # `pr_review_gh.checks_blocked` for why the two halves of `blockers` are not interchangeable.
+        return False
+    if current.status == "pending":
+        return True
+    return current.status == "none" and not none_grace_spent
+
+
 @app.command()
 def checks(
     pr: Annotated[int, typer.Option(help="Pull request number.")],
@@ -322,20 +368,26 @@ def checks(
     Prints compact JSON: `status` (`passed` / `failed` / `pending` / `none`), `required_only`,
     `total`, the `failed` and `pending` check names, `contexts_truncated`, and the same
     `reviewability` object `fetch` reports. Read the whole thing — it is small on purpose. In
-    particular `status: "none"` on a PR with `reviewability.blockers` means checks *cannot start*
-    (GitHub runs no workflows on a draft or a conflicting PR), not that the repository has no CI,
-    which is otherwise indistinguishable and is why a PR can appear to stall indefinitely.
+    particular `status: "none"` on a PR whose `reviewability.mergeable` is `CONFLICTING` means
+    checks *cannot start*, not that the repository has no CI, which is otherwise indistinguishable
+    and is why a PR can appear to stall indefinitely.
 
     With `--timeout-seconds 0` (the default) this is a single snapshot. Given a timeout it polls,
-    sleeping `--interval-seconds` between attempts, and returns as soon as `status` is anything but
-    `pending` — or when the window ends, in which case `status` is still `pending` and the caller
-    can issue another call. A `pending` result and a `passed` result are distinct values, so a
-    caller can never mistake one for the other.
+    sleeping `--interval-seconds` between attempts, and returns as soon as the verdict can no
+    longer change — or when the window ends, in which case `status` is whatever the last poll saw
+    and the caller can issue another call. `pending` and `passed` are distinct values, so a caller
+    can never mistake one for the other.
 
-    Waiting stops immediately when `reviewability.blockers` is non-empty: no check can start, so
-    there is nothing for the window to observe. Use `--interval-seconds`/`--timeout-seconds` rather
-    than an ad-hoc shell polling loop — an unpaced loop exhausts GitHub's secondary rate limit long
-    before the primary quota shows any sign of it.
+    A `pending` result polls for the whole window; a `none` gets exactly one re-poll before it is
+    reported, because GitHub returns the same empty rollup for "the push's workflow runs are not
+    registered yet" and for "this repository has no CI" — see `_checks_unsettled`.
+
+    Waiting stops immediately on a *conflicting* PR: GitHub builds no merge ref for it, so no
+    workflow runs and there is nothing for the window to observe. A **draft** PR is not a reason to
+    stop — `pull_request` fires on drafts unless a workflow opts out, and this repository's own
+    workflows do not (`pr_review_gh.checks_blocked`). Use `--interval-seconds`/`--timeout-seconds`
+    rather than an ad-hoc shell polling loop — an unpaced loop exhausts GitHub's secondary rate
+    limit long before the primary quota shows any sign of it.
 
     A `gh` failure mid-wait propagates and exits non-zero rather than being retried inline: unlike
     `watch`, this command is short and re-running it costs one snapshot.
@@ -346,7 +398,10 @@ def checks(
     # `--timeout-seconds 0` the deadline is already spent, and bounding it would starve the
     # documented immediate snapshot into a `TimeoutExpired`.
     current = build_checks_result(owner, repo, pr, gh_timeout=gh_timeout_seconds)
-    while current.status == "pending" and not current.reviewability.blockers:
+    # `none` is polled at most once — see `_checks_unsettled`. Set before each re-poll that starts
+    # from a `none`, so the grace is spent by taking it rather than by any clock of its own.
+    none_grace_spent = False
+    while _checks_unsettled(current, none_grace_spent=none_grace_spent):
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             break
@@ -356,6 +411,7 @@ def checks(
             # to nothing. Report the last state fetched rather than spawn a doomed call — same
             # cutoff, and same rationale, as `watch`.
             break
+        none_grace_spent = none_grace_spent or current.status == "none"
         current = build_checks_result(owner, repo, pr, deadline=deadline, gh_timeout=gh_timeout_seconds)
     typer.echo(current.model_dump_json())
 

--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py
@@ -160,8 +160,14 @@ def fetch(
     thread at all and would otherwise be invisible even when `unresolved_count` is 0.
     `unresponded_reviews` narrows that to the ones nothing has been posted on the PR about since —
     see `pr_review_gh.build_fetch_result` for exactly how that is derived; treat each as
-    actionable input. `codex_approved` is `True` when Codex's thumbs-up reaction is currently
-    present on the PR.
+    actionable input.
+
+    `codex_approved` is `True` when Codex's thumbs-up reaction is present *and* postdates the
+    current revision. When it is `False`, read `codex_approval_stale` before concluding anything:
+    `True` there means Codex did approve but a later push replaced the code it approved, so a fresh
+    review has to be requested rather than waited for. Both `False` means Codex has not reacted at
+    all. `codex_approved_at` and `latest_revision_at` are the two timestamps that verdict was
+    computed from.
 
     `reviewability.blockers` is non-empty when the PR itself is why nothing is outstanding: a draft
     gets no reviewers requested and a conflicting branch gets no review runs, so an empty

--- a/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
@@ -53,6 +53,7 @@ import pytest
 from pr_review_gh import _is_codex_thumbs_up, build_fetch_result
 from pr_review_models import (
     Author,
+    ChecksResult,
     FetchResult,
     IssueComment,
     PullRequestHeadState,
@@ -164,13 +165,18 @@ def _head_state(
     is_draft: bool = False,
     mergeable: str = "MERGEABLE",
     merge_state_status: str = "CLEAN",
+    rollup: dict[str, object] | None = None,
 ) -> PullRequestHeadState:
-    """Build a `PullRequestHeadState`, defaulting to a reviewable (non-draft, conflict-free) PR."""
+    """Build a `PullRequestHeadState`, defaulting to a reviewable (non-draft, conflict-free) PR.
+
+    `rollup` defaults to `None` — a head commit nothing has reported a check against, which is
+    what every test outside the `checks` section is indifferent to.
+    """
     return PullRequestHeadState.model_validate({
         "isDraft": is_draft,
         "mergeable": mergeable,
         "mergeStateStatus": merge_state_status,
-        "commits": {"nodes": [{"commit": {"committedDate": commit_date}}]},
+        "commits": {"nodes": [{"commit": {"committedDate": commit_date, "statusCheckRollup": rollup}}]},
     })
 
 
@@ -337,7 +343,9 @@ def test_fetch_flattens_pages_filters_resolved_and_derives_new_fields(mocker: Mo
                     "isDraft": False,
                     "mergeable": "MERGEABLE",
                     "mergeStateStatus": "CLEAN",
-                    "commits": {"nodes": [{"commit": {"committedDate": "2026-01-01T12:00:00Z"}}]},
+                    "commits": {
+                        "nodes": [{"commit": {"committedDate": "2026-01-01T12:00:00Z", "statusCheckRollup": None}}]
+                    },
                 }
             }
         }
@@ -741,7 +749,9 @@ def test_fetch_head_state_reads_commit_date_via_graphql_last_one(mocker: MockerF
                     "isDraft": False,
                     "mergeable": "MERGEABLE",
                     "mergeStateStatus": "CLEAN",
-                    "commits": {"nodes": [{"commit": {"committedDate": "2026-01-06T00:00:00Z"}}]},
+                    "commits": {
+                        "nodes": [{"commit": {"committedDate": "2026-01-06T00:00:00Z", "statusCheckRollup": None}}]
+                    },
                 }
             }
         }
@@ -850,11 +860,12 @@ def test_ingress_models_still_parse_github_iso_timestamps() -> None:
     strictness on exactly those fields and nothing else — so an unparseable value is still
     rejected, while the other forms a lax `datetime` accepts (a Unix epoch number) remain accepted.
     """
-    assert pr_review_models.GitHubCommitDate.model_validate({"committedDate": "2026-01-06T00:00:00Z"}) == (
-        pr_review_models.GitHubCommitDate(committedDate=datetime(2026, 1, 6, tzinfo=UTC))
+    payload = {"committedDate": "2026-01-06T00:00:00Z", "statusCheckRollup": None}
+    assert pr_review_models.HeadCommit.model_validate(payload) == (
+        pr_review_models.HeadCommit(committedDate=datetime(2026, 1, 6, tzinfo=UTC), statusCheckRollup=None)
     )
     with pytest.raises(ValidationError):
-        pr_review_models.GitHubCommitDate.model_validate({"committedDate": "not-a-timestamp"})
+        pr_review_models.HeadCommit.model_validate({"committedDate": "not-a-timestamp", "statusCheckRollup": None})
 
 
 def test_internal_result_models_are_not_strict() -> None:
@@ -1341,20 +1352,25 @@ def _status_context(name: str, *, state: str = "SUCCESS", required: bool = True)
     return {"__typename": "StatusContext", "context": name, "state": state, "isRequired": required}
 
 
-def _checks_raw(nodes: list[dict[str, object]] | None, *, has_next_page: bool = False) -> str:
-    """The checks query's raw response. `nodes=None` is a head commit with no rollup at all."""
+def _checks_raw(
+    nodes: list[dict[str, object]] | None,
+    *,
+    has_next_page: bool = False,
+    is_draft: bool = False,
+    mergeable: str = "MERGEABLE",
+    merge_state_status: str = "CLEAN",
+) -> str:
+    """The head-state query's raw response, defaulting to a reviewable PR.
+
+    One response, not two: the check rollup and the PR-level reviewability fields come out of the
+    same `pullRequest` snapshot (see `pr_review_gh._HEAD_STATE_QUERY`). `nodes=None` is a head
+    commit with no rollup at all.
+    """
     rollup = (
         None
         if nodes is None
         else {"contexts": {"totalCount": len(nodes), "pageInfo": {"hasNextPage": has_next_page}, "nodes": nodes}}
     )
-    return json.dumps({
-        "data": {"repository": {"pullRequest": {"commits": {"nodes": [{"commit": {"statusCheckRollup": rollup}}]}}}}
-    })
-
-
-def _head_state_raw(*, is_draft: bool = False, mergeable: str = "MERGEABLE", merge_state_status: str = "CLEAN") -> str:
-    """The head-state query's raw response, defaulting to a reviewable PR."""
     return json.dumps({
         "data": {
             "repository": {
@@ -1362,20 +1378,44 @@ def _head_state_raw(*, is_draft: bool = False, mergeable: str = "MERGEABLE", mer
                     "isDraft": is_draft,
                     "mergeable": mergeable,
                     "mergeStateStatus": merge_state_status,
-                    "commits": {"nodes": [{"commit": {"committedDate": "2026-01-01T12:00:00Z"}}]},
+                    "commits": {
+                        "nodes": [{"commit": {"committedDate": "2026-01-01T12:00:00Z", "statusCheckRollup": rollup}}]
+                    },
                 }
             }
         }
     })
 
 
-def _invoke_checks(mocker: MockerFixture, checks_raw: str, head_state_raw: str) -> dict[str, object]:
-    """Run `checks` against one canned pair of `gh` responses and return the parsed JSON."""
-    mocker.patch.object(pr_review_gh, "run_gh", side_effect=[checks_raw, head_state_raw])
+def _invoke_checks(mocker: MockerFixture, checks_raw: str) -> dict[str, object]:
+    """Run `checks` against one canned `gh` response and return the parsed JSON."""
+    mocker.patch.object(pr_review_gh, "run_gh", side_effect=[checks_raw])
     result = runner.invoke(app, ["checks", "--pr", "3208"])
     assert result.exit_code == 0, result.output
     parsed: dict[str, object] = json.loads(result.output)
     return parsed
+
+
+def test_checks_reads_the_verdict_and_the_pr_state_from_one_head_snapshot(mocker: MockerFixture) -> None:
+    """The rollup and the reviewability come from a single `gh` call over one head commit.
+
+    Regression coverage for a Codex review on PR #167: the rollup and the PR state were fetched by
+    two back-to-back queries, each with its own `commits(last: 1)`, neither selecting `oid` and
+    nothing comparing them — a push landing between the two produced a `ChecksResult` pairing one
+    head's checks with a different head's PR state. `side_effect` holds exactly one response, so a
+    second `gh` call would raise `StopIteration` rather than pass quietly.
+    """
+    run_gh_mock = mocker.patch.object(
+        pr_review_gh, "run_gh", side_effect=[_checks_raw([_check_run("Tests")], mergeable="CONFLICTING")]
+    )
+
+    result = runner.invoke(app, ["checks", "--pr", "3208"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    run_gh_mock.assert_called_once()
+    assert data["status"] == "passed"
+    assert data["reviewability"]["mergeable"] == "CONFLICTING"
 
 
 def test_checks_passes_when_every_required_check_succeeded(mocker: MockerFixture) -> None:
@@ -1391,7 +1431,6 @@ def test_checks_passes_when_every_required_check_succeeded(mocker: MockerFixture
             _status_context("CodeRabbit"),
             _check_run("Release Benchmark", conclusion="FAILURE", required=False),
         ]),
-        _head_state_raw(),
     )
 
     assert data["status"] == "passed"
@@ -1410,9 +1449,7 @@ def test_checks_passes_when_every_required_check_succeeded(mocker: MockerFixture
 
 def test_checks_reports_a_failed_required_check_by_name(mocker: MockerFixture) -> None:
     """One failing required check makes the verdict `failed`, and names it."""
-    data = _invoke_checks(
-        mocker, _checks_raw([_check_run("Tests", conclusion="FAILURE"), _check_run("Prek hooks")]), _head_state_raw()
-    )
+    data = _invoke_checks(mocker, _checks_raw([_check_run("Tests", conclusion="FAILURE"), _check_run("Prek hooks")]))
 
     assert data["status"] == "failed"
     assert data["failed"] == ["Tests"]
@@ -1421,9 +1458,7 @@ def test_checks_reports_a_failed_required_check_by_name(mocker: MockerFixture) -
 def test_checks_pending_and_passed_are_distinct_states(mocker: MockerFixture) -> None:
     """A required check still running reports `pending`, never `passed`, and is named."""
     data = _invoke_checks(
-        mocker,
-        _checks_raw([_check_run("Tests"), _check_run("Prek hooks", status="IN_PROGRESS", conclusion=None)]),
-        _head_state_raw(),
+        mocker, _checks_raw([_check_run("Tests"), _check_run("Prek hooks", status="IN_PROGRESS", conclusion=None)])
     )
 
     assert data["status"] == "pending"
@@ -1439,7 +1474,6 @@ def test_checks_failure_outranks_a_still_running_check(mocker: MockerFixture) ->
             _check_run("Tests", conclusion="FAILURE"),
             _check_run("Prek hooks", status="QUEUED", conclusion=None),
         ]),
-        _head_state_raw(),
     )
 
     assert data["status"] == "failed"
@@ -1451,7 +1485,6 @@ def test_checks_grades_every_check_when_none_is_marked_required(mocker: MockerFi
     data = _invoke_checks(
         mocker,
         _checks_raw([_check_run("Tests", conclusion="FAILURE", required=False), _check_run("Lint", required=False)]),
-        _head_state_raw(),
     )
 
     assert data["status"] == "failed"
@@ -1461,7 +1494,7 @@ def test_checks_grades_every_check_when_none_is_marked_required(mocker: MockerFi
 
 def test_checks_reports_none_when_the_head_commit_has_no_rollup(mocker: MockerFixture) -> None:
     """A head commit nothing has ever reported against yields `none`, not `passed`."""
-    data = _invoke_checks(mocker, _checks_raw(None), _head_state_raw())
+    data = _invoke_checks(mocker, _checks_raw(None))
 
     assert data["status"] == "none"
     assert data["total"] == 0
@@ -1474,7 +1507,7 @@ def test_checks_explains_an_empty_verdict_on_a_conflicting_pr(mocker: MockerFixt
     This is the case that otherwise looks like a repository with no CI, and the reason a PR can
     appear to stall indefinitely: GitHub runs no workflows while the branch conflicts.
     """
-    data = _invoke_checks(mocker, _checks_raw(None), _head_state_raw(mergeable="CONFLICTING"))
+    data = _invoke_checks(mocker, _checks_raw(None, mergeable="CONFLICTING"))
 
     assert data["status"] == "none"
     reviewability = data["reviewability"]
@@ -1484,16 +1517,14 @@ def test_checks_explains_an_empty_verdict_on_a_conflicting_pr(mocker: MockerFixt
 
 def test_checks_flags_a_truncated_context_page(mocker: MockerFixture) -> None:
     """More than one page of checks means the verdict is incomplete, and says so."""
-    data = _invoke_checks(mocker, _checks_raw([_check_run("Tests")], has_next_page=True), _head_state_raw())
+    data = _invoke_checks(mocker, _checks_raw([_check_run("Tests")], has_next_page=True))
 
     assert data["contexts_truncated"] is True
 
 
 def test_checks_keeps_both_checks_that_share_a_name(mocker: MockerFixture) -> None:
     """Two workflows reporting the same check name are graded separately, not collapsed."""
-    data = _invoke_checks(
-        mocker, _checks_raw([_check_run("Tests", conclusion="FAILURE"), _check_run("Tests")]), _head_state_raw()
-    )
+    data = _invoke_checks(mocker, _checks_raw([_check_run("Tests", conclusion="FAILURE"), _check_run("Tests")]))
 
     assert data["total"] == 2
     assert data["failed"] == ["Tests"]
@@ -1553,24 +1584,32 @@ def test_check_contexts_reject_an_unknown_node_type() -> None:
 _CheckStatus = Literal["passed", "failed", "pending", "none"]
 
 
-def _checks_result(status: _CheckStatus, *, blockers: list[str] | None = None) -> pr_review_models.ChecksResult:
-    """Build a minimal `ChecksResult` for the wait-loop tests."""
-    return pr_review_models.ChecksResult(
+def _checks_result(status: _CheckStatus, *, is_draft: bool = False, mergeable: str = "MERGEABLE") -> ChecksResult:
+    """Build a minimal `ChecksResult` for the wait-loop tests.
+
+    `reviewability` is derived by the real `pr_review_gh._reviewability` rather than hand-built, so
+    a test asking for a draft or a conflicting PR gets exactly the blocker sentences production
+    would produce for it — which is the whole point of the tests below that distinguish the two.
+    """
+    return ChecksResult(
         status=status,
         required_only=True,
         total=1,
         failed=[],
         pending=[],
         contexts_truncated=False,
-        reviewability=Reviewability(
-            is_draft=bool(blockers), mergeable="MERGEABLE", merge_state_status="CLEAN", blockers=blockers or []
-        ),
+        reviewability=pr_review_gh._reviewability(_head_state(is_draft=is_draft, mergeable=mergeable)),
     )
 
 
-@pytest.mark.parametrize("status", ["passed", "failed", "none"])
+@pytest.mark.parametrize("status", ["passed", "failed"])
 def test_checks_returns_without_sleeping_once_settled(status: _CheckStatus, mocker: MockerFixture) -> None:
-    """Any non-pending verdict ends the wait immediately — there is nothing left to wait for."""
+    """A terminal verdict ends the wait immediately — neither can change without a new push.
+
+    `none` is deliberately not in this list: it is not terminal on sight, because GitHub reports it
+    both for a repository with no CI and for a head commit whose workflow runs it has not
+    registered yet. See `test_checks_polls_a_none_verdict_through_the_registration_gap`.
+    """
     build_mock = mocker.patch.object(pr_review_threads, "build_checks_result", return_value=_checks_result(status))
     sleep_mock = mocker.patch.object(pr_review_threads.time, "sleep")
 
@@ -1608,12 +1647,79 @@ def test_checks_reports_still_pending_when_the_window_ends(mocker: MockerFixture
     assert json.loads(result.output)["status"] == "pending"
 
 
-def test_checks_stops_waiting_when_the_pr_cannot_run_checks(mocker: MockerFixture) -> None:
-    """A blocked PR ends the wait at once: no check can start, so no window can observe one."""
-    build_mock = mocker.patch.object(
+def test_checks_polls_a_none_verdict_through_the_registration_gap(mocker: MockerFixture) -> None:
+    """`none` right after a push is polled, not returned as the answer.
+
+    Regression coverage for a Codex review on PR #167. The head commit of a just-pushed branch
+    reports a null `statusCheckRollup` until GitHub registers the workflow runs the push triggered,
+    which `build_checks_result` grades as `none`. The loop only continued on `pending`, so
+    `checks --timeout-seconds 270` returned that first snapshot instantly — indistinguishable from
+    a repository with no CI at all, at exactly the moment SKILL.md step 3 tells the reader to run
+    this command.
+    """
+    mocker.patch.object(
         pr_review_threads,
         "build_checks_result",
-        return_value=_checks_result("pending", blockers=["draft: reviewers are not requested until the PR is ready"]),
+        side_effect=[_checks_result("none"), _checks_result("pending"), _checks_result("passed")],
+    )
+    sleep_mock = mocker.patch.object(pr_review_threads.time, "sleep")
+
+    result = runner.invoke(app, ["checks", "--pr", "3208", "--interval-seconds", "1", "--timeout-seconds", "40"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["status"] == "passed"
+    assert sleep_mock.call_count == 2
+
+
+def test_checks_settles_a_persistent_none_after_one_grace_poll(mocker: MockerFixture) -> None:
+    """A repository with no CI costs one extra interval, not the caller's whole window.
+
+    The counterpart to `test_checks_polls_a_none_verdict_through_the_registration_gap`: `none` is
+    polled once, and a second `none` is the answer. Two `build_checks_result` calls against a
+    40-second window with a 1-second interval — a loop that kept polling `none` for the window
+    would make many more.
+    """
+    build_mock = mocker.patch.object(pr_review_threads, "build_checks_result", return_value=_checks_result("none"))
+    sleep_mock = mocker.patch.object(pr_review_threads.time, "sleep")
+
+    result = runner.invoke(app, ["checks", "--pr", "3208", "--interval-seconds", "1", "--timeout-seconds", "40"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["status"] == "none"
+    assert build_mock.call_count == 2
+    assert sleep_mock.call_count == 1
+
+
+def test_checks_keeps_waiting_on_a_draft_pr(mocker: MockerFixture) -> None:
+    """A draft blocker does not stop the wait: GitHub does run workflows on a draft PR.
+
+    Regression coverage for a Codex review on PR #167. Any non-empty `reviewability.blockers` used
+    to short-circuit the loop, on the strength of a claim about *reviewers* not being requested for
+    a draft. Workflows are a different mechanism: `pull_request` fires on a draft for its default
+    activity types, and this repository's own `.github/workflows/test.yml` and `benchmark.yml`
+    trigger on a bare `pull_request` with no `types:` filter and no draft guard (verified against
+    the workflow files, 2026-08-31). A `pending` verdict is itself proof a check context exists.
+    """
+    mocker.patch.object(
+        pr_review_threads,
+        "build_checks_result",
+        side_effect=[_checks_result("pending", is_draft=True), _checks_result("passed", is_draft=True)],
+    )
+    sleep_mock = mocker.patch.object(pr_review_threads.time, "sleep")
+
+    result = runner.invoke(app, ["checks", "--pr", "3208", "--interval-seconds", "1", "--timeout-seconds", "40"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["status"] == "passed"
+    assert data["reviewability"]["blockers"] != []
+    sleep_mock.assert_called_once_with(1)
+
+
+def test_checks_stops_waiting_on_a_conflicting_pr(mocker: MockerFixture) -> None:
+    """A conflicting PR ends the wait at once: GitHub builds no merge ref, so no workflow runs."""
+    build_mock = mocker.patch.object(
+        pr_review_threads, "build_checks_result", return_value=_checks_result("pending", mergeable="CONFLICTING")
     )
     sleep_mock = mocker.patch.object(pr_review_threads.time, "sleep")
 
@@ -1623,6 +1729,28 @@ def test_checks_stops_waiting_when_the_pr_cannot_run_checks(mocker: MockerFixtur
     assert json.loads(result.output)["status"] == "pending"
     build_mock.assert_called_once()
     sleep_mock.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("is_draft", "mergeable", "expected"),
+    [
+        (False, "MERGEABLE", False),
+        (True, "MERGEABLE", False),
+        (False, "CONFLICTING", True),
+        (True, "CONFLICTING", True),
+        (False, "UNKNOWN", False),
+    ],
+    ids=["clean", "draft-only", "conflicting-only", "both", "mergeability-not-computed-yet"],
+)
+def test_checks_blocked_only_counts_the_conflicting_blocker(is_draft: bool, mergeable: str, expected: bool) -> None:
+    """`blockers` is not one undifferentiated list: only conflict stops CI, draft stops reviewers.
+
+    `UNKNOWN` is not a conflict — GitHub computes mergeability in a background job, and that is
+    precisely the state just after a push, when `checks` is most likely to be called.
+    """
+    reviewability = pr_review_gh._reviewability(_head_state(is_draft=is_draft, mergeable=mergeable))
+
+    assert pr_review_gh.checks_blocked(reviewability) is expected
 
 
 def test_checks_rejects_a_non_positive_interval() -> None:

--- a/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
@@ -195,6 +195,9 @@ def _state(
         ],
         unresolved_count=unresolved_count,
         codex_approved=codex_approved,
+        codex_approval_stale=False,
+        codex_approved_at=_OLD_COMMIT_DATE if codex_approved else None,
+        latest_revision_at=_OLD_COMMIT_DATE,
         reviewability=Reviewability(is_draft=False, mergeable="MERGEABLE", merge_state_status="CLEAN", blockers=[]),
     )
 
@@ -681,6 +684,87 @@ def test_build_fetch_result_codex_approved_false_when_reaction_predates_head_com
     result = build_fetch_result("o", "r", 1)
 
     assert result.codex_approved is False
+
+
+def _codex_only_fetch(mocker: MockerFixture, reactions: list[Reaction], *, commit_date: datetime) -> FetchResult:
+    """Run `build_fetch_result` with only the reaction stream and head date varying."""
+    mocker.patch.object(pr_review_gh, "_fetch_pages", return_value=_empty_threads())
+    mocker.patch.object(pr_review_gh, "_fetch_review_pages", return_value=[_reviews_conn([])])
+    mocker.patch.object(pr_review_gh, "_fetch_issue_comments", return_value=[])
+    mocker.patch.object(pr_review_gh, "_fetch_pr_reactions", return_value=reactions)
+    _patch_identity_and_commit_date(mocker, commit_date=commit_date)
+    return build_fetch_result("o", "r", 1)
+
+
+def test_build_fetch_result_reports_a_stale_codex_approval_distinctly_from_no_approval(mocker: MockerFixture) -> None:
+    """ "Codex approved an older revision" and "Codex never approved" are different answers.
+
+    Both are `codex_approved: False`, and they call for opposite actions: a stale approval means a
+    push invalidated it and a fresh review has to be *requested*, while no approval at all means
+    one is still coming and the caller should keep waiting. Collapsing the two into one boolean is
+    what made the real observation on Jamie-BitFlight/mkapidocs#26 unreadable — a `+1` at
+    `03:37:24Z` against a head committed at `03:40:38Z`, correctly not current, reported
+    identically to a PR Codex had never looked at.
+
+    `codex_approved_at` and `latest_revision_at` carry the evidence so a caller can say by how much.
+    """
+    approved_at = datetime(2026, 1, 1, tzinfo=UTC)
+    head_committed_at = datetime(2026, 1, 2, tzinfo=UTC)
+    reaction = Reaction(content="+1", user=Author(login="chatgpt-codex-connector[bot]"), created_at=approved_at)
+
+    stale = _codex_only_fetch(mocker, [reaction], commit_date=head_committed_at)
+
+    assert stale.codex_approved is False
+    assert stale.codex_approval_stale is True
+    assert stale.codex_approved_at == approved_at
+    assert stale.latest_revision_at == head_committed_at
+
+
+def test_build_fetch_result_reports_no_codex_approval_as_neither_current_nor_stale(mocker: MockerFixture) -> None:
+    """A PR Codex has never reacted to is `False` on both flags, with no approval timestamp."""
+    never = _codex_only_fetch(mocker, [], commit_date=datetime(2026, 1, 2, tzinfo=UTC))
+
+    assert never.codex_approved is False
+    assert never.codex_approval_stale is False
+    assert never.codex_approved_at is None
+
+
+def test_build_fetch_result_current_codex_approval_is_not_also_stale(mocker: MockerFixture) -> None:
+    """The two flags are mutually exclusive: an approval that is current is never also stale."""
+    reaction = Reaction(
+        content="+1", user=Author(login="chatgpt-codex-connector[bot]"), created_at=datetime(2026, 1, 2, tzinfo=UTC)
+    )
+
+    current = _codex_only_fetch(mocker, [reaction], commit_date=datetime(2026, 1, 1, tzinfo=UTC))
+
+    assert current.codex_approved is True
+    assert current.codex_approval_stale is False
+
+
+def test_build_fetch_result_reads_the_latest_codex_reaction_when_several_exist(mocker: MockerFixture) -> None:
+    """Across revisions a PR accumulates several `+1`s; only the most recent can still apply."""
+    reactions = [
+        Reaction(content="+1", user=Author(login="chatgpt-codex-connector[bot]"), created_at=day)
+        for day in (datetime(2026, 1, 1, tzinfo=UTC), datetime(2026, 1, 3, tzinfo=UTC))
+    ]
+
+    result = _codex_only_fetch(mocker, reactions, commit_date=datetime(2026, 1, 2, tzinfo=UTC))
+
+    assert result.codex_approved is True
+    assert result.codex_approved_at == datetime(2026, 1, 3, tzinfo=UTC)
+
+
+def test_a_stale_codex_approval_is_not_outstanding_work() -> None:
+    """`watch` must not treat a stale approval as a reason to return.
+
+    `has_outstanding_work` keys on `codex_approved` alone, and that is deliberate: a stale approval
+    is not a signal that arrived, it is one that expired. Returning on it would make `watch` exit
+    immediately and forever on any PR whose approval a push invalidated.
+    """
+    state = _state()
+    stale = state.model_copy(update={"codex_approval_stale": True, "codex_approved_at": _OLD_COMMIT_DATE})
+
+    assert stale.has_outstanding_work() is False
 
 
 def test_build_fetch_result_codex_approved_false_when_reaction_predates_reused_commit_force_push(


### PR DESCRIPTION
Codex raised three defects on #167 four and a half minutes after it merged, so nobody acted on them. All three were still live on `origin/main`; each is verified below before being fixed. A fourth change came out of a separate false report whose observation was real even though its diagnosis was not.

## `status: "none"` was never polled

`pr_review_threads.py:349` continued only on `"pending"`. A just-pushed head commit reports a null `statusCheckRollup` until GitHub registers the workflow runs the push triggered; `build_checks_result` grades that empty rollup as `"none"`, so `checks --timeout-seconds 270` returned the first snapshot instantly — at exactly the moment SKILL.md step 3 tells the reader to run it. The caller got "no checks configured" seconds after a push, indistinguishable from a repo with no CI.

**The rule chosen:** `pending` polls for the caller's whole window — it is proof a check context exists and has not finished. `none` gets exactly **one** re-poll of grace, then it is the answer.

That bound introduces no duration of its own, which is the point. The wait is one `--interval-seconds` — the unit the caller already passed as "how long between observations" — and `--timeout-seconds` still caps it. One observation after a wait is the least that can separate the two cases: a registration gap has closed into a real verdict by then, while a repo with genuinely no CI still reports `none` and settles after one extra interval instead of spinning out the whole window. The reasoning lives in `_checks_unsettled`'s docstring, at the loop.

## The draft blocker stopped the poll, and its premise was false

Any non-empty `reviewability.blockers` ended the wait. But the draft blocker (`pr_review_gh.py:453`) reads "reviewers are not requested until the PR is marked ready for review" — a statement about **reviews**, used to decide something about **checks**.

Verified against this repo's own workflows: `.github/workflows/test.yml` and `benchmark.yml` both trigger on a bare `pull_request` with no `types:` filter, and `grep -rn draft .github/workflows/` returns nothing. Both therefore run on draft PRs. A `pending` status is itself proof a check context exists and can still settle.

The two blockers are no longer interchangeable. `pr_review_gh.checks_blocked` is the single place the distinction is made:

- **conflicting** → still short-circuits. GitHub builds no merge ref for a conflicting PR, so no `pull_request` workflow has anything to check out.
- **draft** → no longer does.

**The false claim is corrected in both places it appeared** — the `checks` docstring in `pr_review_threads.py` and SKILL.md — which each said GitHub runs no workflows on a draft *or* a conflicting PR. Only the conflicting half is true. `Reviewability`'s own docstring is untouched: for *reviewers*, the draft claim is correct, and that is what `fetch` reads it for.

## The verdict and the reviewability came from two unlinked head reads

`build_checks_result` called `_fetch_check_contexts` then `_fetch_head_state`. `_CHECKS_QUERY` and `_HEAD_STATE_QUERY` each ran their own `commits(last: 1)`, neither selected `oid`, and nothing compared them — a push landing between the two calls yielded a result mixing an old head's rollup with a new head's PR state.

**Merged, not `oid`-compared.** The comment above `_HEAD_STATE_QUERY` already argued these fields "live on the same `pullRequest` object, so asking for them here costs no extra round trip"; the rollup follows the same reasoning. One query over one `pullRequest` snapshot removes the race structurally rather than detecting it, and it *deletes* a `gh` call from `checks` where `oid`-comparison would have added a retry path. `_fetch_check_contexts` is gone; `_CHECKS_QUERY` is gone.

Smoke-tested live: `checks --pr 167` returns `status: passed`, `total: 6` — exactly the six contexts this repo's branch protection marks required.

## A stale Codex approval now reads differently from no approval

A review sweep reported `codex_approved: false` on a PR whose 👍 was plainly present, and diagnosed a login match missing the `[bot]` suffix. **That diagnosis is wrong** — `_CODEX_REACTOR_LOGINS` already holds both spellings, the lookup is lowercased, and `test_is_codex_thumbs_up_true_regardless_of_bot_suffix` already asserts it. Nothing about the matching changed here.

The observation was real, though. On `Jamie-BitFlight/mkapidocs#26` the reaction landed at `03:37:24Z` and head `d546671` was committed at `03:40:38Z` — a push invalidated the approval three minutes later, and the staleness rule correctly refused to report it as current. The defect was that the answer was *unreadable*: one boolean collapsed two situations calling for opposite actions.

`fetch` now reports `codex_approval_stale` alongside `codex_approved` (mutually exclusive by construction), plus `codex_approved_at` and `latest_revision_at` — the two timestamps the verdict was computed from, so a caller can say *how* stale, not only *that* it is. Confirmed live against that PR: `codex_approval_stale: True` with both timestamps.

`has_outstanding_work` still keys on `codex_approved` alone, deliberately. A stale approval is a signal that expired, not one that arrived; returning on it would make `watch` exit immediately and forever on any PR whose approval a push invalidated. A test pins that.

## Evidence

Every new test was run against `origin/main`'s production files before the fix. Each fails for the right reason, not merely fails:

| Test | Pre-fix failure |
|---|---|
| `test_checks_polls_a_none_verdict_through_the_registration_gap` | `assert 'none' == 'passed'` — never polled |
| `test_checks_settles_a_persistent_none_after_one_grace_poll` | `assert 1 == 2` — no grace poll taken |
| `test_checks_keeps_waiting_on_a_draft_pr` | `assert 'pending' == 'passed'` — draft short-circuited |
| `test_checks_reads_the_verdict_and_the_pr_state_from_one_head_snapshot` | `StopIteration` — a second `gh` call was made |
| `test_build_fetch_result_reports_a_stale_codex_approval_distinctly_from_no_approval` | `AttributeError: no attribute 'codex_approval_stale'` |

`test_checks_stops_waiting_on_a_conflicting_pr` passes on both sides — preserved behaviour, not new.

`test_checks_returns_without_sleeping_once_settled` loses `"none"` from its parametrize list. That is the contract change, stated in its docstring: `none` is no longer terminal on sight.

## Gate

`uv run prek run --all-files` — all 22 hooks Passed.
`uv run pytest` — `1487 passed, 10 skipped in 78.51s`, coverage 86.37%. `test_io_scan_1000_skills_timing` passed in the full parallel run.

## No new constants

The `none` grace period is one `--interval-seconds`, a value the caller supplies. No timeout, interval, or threshold is introduced by this diff.