### PR TITLE
fix: address top code-review findings from this week's changes

### DIFF
--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_gh.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_gh.py
@@ -16,8 +16,9 @@ import re
 import shutil
 import subprocess
 import time
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
-from typing import Literal
+from typing import Literal, NamedTuple
 
 from pr_review_models import (
     CheckContext,
@@ -95,7 +96,7 @@ query($o: String!, $r: String!, $pr: Int!) {
 # One query for every PR-level field this script reads off the head: the three reviewability
 # fields, the head commit's date, and its check rollup. They all live on the same `pullRequest`
 # object, so asking for them together costs one round trip instead of two, and `build_fetch_result`
-# is already seven sequential `gh` calls deep.
+# already makes seven `gh` calls per snapshot.
 #
 # The rollup used to be fetched by a second query with its own `commits(last: 1)`. Neither query
 # selected `oid` and nothing compared them, so a push landing between the two calls produced a
@@ -668,9 +669,10 @@ def gh_timeout_budget(deadline: float | None, gh_timeout: float | None) -> float
     `deadline` is `None` for a plain `fetch` and for `watch`'s mandatory first fetch: neither has a
     window to respect, so the caller's `--gh-timeout-seconds` applies unchanged (`None` = no
     bound). `watch` passes its own `deadline` for each *poll*, so all seven of
-    `build_fetch_result`'s `gh` calls are bounded by whatever is actually left, re-measured between
-    them, rather than by a fixed reservation subtracted from every poll regardless of how fast
-    GitHub responds.
+    `build_fetch_result`'s `gh` calls -- issued concurrently, so each is budgeted from
+    approximately the same moment rather than from a progressively later one -- are bounded by
+    whatever is actually left in that poll's window, rather than by a fixed reservation subtracted
+    from every poll regardless of how fast GitHub responds.
 
     Args:
         deadline: A `time.monotonic()` timestamp to respect, or `None` for no deadline.
@@ -684,6 +686,82 @@ def gh_timeout_budget(deadline: float | None, gh_timeout: float | None) -> float
     return max(0.0, deadline - time.monotonic())
 
 
+class _ConcurrentFetch(NamedTuple):
+    """The typed result of `_fetch_concurrently`'s seven independent `gh` calls.
+
+    A plain tuple (or a list gathered in a loop) would force every element to the same union type
+    under static type checking, since nothing about a bare sequence records which position held
+    which call's result. A `NamedTuple` keeps each field's own type -- `list[ReviewThreadsConnection]`
+    for `thread_pages`, `str` for `authenticated_login`, and so on -- exactly as if each had been
+    assigned from its own sequential call, which is what `build_fetch_result` used to do before
+    these seven moved onto a thread pool.
+    """
+
+    thread_pages: list[ReviewThreadsConnection]
+    review_pages: list[ReviewsConnection]
+    issue_comments: list[IssueComment]
+    reactions: list[Reaction]
+    authenticated_login: str
+    head_state: PullRequestHeadState
+    latest_force_push_at: datetime | None
+
+
+def _fetch_concurrently(
+    owner: str, repo: str, pr: int, *, deadline: float | None, gh_timeout: float | None
+) -> _ConcurrentFetch:
+    """Run `build_fetch_result`'s seven independent `gh` calls on a thread pool and gather them.
+
+    Split out of `build_fetch_result` itself so the pool's bookkeeping (one `Future` per call)
+    stays local to this function instead of adding seven more names to a function already busy
+    assembling the result. Each call is a blocking `subprocess` invocation, not native async I/O,
+    hence a thread pool rather than asyncio -- and none of the seven consumes another's output, so
+    there is no reason to pay the sum of seven round-trip latencies instead of the max.
+
+    Args:
+        owner: Repository owner login.
+        repo: Repository name.
+        pr: Pull request number.
+        deadline: A `time.monotonic()` timestamp each call should respect — see `gh_timeout_budget`.
+        gh_timeout: Per-call bound applied when `deadline` is `None`.
+
+    Returns:
+        All seven calls' results, gathered in a fixed field order so a failure raises the same
+        call's exception a sequential run would have raised first.
+    """
+    with ThreadPoolExecutor(max_workers=7) as executor:
+        thread_pages_future = executor.submit(
+            _fetch_pages, owner, repo, pr, gh_timeout=gh_timeout_budget(deadline, gh_timeout)
+        )
+        review_pages_future = executor.submit(
+            _fetch_review_pages, owner, repo, pr, gh_timeout=gh_timeout_budget(deadline, gh_timeout)
+        )
+        issue_comments_future = executor.submit(
+            _fetch_issue_comments, owner, repo, pr, gh_timeout=gh_timeout_budget(deadline, gh_timeout)
+        )
+        reactions_future = executor.submit(
+            _fetch_pr_reactions, owner, repo, pr, gh_timeout=gh_timeout_budget(deadline, gh_timeout)
+        )
+        authenticated_login_future = executor.submit(
+            _fetch_authenticated_login, gh_timeout=gh_timeout_budget(deadline, gh_timeout)
+        )
+        head_state_future = executor.submit(
+            _fetch_head_state, owner, repo, pr, gh_timeout=gh_timeout_budget(deadline, gh_timeout)
+        )
+        latest_force_push_at_future = executor.submit(
+            _fetch_latest_force_push_at, owner, repo, pr, gh_timeout=gh_timeout_budget(deadline, gh_timeout)
+        )
+
+        return _ConcurrentFetch(
+            thread_pages=thread_pages_future.result(),
+            review_pages=review_pages_future.result(),
+            issue_comments=issue_comments_future.result(),
+            reactions=reactions_future.result(),
+            authenticated_login=authenticated_login_future.result(),
+            head_state=head_state_future.result(),
+            latest_force_push_at=latest_force_push_at_future.result(),
+        )
+
+
 def build_fetch_result(
     owner: str, repo: str, pr: int, *, deadline: float | None = None, gh_timeout: float | None = None
 ) -> FetchResult:
@@ -691,7 +769,10 @@ def build_fetch_result(
 
     Shared by `fetch` (prints the result once, `deadline=None`) and `watch` (calls this repeatedly
     on a polling interval, passing its own deadline) so both subcommands assemble a `FetchResult`
-    identically. Makes seven `gh` calls, each independently bounded by `gh_timeout_budget(deadline)`:
+    identically. Makes seven `gh` calls concurrently (a thread pool, since each is a blocking
+    `subprocess` call rather than native async I/O) -- none consumes another's output, so there is
+    no reason to pay the sum of seven round-trip latencies instead of the max. Each is
+    independently bounded by `gh_timeout_budget(deadline)`:
     the paginated review-threads query, the paginated reviews query, every PR-level issue comment
     (for `unresponded_reviews`), every reaction on the PR itself (for `codex_approved`), the
     currently-authenticated `gh` identity (also for `unresponded_reviews`), and the PR's head
@@ -743,19 +824,11 @@ def build_fetch_result(
         Codex's approval reaction is present right now for the current revision, for an older one,
         or not at all.
     """
-    thread_pages = _fetch_pages(owner, repo, pr, gh_timeout=gh_timeout_budget(deadline, gh_timeout))
-    review_pages = _fetch_review_pages(owner, repo, pr, gh_timeout=gh_timeout_budget(deadline, gh_timeout))
-    issue_comments = _fetch_issue_comments(owner, repo, pr, gh_timeout=gh_timeout_budget(deadline, gh_timeout))
-    reactions = _fetch_pr_reactions(owner, repo, pr, gh_timeout=gh_timeout_budget(deadline, gh_timeout))
-    authenticated_login = _fetch_authenticated_login(gh_timeout=gh_timeout_budget(deadline, gh_timeout))
-    head_state = _fetch_head_state(owner, repo, pr, gh_timeout=gh_timeout_budget(deadline, gh_timeout))
-    latest_force_push_at = _fetch_latest_force_push_at(
-        owner, repo, pr, gh_timeout=gh_timeout_budget(deadline, gh_timeout)
-    )
-    latest_revision_at = _latest_revision_at(head_state, latest_force_push_at)
+    fetched = _fetch_concurrently(owner, repo, pr, deadline=deadline, gh_timeout=gh_timeout)
+    latest_revision_at = _latest_revision_at(fetched.head_state, fetched.latest_force_push_at)
 
-    all_threads = [node for page in thread_pages for node in page.nodes]
-    all_reviews = [node for page in review_pages for node in page.nodes]
+    all_threads = [node for page in fetched.thread_pages for node in page.nodes]
+    all_reviews = [node for page in fetched.review_pages for node in page.nodes]
     unresolved = [
         UnresolvedThread(
             id=node.id,
@@ -769,16 +842,18 @@ def build_fetch_result(
     reviews_with_body = [review for review in all_reviews if review.body.strip()]
 
     own_comments = [
-        comment for comment in issue_comments if comment.user is not None and comment.user.login == authenticated_login
+        comment
+        for comment in fetched.issue_comments
+        if comment.user is not None and comment.user.login == fetched.authenticated_login
     ]
     unresponded_reviews = _unresponded_reviews(reviews_with_body, own_comments)
-    codex_approved_at = _latest_codex_approval_at(reactions)
+    codex_approved_at = _latest_codex_approval_at(fetched.reactions)
 
     return FetchResult(
-        reviews_count=review_pages[0].totalCount,
+        reviews_count=fetched.review_pages[0].totalCount,
         reviews_with_body=reviews_with_body,
         unresponded_reviews=unresponded_reviews,
-        threads_count=thread_pages[0].totalCount,
+        threads_count=fetched.thread_pages[0].totalCount,
         unresolved=unresolved,
         unresolved_count=len(unresolved),
         # Present and at/after the current revision vs. present and before it: two conditions over
@@ -788,7 +863,7 @@ def build_fetch_result(
         codex_approval_stale=codex_approved_at is not None and codex_approved_at < latest_revision_at,
         codex_approved_at=codex_approved_at,
         latest_revision_at=latest_revision_at,
-        reviewability=_reviewability(head_state),
+        reviewability=_reviewability(fetched.head_state),
     )
 
 

--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_gh.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_gh.py
@@ -727,8 +727,16 @@ def _fetch_concurrently(
     Returns:
         All seven calls' results, gathered in a fixed field order so a failure raises the same
         call's exception a sequential run would have raised first.
+
+    A failing call is reported the moment its own `.result()` raises -- it does not wait for
+    still-running siblings. `executor.shutdown()` always runs with `wait=False`: on the success
+    path every future is already done by the time its `.result()` returns, so `wait=False` costs
+    nothing; on a failure path it is what stops the pool from blocking the exception behind
+    whichever sibling call happens to be slowest (the old `with ThreadPoolExecutor(...) as
+    executor:` form called the default `shutdown(wait=True)` on exit, which did exactly that).
     """
-    with ThreadPoolExecutor(max_workers=7) as executor:
+    executor = ThreadPoolExecutor(max_workers=7)
+    try:
         thread_pages_future = executor.submit(
             _fetch_pages, owner, repo, pr, gh_timeout=gh_timeout_budget(deadline, gh_timeout)
         )
@@ -760,6 +768,11 @@ def _fetch_concurrently(
             head_state=head_state_future.result(),
             latest_force_push_at=latest_force_push_at_future.result(),
         )
+    finally:
+        # `cancel_futures=True` drops any of the seven not yet started (none, in practice, since
+        # `max_workers=7` covers all seven submissions at once); `wait=False` is what keeps a
+        # raised exception from waiting on the rest -- see the docstring above.
+        executor.shutdown(wait=False, cancel_futures=True)
 
 
 def build_fetch_result(

--- a/.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/pr_review_threads.py
@@ -118,15 +118,15 @@ def _owner_repo(github: str | None, *, gh_timeout: float | None) -> tuple[str, s
 
     Raises:
         typer.Exit: Autodetection was attempted (no `--github` given) and failed -- `gh` is
-            missing, unauthenticated, or this checkout has no GitHub remote `gh` recognizes.
-            Exits with code 1; nothing else is printed to stdout.
+            missing, unauthenticated, timed out, or this checkout has no GitHub remote `gh`
+            recognizes. Exits with code 1; nothing else is printed to stdout.
     """
     if github is not None:
         owner, repo = github.split("/", 1)
         return owner, repo
     try:
         return detect_repo_identity(gh_timeout=gh_timeout)
-    except (FileNotFoundError, subprocess.CalledProcessError, ValidationError) as exc:
+    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired, ValidationError) as exc:
         typer.echo(
             f"Could not detect this checkout's GitHub repository via `gh repo view` ({exc}). "
             "Pass --github owner/repo to specify it explicitly.",

--- a/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
@@ -408,6 +408,42 @@ def test_fetch_flattens_pages_filters_resolved_and_derives_new_fields(mocker: Mo
     }
 
 
+# --- _fetch_concurrently: fail-fast on one call while a sibling is still running ----------------
+
+
+def test_fetch_concurrently_fails_fast_without_waiting_for_slow_sibling(mocker: MockerFixture) -> None:
+    """A failing `gh` call must surface promptly even while a sibling call is still running.
+
+    Regression test for the old `with ThreadPoolExecutor(...) as executor:` form: its `__exit__`
+    called the default `shutdown(wait=True)`, which blocked the whole function until every
+    submitted future finished -- including ones nothing had asked for the result of yet -- before
+    the original failure was ever reported. `_fetch_pr_reactions` is field 4 in `_ConcurrentFetch`'s
+    fixed evaluation order and raises immediately; `_fetch_head_state` is field 6 (later, so its
+    own `.result()` is never reached) and sleeps far longer than this test's budget. A correct
+    fix reports the exception without waiting on that sleep.
+    """
+    slow_seconds = 2.0
+    mocker.patch.object(pr_review_gh, "_fetch_pages", return_value=_empty_threads())
+    mocker.patch.object(pr_review_gh, "_fetch_review_pages", return_value=[_reviews_conn([])])
+    mocker.patch.object(pr_review_gh, "_fetch_issue_comments", return_value=[])
+    mocker.patch.object(pr_review_gh, "_fetch_pr_reactions", side_effect=subprocess.CalledProcessError(1, ["gh"]))
+    mocker.patch.object(pr_review_gh, "_fetch_authenticated_login", return_value=_AGENT_LOGIN)
+
+    def _slow_head_state(*args: object, **kwargs: object) -> PullRequestHeadState:
+        time.sleep(slow_seconds)
+        return _head_state(_OLD_COMMIT_DATE)
+
+    mocker.patch.object(pr_review_gh, "_fetch_head_state", side_effect=_slow_head_state)
+    mocker.patch.object(pr_review_gh, "_fetch_latest_force_push_at", return_value=None)
+
+    started = time.monotonic()
+    with pytest.raises(subprocess.CalledProcessError):
+        pr_review_gh._fetch_concurrently("o", "r", 1, deadline=None, gh_timeout=None)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < slow_seconds / 2
+
+
 # --- build_fetch_result: unresponded_reviews / codex_approved unit matrix ----------------------
 
 

--- a/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
+++ b/.agents/skills/receiving-pr-reviews/scripts/test_pr_review_threads.py
@@ -355,19 +355,32 @@ def test_fetch_flattens_pages_filters_resolved_and_derives_new_fields(mocker: Mo
     })
     # No `HeadRefForcePushedEvent` has ever landed on this PR — an empty `timelineItems.nodes`.
     force_push_raw = json.dumps({"data": {"repository": {"pullRequest": {"timelineItems": {"nodes": []}}}}})
-    mocker.patch.object(
-        pr_review_gh,
-        "run_gh",
-        side_effect=[
-            json.dumps(thread_pages),
-            json.dumps(reviews_pages),
-            issue_comments_raw,
-            reactions_raw,
-            _AGENT_LOGIN,
-            head_state_raw,
-            force_push_raw,
-        ],
-    )
+
+    def _run_gh_by_args(args: list[str], *, timeout: float | None = None) -> str:
+        """Route each `run_gh` call to its scripted response by *which* call it is, not by call
+        order — `build_fetch_result`'s seven `gh` calls run concurrently on a thread pool, so
+        nothing guarantees they reach this mock in submission order the way a positional
+        `side_effect` list would require.
+        """
+        query = next((arg for arg in args if arg.startswith("query=")), None)
+        if query == f"query={pr_review_gh._UNRESOLVED_THREADS_QUERY}":
+            return json.dumps(thread_pages)
+        if query == f"query={pr_review_gh._REVIEWS_QUERY}":
+            return json.dumps(reviews_pages)
+        if query == f"query={pr_review_gh._HEAD_STATE_QUERY}":
+            return head_state_raw
+        if query == f"query={pr_review_gh._LATEST_FORCE_PUSH_QUERY}":
+            return force_push_raw
+        if any(arg.endswith("/comments") for arg in args):
+            return issue_comments_raw
+        if any(arg.endswith("/reactions") for arg in args):
+            return reactions_raw
+        if args[:2] == ["api", "user"]:
+            return _AGENT_LOGIN
+        message = f"unexpected run_gh call in test: {args}"
+        raise AssertionError(message)
+
+    mocker.patch.object(pr_review_gh, "run_gh", side_effect=_run_gh_by_args)
 
     result = runner.invoke(app, ["fetch", "--pr", "3208"])
 
@@ -1016,6 +1029,25 @@ def test_fetch_exits_nonzero_and_names_github_flag_when_detection_fails(mocker: 
     principle rules out silently guessing an identity here).
     """
     mocker.patch.object(pr_review_threads, "detect_repo_identity", side_effect=subprocess.CalledProcessError(1, ["gh"]))
+    fetch_mock = mocker.patch.object(pr_review_threads, "build_fetch_result")
+
+    result = runner.invoke(app, ["fetch", "--pr", "3208"])
+
+    assert result.exit_code != 0
+    assert "--github" in result.output
+    fetch_mock.assert_not_called()
+
+
+def test_fetch_exits_nonzero_and_names_github_flag_when_detection_times_out(mocker: MockerFixture) -> None:
+    """A `gh repo view` that exceeds `--gh-timeout-seconds` is handled the same as any other detection failure.
+
+    `detect_repo_identity` bounds its `gh` call with `gh_timeout` and raises `subprocess.TimeoutExpired` when it's
+    exceeded — that exception must stop the command with the same `--github` guidance as any other detection
+    failure, not propagate as an unhandled exception.
+    """
+    mocker.patch.object(
+        pr_review_threads, "detect_repo_identity", side_effect=subprocess.TimeoutExpired(cmd=["gh"], timeout=30)
+    )
     fetch_mock = mocker.patch.object(pr_review_threads, "build_fetch_result")
 
     result = runner.invoke(app, ["fetch", "--pr", "3208"])

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -2117,7 +2117,7 @@ class FrontmatterValidator:
 
         hooks_value = data.get("hooks")
         if isinstance(hooks_value, dict):
-            HookValidator().validate_hook_script_references_in_hooks_dict(hooks_value, path.parent, errors)
+            HookValidator().validate_hook_script_references_in_hooks_dict(hooks_value, path.parent, errors, warnings)
 
     def can_fix(self) -> bool:
         """Check if validator supports auto-fixing.
@@ -3346,11 +3346,12 @@ class HookValidator:
         if hooks_obj is None:
             return ValidationResult(passed=False, errors=errors, warnings=[], info=[])
 
+        warnings: list[ValidationIssue] = []
         errors.extend(check_hk002(hooks_obj))
         errors.extend(check_hk003(hooks_obj))
-        self.validate_hook_script_references_in_hooks_dict(hooks_obj, path.parent, errors)
+        self.validate_hook_script_references_in_hooks_dict(hooks_obj, path.parent, errors, warnings)
 
-        return ValidationResult(passed=not errors, errors=errors, warnings=[], info=[])
+        return ValidationResult(passed=not errors, errors=errors, warnings=warnings, info=[])
 
     def can_fix(self) -> bool:
         """Check if validator supports auto-fixing.
@@ -3439,20 +3440,30 @@ class HookValidator:
         return find_hook_plugin_dir(base_dir)
 
     def _validate_command_script_references(
-        self, hook_entries: Iterable[object], base_dir: Path, errors: list[ValidationIssue]
+        self,
+        hook_entries: Iterable[object],
+        base_dir: Path,
+        errors: list[ValidationIssue],
+        warnings: list[ValidationIssue],
     ) -> None:
         """Check that file-path ``command`` values in hook entries exist and are executable.
 
         Args:
             hook_entries: List of hook entry dicts to inspect.
             base_dir: Directory to use as the resolution base for relative paths.
-            errors: List to append HK004 errors and HK005 warnings to.
+            errors: List to append HK004 (error-severity) issues to.
+            warnings: List to append HK005 (warning-severity) issues to.
         """
         errors.extend(check_hk004(hook_entries, base_dir))
-        errors.extend(check_hk005(hook_entries, base_dir))
+        for issue in check_hk005(hook_entries, base_dir):
+            (errors if issue.severity == "error" else warnings).append(issue)
 
     def validate_hook_script_references_in_hooks_dict(
-        self, hooks_dict: Mapping[str, YamlValue], base_dir: Path, errors: list[ValidationIssue]
+        self,
+        hooks_dict: Mapping[str, YamlValue],
+        base_dir: Path,
+        errors: list[ValidationIssue],
+        warnings: list[ValidationIssue],
     ) -> None:
         """Validate command file-path references in a hooks configuration dict.
 
@@ -3463,10 +3474,11 @@ class HookValidator:
         Args:
             hooks_dict: Hooks configuration mapping event types to groups.
             base_dir: Directory used as base for resolving relative script paths.
-            errors: List to append HK004 errors and HK005 warnings to.
+            errors: List to append HK004 (error-severity) issues to.
+            warnings: List to append HK005 (warning-severity) issues to.
         """
         for entry in iter_hook_entries(hooks_dict):
-            self._validate_command_script_references([entry], base_dir, errors)
+            self._validate_command_script_references([entry], base_dir, errors, warnings)
 
 
 # ============================================================================
@@ -3742,6 +3754,8 @@ def _get_fixers_for_path(validators: list[Validator], path: Path) -> list[Valida
         ``validators`` plus any fix-only validator that applies to this path.
     """
     if not validators or FileType.detect_file_type(path) not in _NAME_BEARING_FILE_TYPES:
+        return validators
+    if _frontmatter_requirement(path) == _FrontmatterRequirement.EXEMPT:
         return validators
     return [*validators, NameFormatValidator()]
 

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -3332,9 +3332,10 @@ class HookValidator:
         HK001 is terminal: an unreadable file, invalid JSON, or a missing /
         non-object top-level ``hooks`` key leaves nothing for the remaining
         rules to inspect.  Otherwise HK002/HK003 check the structure and
-        HK004/HK005 check the referenced scripts.  All issues share one list so
-        that missing-script warnings surface in the same result as structural
-        errors.
+        HK004/HK005 check the referenced scripts.  HK004 (missing script) is
+        a hard error and goes to ``errors``; HK005 (non-executable script) is
+        a warning and goes to ``warnings``.  ``passed`` reflects ``errors``
+        only, so HK005 findings alone do not fail validation.
 
         Args:
             path: Path to hooks.json

--- a/packages/skilllint/rule_registry.py
+++ b/packages/skilllint/rule_registry.py
@@ -34,6 +34,8 @@ from pydantic import BaseModel, Field
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from skilllint.plugin_validator import ValidationIssue
+
 _logger = logging.getLogger(__name__)
 
 
@@ -52,6 +54,33 @@ def rule_reference(code: str) -> str:
         The ``skilllint rule <CODE>`` invocation for that rule.
     """
     return f"skilllint rule {str(code).upper()}"
+
+
+def _make_issue(
+    *, field: str, severity: Literal["error", "warning", "info"], message: str, code: str, suggestion: str | None = None
+) -> ValidationIssue:
+    """Construct a ValidationIssue for a rule.
+
+    Shared across the rules/*.py series modules to avoid duplicating the same
+    construction across files.
+
+    Args:
+        field: Issue field label (meaning varies by rule series).
+        severity: Issue severity.
+        message: Human-readable description.
+        code: Rule code (e.g. "FM001").
+        suggestion: Optional repair hint.
+
+    Returns:
+        A frozen ValidationIssue instance.
+    """
+    # Deferred import to break the circular dependency: plugin_validator
+    # imports rules/, so rules/ cannot import plugin_validator at module level.
+    from skilllint.plugin_validator import ValidationIssue  # noqa: PLC0415
+
+    return ValidationIssue(
+        field=field, severity=severity, message=message, code=code, docs_url=rule_reference(code), suggestion=suggestion
+    )
 
 
 class RuleAuthority(BaseModel):

--- a/packages/skilllint/rules/_mcp_tool_discovery.py
+++ b/packages/skilllint/rules/_mcp_tool_discovery.py
@@ -14,6 +14,7 @@ Entry points:
 
 from __future__ import annotations
 
+import functools
 import json
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
@@ -72,6 +73,11 @@ def _extract_mcp_server_keys(data: dict[str, object]) -> set[str]:
     return set()
 
 
+# ponytail: global process-lifetime cache; fine for a linter CLI invocation.
+# Paths don't mutate mid-run, so re-walking the same ancestry for every
+# skill/agent file in a large plugin is pure waste (see AGENTS.md efficiency
+# review: same root plugin.json/.mcp.json re-read/re-parsed per file).
+@functools.cache
 def collect_plugin_names_from_ancestry(file_path: pathlib.Path) -> dict[str, set[str]]:
     """Walk upward from *file_path* collecting plugin names from plugin.json files.
 
@@ -114,6 +120,11 @@ def collect_plugin_names_from_ancestry(file_path: pathlib.Path) -> dict[str, set
     return plugin_server_map
 
 
+# ponytail: global process-lifetime cache; fine for a linter CLI invocation.
+# Ancestor plugin.json/.mcp.json are never touched by --fix (which only
+# rewrites the file being checked), so a stale-cache read is not possible
+# for a same-path re-validation pass within one process.
+@functools.cache
 def _collect_servers_from_ancestry(file_path: pathlib.Path) -> set[str]:
     """Walk upward from *file_path* collecting MCP server names from config files.
 
@@ -174,6 +185,12 @@ def _is_plugin_packaged_agent(file_path: pathlib.Path) -> bool:
     return file_path.parent == plugin_dir / "agents"
 
 
+# ponytail: global process-lifetime cache; fine for a linter CLI invocation.
+# Safe for a --fix revalidation pass on the same path: no fixer in this
+# codebase writes the mcpServers frontmatter key (grep confirmed), so the
+# file's own mcpServers value cannot change between the pre-fix and
+# post-fix validation calls this memoizes across.
+@functools.cache
 def _collect_servers_from_frontmatter(file_path: pathlib.Path) -> set[str]:
     """Extract MCP server names declared inline in the agent/skill frontmatter.
 

--- a/packages/skilllint/rules/ag_series.py
+++ b/packages/skilllint/rules/ag_series.py
@@ -31,10 +31,10 @@ plugin_validator at module level.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from skilllint.frontmatter_core import normalize_tools_value
-from skilllint.rule_registry import rule_reference, skilllint_rule
+from skilllint.rule_registry import _make_issue, skilllint_rule
 from skilllint.rules._mcp_tool_discovery import (
     analyze_mcp_tool_reference,
     collect_plugin_names_from_ancestry,
@@ -71,30 +71,6 @@ _UNRESOLVABLE_WILDCARD_TOOLS: frozenset[str] = frozenset({"mcp__*"})
 # Fields the "Supported frontmatter fields" table defines for MCP tool
 # grants/denials on an agent file.
 _AGENT_TOOL_FIELD_NAMES: tuple[str, ...] = ("tools", "disallowedTools")
-
-
-def _make_issue(
-    *, field: str, severity: Literal["error", "warning", "info"], message: str, code: str, suggestion: str | None = None
-) -> ValidationIssue:
-    """Construct a ValidationIssue for an AG rule.
-
-    Args:
-        field: Frontmatter field name (``tools``, ``disallowedTools``, or ``skills``).
-        severity: Issue severity.
-        message: Human-readable description.
-        code: Rule code (e.g. "AG001").
-        suggestion: Optional repair hint.
-
-    Returns:
-        A frozen ValidationIssue instance.
-    """
-    # Deferred import to break the circular dependency: plugin_validator
-    # imports rules/, so rules/ cannot import plugin_validator at module level.
-    from skilllint.plugin_validator import ValidationIssue  # noqa: PLC0415
-
-    return ValidationIssue(
-        field=field, severity=severity, message=message, code=code, docs_url=rule_reference(code), suggestion=suggestion
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/packages/skilllint/rules/as_series.py
+++ b/packages/skilllint/rules/as_series.py
@@ -19,6 +19,7 @@ Severities:
 
 from __future__ import annotations
 
+import functools
 import logging
 from typing import TYPE_CHECKING
 
@@ -334,6 +335,11 @@ def _check_as006(path: pathlib.Path) -> dict | None:
     )
 
 
+# ponytail: global process-lifetime cache; fine for a linter CLI invocation.
+# Ancestor plugin.json is never touched by --fix (which only rewrites the
+# file being checked), so a stale-cache read is not possible for a
+# same-path re-validation pass within one process.
+@functools.cache
 def _find_plugin_json_in_ancestry(path: pathlib.Path) -> bool:
     """Return True if any ancestor directory contains a .claude-plugin/plugin.json file.
 

--- a/packages/skilllint/rules/hk_series.py
+++ b/packages/skilllint/rules/hk_series.py
@@ -32,10 +32,10 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from skilllint.boundary.hooks_json_ingest import HooksJsonDefect, ingest_hooks_json
-from skilllint.rule_registry import rule_reference, skilllint_rule
+from skilllint.rule_registry import _make_issue, skilllint_rule
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Mapping
@@ -84,30 +84,6 @@ _REQUIRED_FIELD_BY_HOOK_TYPE: dict[str, str] = {
     "http": "url",
     "agent": "prompt",
 }
-
-
-def _make_issue(
-    *, field: str, severity: Literal["error", "warning", "info"], message: str, code: str, suggestion: str | None = None
-) -> ValidationIssue:
-    """Construct a ValidationIssue for an HK rule.
-
-    Args:
-        field: JSON path of the offending value (e.g. ``hooks.PreToolUse[0]``).
-        severity: Issue severity.
-        message: Human-readable description.
-        code: Rule code (e.g. "HK001").
-        suggestion: Optional repair hint.
-
-    Returns:
-        A frozen ValidationIssue instance.
-    """
-    # Deferred import to break the circular dependency: plugin_validator
-    # imports rules/, so rules/ cannot import plugin_validator at module level.
-    from skilllint.plugin_validator import ValidationIssue  # noqa: PLC0415
-
-    return ValidationIssue(
-        field=field, severity=severity, message=message, code=code, docs_url=rule_reference(code), suggestion=suggestion
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/packages/skilllint/rules/lk_series.py
+++ b/packages/skilllint/rules/lk_series.py
@@ -38,9 +38,9 @@ plugin_validator at module level.
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
-from skilllint.rule_registry import rule_reference, skilllint_rule
+from skilllint.rule_registry import _make_issue, skilllint_rule
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -194,30 +194,6 @@ def _resolve_claude_variables(url: str, skill_dir: Path) -> str | None:
             return None
         resolved = resolved.replace("${CLAUDE_PLUGIN_ROOT}", str(plugin_root))
     return resolved
-
-
-def _make_issue(
-    *, field: str, severity: Literal["error", "warning", "info"], message: str, code: str, suggestion: str | None = None
-) -> ValidationIssue:
-    """Construct a ValidationIssue for an LK rule.
-
-    Args:
-        field: The field name the issue concerns.
-        severity: Issue severity.
-        message: Human-readable description.
-        code: Rule code (e.g. "LK001").
-        suggestion: Optional repair hint.
-
-    Returns:
-        A frozen ValidationIssue instance.
-    """
-    # Deferred import to break the circular dependency: plugin_validator
-    # imports rules/, so rules/ cannot import plugin_validator at module level.
-    from skilllint.plugin_validator import ValidationIssue  # noqa: PLC0415
-
-    return ValidationIssue(
-        field=field, severity=severity, message=message, code=code, docs_url=rule_reference(code), suggestion=suggestion
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/packages/skilllint/rules/nr_series.py
+++ b/packages/skilllint/rules/nr_series.py
@@ -30,11 +30,11 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import msgspec
 
-from skilllint.rule_registry import rule_reference, skilllint_rule
+from skilllint.rule_registry import _make_issue, skilllint_rule
 
 if TYPE_CHECKING:
     from skilllint.plugin_validator import ValidationIssue
@@ -55,30 +55,6 @@ if TYPE_CHECKING:
 # which says nothing about traversal, boundaries, escaping, or symlinks —
 # verified via `grep -ci` returning 0 for those terms against the cached spec.)
 _NR002_PATH_TRAVERSAL_URL = "https://code.claude.com/docs/en/plugins-reference.md#path-traversal-limitations"
-
-
-def _make_issue(
-    *, field: str, severity: Literal["error", "warning", "info"], message: str, code: str, suggestion: str | None = None
-) -> ValidationIssue:
-    """Construct a ValidationIssue for an NR rule.
-
-    Args:
-        field: Issue field label ("namespace-reference" for reference findings).
-        severity: Issue severity.
-        message: Human-readable description.
-        code: Rule code (e.g., "NR001").
-        suggestion: Optional repair hint.
-
-    Returns:
-        A frozen ValidationIssue instance.
-    """
-    # Deferred import to break the circular dependency: plugin_validator
-    # imports rules/, so rules/ cannot import plugin_validator at module level.
-    from skilllint.plugin_validator import ValidationIssue  # noqa: PLC0415
-
-    return ValidationIssue(
-        field=field, severity=severity, message=message, code=code, docs_url=rule_reference(code), suggestion=suggestion
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/packages/skilllint/rules/pd_series.py
+++ b/packages/skilllint/rules/pd_series.py
@@ -28,9 +28,9 @@ plugin_validator at module level.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
-from skilllint.rule_registry import rule_reference, skilllint_rule
+from skilllint.rule_registry import _make_issue, skilllint_rule
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -40,30 +40,6 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Spec sources
 # ---------------------------------------------------------------------------
-
-
-def _make_issue(
-    *, field: str, severity: Literal["error", "warning", "info"], message: str, code: str, suggestion: str | None = None
-) -> ValidationIssue:
-    """Construct a ValidationIssue for a PD rule.
-
-    Args:
-        field: Issue field label.
-        severity: Issue severity.
-        message: Human-readable description.
-        code: Rule code (e.g., "PD001").
-        suggestion: Optional organisation hint.
-
-    Returns:
-        A frozen ValidationIssue instance.
-    """
-    # Deferred import to break the circular dependency: plugin_validator
-    # imports rules/, so rules/ cannot import plugin_validator at module level.
-    from skilllint.plugin_validator import ValidationIssue  # noqa: PLC0415
-
-    return ValidationIssue(
-        field=field, severity=severity, message=message, code=code, docs_url=rule_reference(code), suggestion=suggestion
-    )
 
 
 def _check_disclosure_dir(path: Path, dir_name: str, code: str) -> list[ValidationIssue]:

--- a/packages/skilllint/rules/pl_series.py
+++ b/packages/skilllint/rules/pl_series.py
@@ -47,11 +47,11 @@ plugin_validator at module level.
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import msgspec
 
-from skilllint.rule_registry import rule_reference, skilllint_rule
+from skilllint.rule_registry import _make_issue, skilllint_rule
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -125,30 +125,6 @@ _CLAUDE_ERROR_PATTERNS: dict[str, str] = {
     "PL004": r"path.*must.*start.*with.*\./|invalid.*path.*format",
     "PL005": r"file.*does not exist|referenced.*file.*not found|missing.*file",
 }
-
-
-def _make_issue(
-    *, field: str, severity: Literal["error", "warning", "info"], message: str, code: str, suggestion: str | None = None
-) -> ValidationIssue:
-    """Construct a ValidationIssue for a PL rule.
-
-    Args:
-        field: Manifest file the issue concerns ("plugin.json" / "marketplace.json").
-        severity: Issue severity.
-        message: Human-readable description.
-        code: Rule code (e.g. "PL001").
-        suggestion: Optional repair hint.
-
-    Returns:
-        A frozen ValidationIssue instance.
-    """
-    # Deferred import to break the circular dependency: plugin_validator
-    # imports rules/, so rules/ cannot import plugin_validator at module level.
-    from skilllint.plugin_validator import ValidationIssue  # noqa: PLC0415
-
-    return ValidationIssue(
-        field=field, severity=severity, message=message, code=code, docs_url=rule_reference(code), suggestion=suggestion
-    )
 
 
 def analyze_marketplace_root_keys(data: dict[str, YamlValue]) -> tuple[list[str], list[str]]:

--- a/packages/skilllint/rules/pr_series.py
+++ b/packages/skilllint/rules/pr_series.py
@@ -38,11 +38,11 @@ plugin_validator at module level.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import msgspec.json
 
-from skilllint.rule_registry import rule_reference, skilllint_rule
+from skilllint.rule_registry import _make_issue, skilllint_rule
 
 if TYPE_CHECKING:
     from skilllint.plugin_validator import ValidationIssue, YamlValue
@@ -120,41 +120,17 @@ def parse_registered_paths(manifest: dict[str, YamlValue], plugin_dir: Path, fie
     value = manifest[field]
 
     if isinstance(value, str):
-        value_path = plugin_dir / value.lstrip("./")
+        value_path = plugin_dir / value.removeprefix("./")
         if value_path.is_dir():
             registered.update(
                 f.relative_to(plugin_dir) for f in value_path.glob("*.md") if f.name not in FRONTMATTER_EXEMPT_FILENAMES
             )
         else:
-            registered.add(Path(value.lstrip("./")))
+            registered.add(Path(value.removeprefix("./")))
     elif isinstance(value, list):
-        registered.update(Path(item.lstrip("./")) for item in value if isinstance(item, str))
+        registered.update(Path(item.removeprefix("./")) for item in value if isinstance(item, str))
 
     return registered
-
-
-def _make_issue(
-    *, field: str, severity: Literal["error", "warning", "info"], message: str, code: str, suggestion: str | None = None
-) -> ValidationIssue:
-    """Construct a ValidationIssue for a PR rule.
-
-    Args:
-        field: The manifest field the issue concerns (always "plugin.json").
-        severity: Issue severity.
-        message: Human-readable description.
-        code: Rule code (e.g. "PR001").
-        suggestion: Optional repair hint.
-
-    Returns:
-        A frozen ValidationIssue instance.
-    """
-    # Deferred import to break the circular dependency: plugin_validator
-    # imports rules/, so rules/ cannot import plugin_validator at module level.
-    from skilllint.plugin_validator import ValidationIssue  # noqa: PLC0415
-
-    return ValidationIssue(
-        field=field, severity=severity, message=message, code=code, docs_url=rule_reference(code), suggestion=suggestion
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/packages/skilllint/rules/sl_series.py
+++ b/packages/skilllint/rules/sl_series.py
@@ -28,9 +28,9 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
-from skilllint.rule_registry import rule_reference, skilllint_rule
+from skilllint.rule_registry import _make_issue, skilllint_rule
 
 if TYPE_CHECKING:
     from skilllint.plugin_validator import ValidationIssue
@@ -71,30 +71,6 @@ def iter_symlinks(path: Path) -> list[Path]:
                     symlinks.append(candidate)
 
     return symlinks
-
-
-def _make_issue(
-    *, field: str, severity: Literal["error", "warning", "info"], message: str, code: str, suggestion: str | None = None
-) -> ValidationIssue:
-    """Construct a ValidationIssue for an SL rule.
-
-    Args:
-        field: The symlink path the issue concerns.
-        severity: Issue severity.
-        message: Human-readable description.
-        code: Rule code (e.g. "SL001").
-        suggestion: Optional repair hint.
-
-    Returns:
-        A frozen ValidationIssue instance.
-    """
-    # Deferred import to break the circular dependency: plugin_validator
-    # imports rules/, so rules/ cannot import plugin_validator at module level.
-    from skilllint.plugin_validator import ValidationIssue  # noqa: PLC0415
-
-    return ValidationIssue(
-        field=field, severity=severity, message=message, code=code, docs_url=rule_reference(code), suggestion=suggestion
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/packages/skilllint/tests/test_hook_script_discovery.py
+++ b/packages/skilllint/tests/test_hook_script_discovery.py
@@ -109,10 +109,11 @@ class TestValidateCommandScriptReferences:
 
         validator = HookValidator()
         errors: list = []
+        warnings: list = []
         entries: list[dict[str, YamlValue]] = [{"type": "command", "command": "./hook.sh"}]
-        validator._validate_command_script_references(entries, tmp_path, errors)
+        validator._validate_command_script_references(entries, tmp_path, errors, warnings)
 
-        hk_codes = [e.code for e in errors]
+        hk_codes = [e.code for e in errors] + [e.code for e in warnings]
         assert "HK004" not in hk_codes
         assert "HK005" not in hk_codes
 
@@ -125,8 +126,9 @@ class TestValidateCommandScriptReferences:
         """
         validator = HookValidator()
         errors: list = []
+        warnings: list = []
         entries: list[dict[str, YamlValue]] = [{"type": "command", "command": "./nonexistent.sh"}]
-        validator._validate_command_script_references(entries, tmp_path, errors)
+        validator._validate_command_script_references(entries, tmp_path, errors, warnings)
 
         hk_codes = [e.code for e in errors]
         assert "HK004" in hk_codes
@@ -147,11 +149,13 @@ class TestValidateCommandScriptReferences:
 
         validator = HookValidator()
         errors: list = []
+        warnings: list = []
         entries: list[dict[str, YamlValue]] = [{"type": "command", "command": "./hook.sh"}]
-        validator._validate_command_script_references(entries, tmp_path, errors)
+        validator._validate_command_script_references(entries, tmp_path, errors, warnings)
 
-        hk_codes = [e.code for e in errors]
+        hk_codes = [e.code for e in warnings]
         assert "HK005" in hk_codes
+        assert "HK005" not in [e.code for e in errors]
 
     def test_shell_command_ignored(self, tmp_path: Path) -> None:
         """Test that bare shell commands are not validated as file paths.
@@ -162,10 +166,12 @@ class TestValidateCommandScriptReferences:
         """
         validator = HookValidator()
         errors: list = []
+        warnings: list = []
         entries: list[dict[str, YamlValue]] = [{"type": "command", "command": "echo hello"}]
-        validator._validate_command_script_references(entries, tmp_path, errors)
+        validator._validate_command_script_references(entries, tmp_path, errors, warnings)
 
         assert len(errors) == 0
+        assert len(warnings) == 0
 
     def test_plugin_root_variable(self, tmp_path: Path) -> None:
         """Test ${CLAUDE_PLUGIN_ROOT} variable resolution.
@@ -190,10 +196,11 @@ class TestValidateCommandScriptReferences:
 
         validator = HookValidator()
         errors: list = []
+        warnings: list = []
         entries: list[dict[str, YamlValue]] = [{"type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hook.sh"}]
-        validator._validate_command_script_references(entries, hooks_dir, errors)
+        validator._validate_command_script_references(entries, hooks_dir, errors, warnings)
 
-        hk_codes = [e.code for e in errors]
+        hk_codes = [e.code for e in errors] + [e.code for e in warnings]
         assert "HK004" not in hk_codes
         assert "HK005" not in hk_codes
 
@@ -216,9 +223,10 @@ class TestHookScriptReferencesInHooksDict:
 
         validator = HookValidator()
         errors: list = []
-        validator.validate_hook_script_references_in_hooks_dict(hooks_dict, tmp_path, errors)
+        warnings: list = []
+        validator.validate_hook_script_references_in_hooks_dict(hooks_dict, tmp_path, errors, warnings)
 
-        hk_codes = [e.code for e in errors]
+        hk_codes = [e.code for e in errors] + [e.code for e in warnings]
         assert "HK004" not in hk_codes
         assert "HK005" not in hk_codes
 
@@ -235,7 +243,8 @@ class TestHookScriptReferencesInHooksDict:
 
         validator = HookValidator()
         errors: list = []
-        validator.validate_hook_script_references_in_hooks_dict(hooks_dict, tmp_path, errors)
+        warnings: list = []
+        validator.validate_hook_script_references_in_hooks_dict(hooks_dict, tmp_path, errors, warnings)
 
         hk_codes = [e.code for e in errors]
         assert "HK004" in hk_codes
@@ -253,9 +262,11 @@ class TestHookScriptReferencesInHooksDict:
 
         validator = HookValidator()
         errors: list = []
-        validator.validate_hook_script_references_in_hooks_dict(hooks_dict, tmp_path, errors)
+        warnings: list = []
+        validator.validate_hook_script_references_in_hooks_dict(hooks_dict, tmp_path, errors, warnings)
 
         assert len(errors) == 0
+        assert len(warnings) == 0
 
 
 class TestFrontmatterHooksIntegration:

--- a/scripts/post_coverage_summary.mjs
+++ b/scripts/post_coverage_summary.mjs
@@ -21,7 +21,7 @@ export default async function postCoverageSummary({ github, context }) {
   });
 
   const existing = comments.data.find(
-    (c) => c.user.type === 'Bot' && c.body.includes('📊 Test Coverage'),
+    (c) => c.user?.type === 'Bot' && c.body.includes('📊 Test Coverage'),
   );
 
   const body =

--- a/scripts/post_coverage_summary.test.mjs
+++ b/scripts/post_coverage_summary.test.mjs
@@ -93,6 +93,25 @@ describe('postCoverageSummary', () => {
   );
 
   it(
+    'creates comment when an existing comment has a null user (deleted account)',
+    withTempCoverageDir(async () => {
+      writeFileSync('coverage-reports/coverage.xml', `<coverage line-rate="0.85"/>`);
+
+      const gh = mockGithub();
+      gh._state.comments.push({
+        id: 1,
+        user: null,
+        body: '## 📊 Test Coverage Report\n\n**Coverage:** 50.00%\n\n...',
+      });
+
+      await postCoverageSummary({ github: gh, context: mockContext() });
+
+      assert.equal(gh._state.created.body.includes('85.00%'), true);
+      assert.equal(gh._state.updated, null);
+    }),
+  );
+
+  it(
     'returns N/A when line-rate attribute missing',
     withTempCoverageDir(async () => {
       writeFileSync('coverage-reports/coverage.xml', `<coverage branch-rate="0.5"/>`);

--- a/scripts/uvu
+++ b/scripts/uvu
@@ -8,5 +8,5 @@ set -eu
     echo "usage: $0 [uv-add-args] <package>..." >&2
     exit 2
 }
-uv remove "$@"
+uv remove "$@" || true
 uv add "$@"


### PR DESCRIPTION
## Summary
- Fix `--fix` path skipping the frontmatter-exemption check (could rewrite exempt files like AGENTS.md)
- Split HK005 warnings from errors so warning-only issues don't flip `passed=False`
- Guard `scripts/uvu`'s `uv remove` so a new (undeclared) dependency doesn't abort under `set -eu`
- Catch `subprocess.TimeoutExpired` in `pr_review_threads._owner_repo`
- Null-guard `c.user` in `post_coverage_summary.mjs` for deleted GitHub accounts
- Fix `pr_series` path normalization (`.removeprefix` over `.lstrip`) for paths like `../shared/cmd.md`
- Consolidate the duplicated `_make_issue` helper across the `*_series` rule modules into `rule_registry.py`
- Cache repeated ancestor-directory `plugin.json`/`.mcp.json` walks with `functools.cache`
- Parallelize `pr_review_gh.py`'s independent `gh` calls via `ThreadPoolExecutor`

Found via `/code-review high --fix` over this week's changes (`77d596c`..`40f3eeb`, 37 commits).

## Test plan
- [x] `uv run prek run --all-files` — all hooks pass
- [x] `uv run pytest` — 1488 passed, 10 skipped, 86.36% coverage
- [x] `uv run ty check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XXp48LEDndUtAWJe1nDtgd