### PR TITLE
test: guard claim files against value drift, not just missing symbols

### DIFF
--- a/docs/design-rule-provenance-registry.md
+++ b/docs/design-rule-provenance-registry.md
@@ -155,6 +155,8 @@ Each entry maps a **claim** (a specific assertion made by a rule) to its authori
     "source_type": "python_constant | schema_json_field | schema_json_enum"
   },
 
+  "expected_value": "the value the resolved symbol must currently hold -- a scalar, an array of strings for a set/field_set claim, or a regex pattern string for a pattern claim. Checked by packages/skilllint/tests/test_provenance_registry_locators.py, which normalizes set/list/tuple values order-independently and compiled patterns by their .pattern string before comparing. Required on every claim (#146) -- a locator that only resolves, without asserting a value, does not catch the code drifting away from what the claim describes.",
+
   "x-audited": {
     "date": "string -- ISO 8601 date of last successful verification",
     "source": "string -- vendor file path used in last verification"
@@ -182,11 +184,18 @@ Rules with no upstream authority -- pure lint-style opinions -- go in a separate
       "description": "string -- what the rule enforces",
       "rationale": "string -- why this is a lint opinion rather than a spec requirement",
       "constraint": "string -- the specific check (e.g., regex pattern, field check)",
-      "references": ["string -- any supporting context, not authoritative"]
+      "references": ["string -- prose pointer to where the constraint lives; must not include a line number, since that is exactly the fact assertion_location now tracks (#146)"],
+      "assertion_location": "same shape as the claim entry field above -- an opinion still names a resolvable Python symbol, it just has no vendor authority behind it",
+      "expected_value": "same meaning as the claim entry field above"
     }
   }
 }
 ```
+
+`assertion_location` and `expected_value` are checked by the same test as the
+provenance registry's (`test_provenance_registry_locators.py`), which iterates
+both files' entries through one loop -- an opinion is "no vendor source", not
+"no verifiable claim", so it gets the same locator+value guard.
 
 ### Rules classified as opinions (from provenance audit)
 

--- a/packages/skilllint/schemas/opinion-catalog.json
+++ b/packages/skilllint/schemas/opinion-catalog.json
@@ -9,8 +9,14 @@
       "rationale": "The 4400-token warning threshold is an empirical observation about context-window pressure, not a vendor-specified limit. No upstream spec or schema defines a maximum skill body token count.",
       "constraint": "TOKEN_WARNING_THRESHOLD = 4400 (tokens, approximate)",
       "references": [
-        "packages/skilllint/token_counter.py line 41: TOKEN_WARNING_THRESHOLD: int = 4400"
-      ]
+        "packages/skilllint/limits.py: BODY_TOKEN_WARNING"
+      ],
+      "assertion_location": {
+        "file": "packages/skilllint/limits.py",
+        "symbol": "BODY_TOKEN_WARNING",
+        "source_type": "python_constant"
+      },
+      "expected_value": 4400
     },
     "SK007": {
       "rule_code": "SK007",
@@ -18,8 +24,14 @@
       "rationale": "The 8800-token error threshold is an empirical observation about when skill bodies become unwieldy, not a vendor-specified limit. No upstream spec or schema defines a maximum skill body token count.",
       "constraint": "TOKEN_ERROR_THRESHOLD = 8800 (tokens, approximate)",
       "references": [
-        "packages/skilllint/token_counter.py line 44: TOKEN_ERROR_THRESHOLD: int = 8800"
-      ]
+        "packages/skilllint/limits.py: BODY_TOKEN_ERROR"
+      ],
+      "assertion_location": {
+        "file": "packages/skilllint/limits.py",
+        "symbol": "BODY_TOKEN_ERROR",
+        "source_type": "python_constant"
+      },
+      "expected_value": 8800
     },
     "SK005": {
       "rule_code": "SK005",
@@ -27,7 +39,25 @@
       "rationale": "Trigger phrases enable the model to decide when to auto-load a skill. No vendor schema or spec defines a required set of trigger phrases. The specific phrase list is a lint opinion.",
       "constraint": "Description must contain at least one of: 'use when', 'use this', 'use on', 'used when', 'used by', 'when ', 'trigger', 'activate', 'load this', 'load when', 'invoke'",
       "references": [
-        "packages/skilllint/rules/sk_series.py lines 154-165: _REQUIRED_TRIGGER_PHRASES"
+        "packages/skilllint/rules/sk_series.py: _REQUIRED_TRIGGER_PHRASES"
+      ],
+      "assertion_location": {
+        "file": "packages/skilllint/rules/sk_series.py",
+        "symbol": "_REQUIRED_TRIGGER_PHRASES",
+        "source_type": "python_constant"
+      },
+      "expected_value": [
+        "activate",
+        "invoke",
+        "load this",
+        "load when",
+        "trigger",
+        "use on",
+        "use this",
+        "use when",
+        "used by",
+        "used when",
+        "when "
       ]
     },
     "FM004": {
@@ -37,7 +67,13 @@
       "constraint": "Description field should use a single-line string, not a YAML block scalar or folded scalar",
       "references": [
         "packages/skilllint/rules/fm_series.py: _FM004_DESCRIPTION_BLOCK_SCALAR regex and check_fm004 function"
-      ]
+      ],
+      "assertion_location": {
+        "file": "packages/skilllint/rules/fm_series.py",
+        "symbol": "_FM004_DESCRIPTION_BLOCK_SCALAR",
+        "source_type": "python_constant"
+      },
+      "expected_value": "(?m)^description\\s*:\\s*(?:\\|[-+]?|>[-+]?)(?:\\s+#.*)?\\s*$"
     },
     "FM010.name_pattern": {
       "rule_code": "FM010",
@@ -45,9 +81,15 @@
       "rationale": "The agentskills.io schema enforces maxLength=64 but does not specify a regex pattern for the name field. The lowercase-alphanumeric-with-hyphens pattern and the consecutive-hyphen prohibition have no vendor source; they are lint opinions based on convention.",
       "constraint": "Name must match ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ and must not contain consecutive hyphens (--)",
       "references": [
-        "packages/skilllint/rules/fm_series.py: _NAME_RE = re.compile(r'^[a-z0-9]([a-z0-9-]*[a-z0-9])?$')",
-        "packages/skilllint/rules/fm_series.py: _CONSECUTIVE_HYPHENS_RE = re.compile(r'--')"
-      ]
+        "packages/skilllint/rules/fm_series.py: _NAME_RE",
+        "packages/skilllint/rules/fm_series.py: _CONSECUTIVE_HYPHENS_RE"
+      ],
+      "assertion_location": {
+        "file": "packages/skilllint/rules/fm_series.py",
+        "symbol": "_NAME_RE",
+        "source_type": "python_constant"
+      },
+      "expected_value": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
     },
     "FM007.claude_code_tool_fields": {
       "rule_code": "FM007",
@@ -57,7 +99,13 @@
       "references": [
         "packages/skilllint/rules/fm_series.py: _CLAUDE_CODE_TOOL_FIELD_NAMES",
         "packages/skilllint/schemas/claude_code/v1.json: declares `tools`, does not declare `disallowedTools`"
-      ]
+      ],
+      "assertion_location": {
+        "file": "packages/skilllint/rules/fm_series.py",
+        "symbol": "_CLAUDE_CODE_TOOL_FIELD_NAMES",
+        "source_type": "python_constant"
+      },
+      "expected_value": ["disallowedTools", "tools"]
     },
     "HK003.valid_hook_types": {
       "rule_code": "HK003",
@@ -67,7 +115,13 @@
       "references": [
         "packages/skilllint/rules/hk_series.py: VALID_HOOK_TYPES",
         "docs/design-rule-provenance-registry.md: HK003 VALID_HOOK_TYPES has no vendor source"
-      ]
+      ],
+      "assertion_location": {
+        "file": "packages/skilllint/rules/hk_series.py",
+        "symbol": "VALID_HOOK_TYPES",
+        "source_type": "python_constant"
+      },
+      "expected_value": ["agent", "command", "http", "prompt"]
     },
     "SK004.min_description_length": {
       "rule_code": "SK004",
@@ -75,9 +129,15 @@
       "rationale": "The 20-character minimum description length is a quality heuristic, not a spec requirement. The agentskills.io schema sets minLength=1 for description; the 20-char threshold is a lint opinion for description quality.",
       "constraint": "_MIN_DESCRIPTION_LENGTH = 20 (characters); the 1024 maximum is schema-backed (see provenance registry SK004.max_description_length)",
       "references": [
-        "packages/skilllint/rules/sk_series.py line 72: _MIN_DESCRIPTION_LENGTH = 20",
+        "packages/skilllint/rules/sk_series.py: _MIN_DESCRIPTION_LENGTH",
         "packages/skilllint/schemas/agentskills_io/v1.json: description minLength = 1 (spec minimum)"
-      ]
+      ],
+      "assertion_location": {
+        "file": "packages/skilllint/rules/sk_series.py",
+        "symbol": "_MIN_DESCRIPTION_LENGTH",
+        "source_type": "python_constant"
+      },
+      "expected_value": 20
     },
     "HK002.valid_event_types": {
       "rule_code": "HK002",
@@ -87,6 +147,35 @@
       "references": [
         "packages/skilllint/rules/hk_series.py: VALID_EVENT_TYPES",
         "docs/design-rule-provenance-registry.md: 12 of the 21 event names have no traceable vendor source"
+      ],
+      "assertion_location": {
+        "file": "packages/skilllint/rules/hk_series.py",
+        "symbol": "VALID_EVENT_TYPES",
+        "source_type": "python_constant"
+      },
+      "expected_value": [
+        "ConfigChange",
+        "Elicitation",
+        "ElicitationResult",
+        "InstructionsLoaded",
+        "Notification",
+        "PermissionRequest",
+        "PostCompact",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "PreCompact",
+        "PreToolUse",
+        "SessionEnd",
+        "SessionStart",
+        "Stop",
+        "StopFailure",
+        "SubagentStart",
+        "SubagentStop",
+        "TaskCompleted",
+        "TeammateIdle",
+        "UserPromptSubmit",
+        "WorktreeCreate",
+        "WorktreeRemove"
       ]
     }
   }

--- a/packages/skilllint/schemas/provenance-registry.json
+++ b/packages/skilllint/schemas/provenance-registry.json
@@ -25,6 +25,7 @@
         "symbol": "_MAX_NAME_LENGTH",
         "source_type": "python_constant"
       },
+      "expected_value": 64,
       "x-audited": {
         "date": "2026-03-14",
         "source": "packages/skilllint/schemas/agentskills_io/v1.json"
@@ -52,6 +53,7 @@
         "symbol": "_AGENTSKILLS_TOOL_FIELD_NAMES",
         "source_type": "python_constant"
       },
+      "expected_value": ["allowed-tools"],
       "x-audited": {
         "date": "2026-03-14",
         "source": "packages/skilllint/schemas/agentskills_io/v1.json"
@@ -79,6 +81,7 @@
         "symbol": "DESCRIPTION_MAX_LENGTH",
         "source_type": "python_constant"
       },
+      "expected_value": 1024,
       "x-audited": {
         "date": "2026-08-30",
         "source": "packages/skilllint/schemas/agentskills_io/v1.json"

--- a/packages/skilllint/tests/test_provenance_registry_locators.py
+++ b/packages/skilllint/tests/test_provenance_registry_locators.py
@@ -1,44 +1,108 @@
-"""Guard against provenance-registry.json locators pointing at nothing.
+"""Guard against claim files asserting values the code no longer holds.
 
-packages/skilllint/schemas/provenance-registry.json asserts that specific
-Python symbols back specific rule claims, but nothing loads the registry, so
-nothing checks those assertions are true. During #102's review a human found
-four locators pointing at symbols that did not exist (see #136). This test
-imports every ``python_constant`` locator's module and resolves its symbol,
-so drift is caught by CI instead of by a reviewer reading JSON.
+packages/skilllint/schemas/provenance-registry.json and
+packages/skilllint/schemas/opinion-catalog.json each assert that a specific
+Python symbol backs a specific rule claim, and (since #146) what value that
+symbol currently holds. Nothing loaded either file, so nothing checked those
+assertions were true. During #102's review a human found four locators
+pointing at symbols that did not exist (see #136); a separate audit for #146
+found opinion-catalog.json rows citing stale line numbers and one row
+asserting "no vendor document enumerates this set" when the cached vendor
+doc does exactly that. This test imports every ``python_constant`` locator's
+module, resolves its symbol, and asserts the live value matches
+``expected_value``, so both classes of drift are caught by CI instead of by
+a reviewer reading JSON.
 """
 
 from __future__ import annotations
 
 import importlib
 import json
+import re
 from pathlib import Path
+from re import Pattern
+from typing import Any
 
 REPO_ROOT = Path(__file__).parent.parent.parent.parent
-REGISTRY_PATH = REPO_ROOT / "packages" / "skilllint" / "schemas" / "provenance-registry.json"
+SCHEMAS_DIR = REPO_ROOT / "packages" / "skilllint" / "schemas"
+REGISTRY_PATH = SCHEMAS_DIR / "provenance-registry.json"
+OPINION_CATALOG_PATH = SCHEMAS_DIR / "opinion-catalog.json"
 
 # docs/design-rule-provenance-registry.md:155 documents assertion_location.source_type
 # as "python_constant | schema_json_field | schema_json_enum".
 _KNOWN_SOURCE_TYPES = frozenset({"python_constant", "schema_json_field", "schema_json_enum"})
 
 
-def test_provenance_registry_python_constant_locators_resolve() -> None:
-    """Every python_constant assertion_location must import and resolve."""
+def _normalize(value: object) -> object:
+    """Reduce a resolved symbol or an expected_value to a comparable form.
+
+    Covers every claim shape currently in the two catalogs: scalars, regex
+    patterns (compared by .pattern), and sets/lists/tuples of strings
+    (compared order-independently, since frozenset iteration order is not
+    a claim any rule makes).
+    """
+    if isinstance(value, Pattern):
+        return value.pattern
+    if isinstance(value, (set, frozenset, list, tuple)):
+        return sorted(str(item) for item in value)
+    return value
+
+
+def _iter_claims() -> list[tuple[str, dict[str, Any]]]:
+    """Yield (claim_id, claim) from both catalog files.
+
+    provenance-registry.json claims have a vendor authority; opinion-catalog.json
+    rows are explicit "no vendor source" opinions. Both make the same kind of
+    locator + value assertion about the code, so both are checked by the same
+    loop rather than by two near-duplicate tests.
+    """
     registry = json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
-    for claim_id, claim in registry["claims"].items():
+    opinions = json.loads(OPINION_CATALOG_PATH.read_text(encoding="utf-8"))
+    return [*registry["claims"].items(), *opinions["opinions"].items()]
+
+
+def test_claim_locators_resolve_and_values_match() -> None:
+    """Every python_constant assertion_location must import, resolve, and match."""
+    for claim_id, claim in _iter_claims():
         location = claim["assertion_location"]
         source_type = location["source_type"]
         assert source_type in _KNOWN_SOURCE_TYPES, f"{claim_id}: unrecognized source_type '{source_type}'"
         if source_type != "python_constant":
             continue
+
         recorded_file = location["file"]
         assert (REPO_ROOT / recorded_file).is_file(), (
             f"{claim_id}: assertion_location.file '{recorded_file}' does not exist"
         )
+
         module_name = recorded_file.removeprefix("packages/").removesuffix(".py").replace("/", ".")
-        target = importlib.import_module(module_name)
+        target: object = importlib.import_module(module_name)
         for part in location["symbol"].split("."):
             assert hasattr(target, part), (
                 f"{claim_id}: {recorded_file} has no symbol '{location['symbol']}' (missing '{part}')"
             )
             target = getattr(target, part)
+
+        assert "expected_value" in claim, f"{claim_id}: missing expected_value"
+        actual = _normalize(target)
+        expected = _normalize(claim["expected_value"])
+        assert actual == expected, (
+            f"{claim_id}: {recorded_file}.{location['symbol']} is {actual!r}, but expected_value says {expected!r}"
+        )
+
+
+def test_opinion_catalog_references_carry_no_stale_line_numbers() -> None:
+    """references entries must not cite a line number.
+
+    A line number is exactly the fact assertion_location.symbol now makes
+    machine-checkable. Keeping one in prose lets it rot silently again (see
+    #146: 4 of 9 rows already cited wrong numbers before this guard existed).
+    """
+    opinions = json.loads(OPINION_CATALOG_PATH.read_text(encoding="utf-8"))
+    line_number_pattern = re.compile(r"\bline[s]?\s+\d+")
+    for claim_id, claim in opinions["opinions"].items():
+        for reference in claim.get("references", []):
+            assert not line_number_pattern.search(reference), (
+                f"{claim_id}: reference cites a line number, which the "
+                f"assertion_location field now tracks and this test checks: {reference!r}"
+            )


### PR DESCRIPTION
## Summary
- provenance-registry.json and opinion-catalog.json each assert a Python symbol backs a rule claim, but the existing locator test only checked the symbol exists, not that its value matches
- Adds `expected_value` to every claim in both files and extends the locator test to assert the live value matches
- Moves opinion-catalog.json's stale line-number citations into the machine-checked `assertion_location` field, and adds a test forbidding new ones

## Why
Four of nine opinion-catalog.json rows already cited stale line numbers, and two rows (HK002, HK003) asserted "no vendor document enumerates this set" when the cached hooks doc actually does. This is the shared mechanism #112's constant fixes land through next (see the stacked PR against this branch).

Part of the #112/#146 workload — see `docs/design-rule-provenance-registry.md` for the wider architecture this closes the first gap in.

## Test plan
- [x] `uv run prek run --all-files`
- [x] `uv run pytest` (1490 passed, 10 skipped)
- [x] Manually corrupted a claim's `expected_value`, confirmed the test fails naming the exact claim; restored, confirmed green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XATWGbELHG23qfNfvJVbDk