### PR TITLE
ci(ruff): stop ruff check rewriting the CI checkout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
         run: uv sync --locked
 
       - name: Lint code
-        run: uv run --locked ruff check --output-format=github
+        run: uv run --locked ruff check --no-fix --output-format=github
         continue-on-error: false
 
   typecheck-ty:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,6 @@ exclude = [
     # Deliberately-broken fixtures -- must never be linted or fixed.
     "packages/skilllint/tests/fixtures/providers/*/failing-examples/*",
 ]
-fix = true
 line-length = 120
 src = [".github", "packages", "scripts", "tests"]
 target-version = "py311"


### PR DESCRIPTION
## The defect: CI is green on a dirty tree

`pyproject.toml` set `fix = true` under `[tool.ruff]`. That makes plain `ruff check` **apply fixes and write files** — it is not a read-only check.

The CI lint step ran it with no `--no-fix`:

```yaml
# .github/workflows/test.yml:81 (before)
- name: Lint code
  run: uv run --locked ruff check --output-format=github
```

So the job rewrote its own checkout, then reported on the tree it had just repaired. When every violation was fixable, the job exited 0 — and the fixes were discarded with the runner. The invariant CI was supposed to assert (*the committed tree passes ruff*) was never actually asserted, and violations could sit on `main` indefinitely while CI stayed green.

## Evidence

All measured in this session against `575b517` (this branch's parent), ruff 0.16.5, using the exact CI invocations.

**1. Baseline probe — is `main` currently carrying laundered fixes?**

```
$ uv run --locked ruff check --output-format=github
EXIT=0
$ git status --porcelain
(clean)
```

No. `main` is genuinely clean today, so there is nothing to land here beyond the config. This is the good case — but it was luck, not enforcement.

**2. Green-on-dirty, reproduced.** Added a module-level `import sys, os` (plus a use, so no `F401`) to `packages/skilllint/token_utils.py` — violations `I001` and `E401`, both fixable:

```
BEFORE_MD5: 5cf38c644e798eabd06e861c762ec779
$ uv run --locked ruff check --output-format=github     # the old CI command
EXIT=0
AFTER_MD5:  15b36453fa910030155538945977fc29
```

**Exit 0, and the file changed on disk.** That is the defect in one command.

**3. Same input, after this PR:**

```
BEFORE_MD5: 5cf38c644e798eabd06e861c762ec779
$ uv run --locked ruff check --no-fix --output-format=github
EXIT=1
AFTER_MD5:  5cf38c644e798eabd06e861c762ec779
```

Non-zero exit, byte-identical file. CI now fails on unclean input instead of laundering it.

## The fix

| Change | Why |
| --- | --- |
| Drop `fix = true` from `[tool.ruff]` | `ruff check` becomes read-only by default, everywhere — CI, ad-hoc runs, editors |
| Add `--no-fix` to the CI lint step | The job asserts its own invariant explicitly, so future config drift cannot silently re-enable rewriting |

Two lines, no source changes.

**Deliberately unchanged:**

- `unsafe-fixes = true` — not part of this defect; it governs which fixes are offered, not whether `check` writes.
- **Local auto-fix still works.** The pre-commit ruff hook passes `--fix` explicitly (`.pre-commit-config.yaml:75`), so it never depended on the config flag. Developer workflow is unaffected.

## Verification

Full gate run on the untouched parent and again on this branch — identical results:

| | `uv run prek run --all-files` | `uv run pytest` |
| --- | --- | --- |
| Baseline (`575b517`) | all 22 hooks Passed | 1487 passed, 10 skipped |
| This branch | all 22 hooks Passed, exit 0 | 1487 passed, 10 skipped, exit 0 |

## Incidental finding (not addressed here)

`pyproject.toml:253` sets `unfixable = ["F401"]`, so unused imports are never auto-removed — they always surface as a real failure. That is why the *first* probe I tried didn't reproduce the mutation. Worth knowing; left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJeBLNA9ybmQvv5REMDkrc