### PR TITLE
fix(HK002,HK003): sync valid event/hook-type sets to hooks.md

### DIFF
--- a/docs/design-rule-provenance-registry.md
+++ b/docs/design-rule-provenance-registry.md
@@ -6,9 +6,9 @@ skilllint's rule catalogue is not fixed to the FM, HK, AS, and PA families -- ru
 
 This disconnection causes staleness. Concrete examples from the provenance audit:
 
-- **HK002 `VALID_EVENT_TYPES`**: The hardcoded frozenset contains 21 event names. Vendor documentation in `.claude/vendor/` only lists 9 of them. The remaining 12 (PermissionRequest, PostToolUseFailure, StopFailure, TeammateIdle, TaskCompleted, InstructionsLoaded, ConfigChange, WorktreeCreate, WorktreeRemove, PostCompact, Elicitation, ElicitationResult) exist only in the hardcoded constant with no traceable vendor source.
+- **HK002 `VALID_EVENT_TYPES`**: The hardcoded frozenset contained 21 event names. Vendor documentation cached at the time only listed 9 of them; the remaining 12 appeared to exist only in the hardcoded constant with no traceable vendor source. **Resolved:** a fresher capture of `code.claude.com/docs/en/hooks.md` enumerates the complete set as level-3 headings — 31 names, a strict superset of the 22 then enforced. HK002 is now a shipped `provenance-registry.json` claim (`HK002.valid_event_types`); see [registry-schema-examples.md](./registry-schema-examples.md).
 
-- **HK003 `VALID_HOOK_TYPES`**: The hardcoded frozenset `{"command", "http", "prompt", "agent"}` has no vendor source defining this enumeration. Vendor hook files use `"command"` and `"http"` but no file enumerates the complete valid set.
+- **HK003 `VALID_HOOK_TYPES`**: The hardcoded frozenset `{"command", "http", "prompt", "agent"}` appeared to have no vendor source defining the enumeration; the vendor hook files available at the time used `"command"` and `"http"` but no file enumerated the complete valid set. **Resolved:** the same fresher `hooks.md` capture's "Common fields" table enumerates all five values, including `mcp_tool`, which the code was missing. HK003 is now a shipped claim (`HK003.valid_hook_types`); see [registry-schema-examples.md](./registry-schema-examples.md).
 
 - **FM007 tool field names**: The set `{"tools", "disallowedTools", "allowed-tools"}` is hardcoded. `disallowedTools` does not appear in any schema file.
 

--- a/docs/registry-schema-examples.md
+++ b/docs/registry-schema-examples.md
@@ -8,6 +8,13 @@ An enumerated set of valid values. The assertion is "this set of strings is the 
 
 ### HK002.valid_event_types
 
+**Shipped.** `code.claude.com/docs/en/hooks.md` enumerates the complete set as
+level-3 headings under "Hook events" — 31 names, where the enforced frozenset
+held only 22. `assertion_location` points at the live `python_constant`
+(`VALID_EVENT_TYPES`) rather than the schema-enum shape below, because the
+schema file carries no such enum; the JSON schema example is kept as a worked
+`enum_set` shape for a future claim that does live in a packaged schema.
+
 ```json
 {
   "rule_code": "HK002",
@@ -16,13 +23,13 @@ An enumerated set of valid values. The assertion is "this set of strings is the 
   "claim_type": "enum_set",
 
   "authority": {
-    "vendor_file": ".claude/vendor/claude_code/plugins/plugin-dev/skills/hook-development/SKILL.md",
-    "anchor_selector": "#hook-input-and-output",
-    "authority_url": "https://docs.anthropic.com/en/docs/claude-code/hooks"
+    "vendor_file": ".claude/vendor/sources/hooks-2026-08-28-0408.md",
+    "anchor_selector": "#hook-events",
+    "authority_url": "https://code.claude.com/docs/en/hooks.md"
   },
 
   "extraction": {
-    "prompt_template": "The following markdown section describes Claude Code hook events. List every event type name mentioned in this section. Return as a JSON array of strings, with exact casing as shown in the source. Include only event type names (e.g., SessionStart, PreToolUse), not field names or other identifiers.\n\nSection:\n{{section}}",
+    "prompt_template": "The following markdown section lists Claude Code hook events as level-3 headings. List every event type name mentioned as a heading in this section. Return as a JSON array of strings, with exact casing as shown in the source.\n\nSection:\n{{section}}",
     "output_schema": {
       "type": "array",
       "items": { "type": "string" }
@@ -31,21 +38,27 @@ An enumerated set of valid values. The assertion is "this set of strings is the 
   },
 
   "assertion_location": {
-    "file": "packages/skilllint/schemas/claude_code/v1.json",
-    "symbol": "$.enums.valid_event_types.values",
-    "source_type": "schema_json_enum"
+    "file": "packages/skilllint/rules/hk_series.py",
+    "symbol": "VALID_EVENT_TYPES",
+    "source_type": "python_constant"
   },
 
   "x-audited": {
-    "date": "2026-03-23",
-    "source": ".claude/vendor/claude_code/plugins/plugin-dev/skills/hook-development/SKILL.md"
+    "date": "2026-09-04",
+    "source": ".claude/vendor/sources/hooks-2026-08-28-0408.md"
   }
 }
 ```
 
-### HK003.valid_hook_types (NOT SHIPPED AS A CLAIM)
+### HK003.valid_hook_types
 
-Kept here as a worked `enum_set` example -- see the note below.
+**Also shipped**, once the same doc's "Common fields" table was found to
+enumerate the whole `type` set (`command`, `http`, `mcp_tool`, `prompt`,
+`agent`) rather than the partial mention this file previously assumed. The
+prior note here said the hook-development page listed only `command` and
+`http` and that treating it as authoritative would misattribute `prompt` and
+`agent`; that page has been superseded by `hooks.md`, whose "Common fields"
+table is a genuine `enum_set` source.
 
 ```json
 {
@@ -55,13 +68,13 @@ Kept here as a worked `enum_set` example -- see the note below.
   "claim_type": "enum_set",
 
   "authority": {
-    "vendor_file": ".claude/vendor/claude_code/plugins/plugin-dev/skills/hook-development/SKILL.md",
-    "anchor_selector": "#hook-types",
-    "authority_url": "https://docs.anthropic.com/en/docs/claude-code/hooks"
+    "vendor_file": ".claude/vendor/sources/hooks-2026-08-28-0408.md",
+    "anchor_selector": "#common-fields",
+    "authority_url": "https://code.claude.com/docs/en/hooks.md"
   },
 
   "extraction": {
-    "prompt_template": "The following markdown section describes Claude Code hook types. List every valid hook type value that can appear in the \"type\" field of a hook entry. Return as a JSON array of lowercase strings.\n\nSection:\n{{section}}",
+    "prompt_template": "The following markdown section is the \"Common fields\" table for Claude Code hook entries. List every valid value for the \"type\" field. Return as a JSON array of lowercase strings.\n\nSection:\n{{section}}",
     "output_schema": {
       "type": "array",
       "items": { "type": "string" }
@@ -70,30 +83,21 @@ Kept here as a worked `enum_set` example -- see the note below.
   },
 
   "assertion_location": {
-    "file": "packages/skilllint/schemas/claude_code/v1.json",
-    "symbol": "$.enums.valid_hook_types.values",
-    "source_type": "schema_json_enum"
+    "file": "packages/skilllint/rules/hk_series.py",
+    "symbol": "VALID_HOOK_TYPES",
+    "source_type": "python_constant"
   },
 
   "x-audited": {
-    "date": "2026-03-23",
-    "source": ".claude/vendor/claude_code/plugins/plugin-dev/skills/hook-development/SKILL.md"
+    "date": "2026-09-04",
+    "source": ".claude/vendor/sources/hooks-2026-08-28-0408.md"
   }
 }
 ```
 
-`packages/skilllint/schemas/provenance-registry.json` does **not** ship this
-claim. Line 11 of `design-rule-provenance-registry.md` already says why: "no
-file enumerates the complete valid set". The enforced set is `{command, http,
-prompt, agent}`, and the hook-development section lists `command` and `http`
-only, so a comparison against it would either mismatch on every run or attribute
-`prompt` and `agent` to a page that does not mention them. HK003 is recorded in
-`opinion-catalog.json` instead, and moves to a claim if a vendor document ever
-enumerates the set.
-
-The shape above is still the right shape for an `enum_set` claim — that is why
-it is kept. The lesson is that an `enum_set` claim needs a source that
-enumerates the *whole* set, not one that happens to mention some members.
+The lesson from the earlier miss stands: an `enum_set` claim needs a source
+that enumerates the *whole* set, not one that happens to mention some
+members.
 
 ### FM007.tool_field_names
 

--- a/packages/skilllint/rules/hk_series.py
+++ b/packages/skilllint/rules/hk_series.py
@@ -49,22 +49,33 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 # Rule data for HK002: the event names Claude Code dispatches hooks for.
+# Source: .claude/vendor/sources/hooks-2026-08-28-0408.md, "Hook events" (level-3
+# headings). Provenance claim HK002.valid_event_types.
 VALID_EVENT_TYPES: frozenset[str] = frozenset({
     "SessionStart",
+    "Setup",
+    "InstructionsLoaded",
     "UserPromptSubmit",
+    "UserPromptExpansion",
     "PreToolUse",
     "PermissionRequest",
+    "PermissionDenied",
     "PostToolUse",
     "PostToolUseFailure",
+    "PostToolBatch",
     "Notification",
+    "MessageDisplay",
     "SubagentStart",
     "SubagentStop",
     "Stop",
     "StopFailure",
     "TeammateIdle",
+    "TaskCreated",
     "TaskCompleted",
-    "InstructionsLoaded",
     "ConfigChange",
+    "CwdChanged",
+    "DirectoryAdded",
+    "FileChanged",
     "WorktreeCreate",
     "WorktreeRemove",
     "PreCompact",
@@ -75,14 +86,19 @@ VALID_EVENT_TYPES: frozenset[str] = frozenset({
 })
 
 # Rule data for HK003: the accepted values of a hook entry's "type" field.
-VALID_HOOK_TYPES: frozenset[str] = frozenset({"command", "http", "prompt", "agent"})
+# Source: .claude/vendor/sources/hooks-2026-08-28-0408.md, "Common fields" table.
+# Provenance claim HK003.valid_hook_types.
+VALID_HOOK_TYPES: frozenset[str] = frozenset({"command", "http", "mcp_tool", "prompt", "agent"})
 
-# Rule data for HK003: the companion field each hook type requires.
-_REQUIRED_FIELD_BY_HOOK_TYPE: dict[str, str] = {
-    "command": "command",
-    "prompt": "prompt",
-    "http": "url",
-    "agent": "prompt",
+# Rule data for HK003: the companion field(s) each hook type requires.
+# mcp_tool requires both "server" and "tool" (source: "MCP tool hook fields"
+# section of the same doc), which a single-field mapping cannot express.
+_REQUIRED_FIELDS_BY_HOOK_TYPE: dict[str, tuple[str, ...]] = {
+    "command": ("command",),
+    "prompt": ("prompt",),
+    "http": ("url",),
+    "agent": ("prompt",),
+    "mcp_tool": ("server", "tool"),
 }
 
 
@@ -308,13 +324,16 @@ def check_hk002(hooks_config: Mapping[str, JsonValue]) -> list[ValidationIssue]:
     ``skilllint`` flags them so misspelled or outdated event names are caught
     before deployment.
 
-    Valid event types include: ``SessionStart``, ``UserPromptSubmit``,
-    ``PreToolUse``, ``PermissionRequest``, ``PostToolUse``,
-    ``PostToolUseFailure``, ``Notification``, ``SubagentStart``,
+    Valid event types include: ``SessionStart``, ``Setup``,
+    ``InstructionsLoaded``, ``UserPromptSubmit``, ``UserPromptExpansion``,
+    ``PreToolUse``, ``PermissionRequest``, ``PermissionDenied``,
+    ``PostToolUse``, ``PostToolUseFailure``, ``PostToolBatch``,
+    ``Notification``, ``MessageDisplay``, ``SubagentStart``,
     ``SubagentStop``, ``Stop``, ``StopFailure``, ``TeammateIdle``,
-    ``TaskCompleted``, ``InstructionsLoaded``, ``ConfigChange``,
-    ``WorktreeCreate``, ``WorktreeRemove``, ``PreCompact``, ``PostCompact``,
-    ``Elicitation``, ``ElicitationResult``, ``SessionEnd``.
+    ``TaskCreated``, ``TaskCompleted``, ``ConfigChange``, ``CwdChanged``,
+    ``DirectoryAdded``, ``FileChanged``, ``WorktreeCreate``,
+    ``WorktreeRemove``, ``PreCompact``, ``PostCompact``, ``Elicitation``,
+    ``ElicitationResult``, ``SessionEnd``.
 
     **Source:** the module-level ``VALID_EVENT_TYPES`` frozenset — the
     canonical set of accepted event type strings.
@@ -380,18 +399,16 @@ def _check_hook_entry(entry: JsonValue, field_prefix: str) -> list[ValidationIss
             )
         ]
 
-    required_field = _REQUIRED_FIELD_BY_HOOK_TYPE[hook_type]
-    if required_field not in entry:
-        return [
-            _make_issue(
-                field=f"{field_prefix}.{required_field}",
-                severity="error",
-                message=f"Hook type '{hook_type}' requires '{required_field}' field",
-                code="HK003",
-            )
-        ]
-
-    return []
+    return [
+        _make_issue(
+            field=f"{field_prefix}.{required_field}",
+            severity="error",
+            message=f"Hook type '{hook_type}' requires '{required_field}' field",
+            code="HK003",
+        )
+        for required_field in _REQUIRED_FIELDS_BY_HOOK_TYPE[hook_type]
+        if required_field not in entry
+    ]
 
 
 def _check_hook_group(group: JsonValue, event_type: str, group_idx: int) -> list[ValidationIssue]:
@@ -446,11 +463,14 @@ def check_hk003(hooks_config: Mapping[str, JsonValue]) -> list[ValidationIssue]:
     - A hook group does not contain a ``"hooks"`` key with a list value.
     - A hook entry is not an object.
     - A hook entry has an invalid or missing ``"type"`` field.  Valid types
-      are ``"command"``, ``"http"``, ``"prompt"``, and ``"agent"``.
+      are ``"command"``, ``"http"``, ``"mcp_tool"``, ``"prompt"``, and
+      ``"agent"``.
     - A ``"command"`` entry is missing the required ``"command"`` field.
     - A ``"prompt"`` entry is missing the required ``"prompt"`` field.
     - An ``"http"`` entry is missing the required ``"url"`` field.
     - An ``"agent"`` entry is missing the required ``"prompt"`` field.
+    - An ``"mcp_tool"`` entry is missing the required ``"server"`` and/or
+      ``"tool"`` fields.
 
     Event types that HK002 rejects are skipped: an unrecognised event name is
     reported once, and its contents are not additionally picked apart here.

--- a/packages/skilllint/schemas/opinion-catalog.json
+++ b/packages/skilllint/schemas/opinion-catalog.json
@@ -107,22 +107,6 @@
       },
       "expected_value": ["disallowedTools", "tools"]
     },
-    "HK003.valid_hook_types": {
-      "rule_code": "HK003",
-      "description": "Recognized hook type values: agent, command, http, prompt",
-      "rationale": "docs/design-rule-provenance-registry.md records that no vendor file enumerates this set: \"Vendor hook files use 'command' and 'http' but no file enumerates the complete valid set.\" Treating the hook-development page as authoritative would attribute 'agent' and 'prompt' to a source that does not list them, so the enumeration is recorded as an opinion until a vendor document defines it.",
-      "constraint": "VALID_HOOK_TYPES = frozenset({\"command\", \"http\", \"prompt\", \"agent\"})",
-      "references": [
-        "packages/skilllint/rules/hk_series.py: VALID_HOOK_TYPES",
-        "docs/design-rule-provenance-registry.md: HK003 VALID_HOOK_TYPES has no vendor source"
-      ],
-      "assertion_location": {
-        "file": "packages/skilllint/rules/hk_series.py",
-        "symbol": "VALID_HOOK_TYPES",
-        "source_type": "python_constant"
-      },
-      "expected_value": ["agent", "command", "http", "prompt"]
-    },
     "SK004.min_description_length": {
       "rule_code": "SK004",
       "description": "Skill description shorter than the 20-character minimum",
@@ -138,45 +122,6 @@
         "source_type": "python_constant"
       },
       "expected_value": 20
-    },
-    "HK002.valid_event_types": {
-      "rule_code": "HK002",
-      "description": "The set of recognized Claude Code hook event names",
-      "rationale": "docs/design-rule-provenance-registry.md records that the vendor material enumerates only part of this set: the frozenset holds 21 event names and the vendor documentation in .claude/vendor/ lists 9 of them, while the remaining 12 (PermissionRequest, PostToolUseFailure, StopFailure, TeammateIdle, TaskCompleted, InstructionsLoaded, ConfigChange, WorktreeCreate, WorktreeRemove, PostCompact, Elicitation, ElicitationResult) have no traceable vendor source. Comparing the whole enforced set against the hook-configuration-formats section would report those 12 as vendor removals and attribute the other 9 to a page that does not enumerate the set. Recorded as an opinion, like HK003, until a vendor document enumerates it.",
-      "constraint": "Hook event names must appear in VALID_EVENT_TYPES",
-      "references": [
-        "packages/skilllint/rules/hk_series.py: VALID_EVENT_TYPES",
-        "docs/design-rule-provenance-registry.md: 12 of the 21 event names have no traceable vendor source"
-      ],
-      "assertion_location": {
-        "file": "packages/skilllint/rules/hk_series.py",
-        "symbol": "VALID_EVENT_TYPES",
-        "source_type": "python_constant"
-      },
-      "expected_value": [
-        "ConfigChange",
-        "Elicitation",
-        "ElicitationResult",
-        "InstructionsLoaded",
-        "Notification",
-        "PermissionRequest",
-        "PostCompact",
-        "PostToolUse",
-        "PostToolUseFailure",
-        "PreCompact",
-        "PreToolUse",
-        "SessionEnd",
-        "SessionStart",
-        "Stop",
-        "StopFailure",
-        "SubagentStart",
-        "SubagentStop",
-        "TaskCompleted",
-        "TeammateIdle",
-        "UserPromptSubmit",
-        "WorktreeCreate",
-        "WorktreeRemove"
-      ]
     }
   }
 }

--- a/packages/skilllint/schemas/provenance-registry.json
+++ b/packages/skilllint/schemas/provenance-registry.json
@@ -86,6 +86,100 @@
         "date": "2026-08-30",
         "source": "packages/skilllint/schemas/agentskills_io/v1.json"
       }
+    },
+    "HK002.valid_event_types": {
+      "rule_code": "HK002",
+      "claim_name": "valid_event_types",
+      "description": "The set of recognized hook event type names that can appear as top-level keys in hooks.json",
+      "claim_type": "enum_set",
+      "authority": {
+        "vendor_file": ".claude/vendor/sources/hooks-2026-08-28-0408.md",
+        "anchor_selector": "#hook-events",
+        "authority_url": "https://code.claude.com/docs/en/hooks.md"
+      },
+      "extraction": {
+        "prompt_template": "The following markdown section lists Claude Code hook events as level-3 headings. List every event type name mentioned as a heading in this section. Return as a JSON array of strings, with exact casing as shown in the source. {{section}}",
+        "output_schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "post_processing": "sort"
+      },
+      "assertion_location": {
+        "file": "packages/skilllint/rules/hk_series.py",
+        "symbol": "VALID_EVENT_TYPES",
+        "source_type": "python_constant"
+      },
+      "expected_value": [
+        "ConfigChange",
+        "CwdChanged",
+        "DirectoryAdded",
+        "Elicitation",
+        "ElicitationResult",
+        "FileChanged",
+        "InstructionsLoaded",
+        "MessageDisplay",
+        "Notification",
+        "PermissionDenied",
+        "PermissionRequest",
+        "PostCompact",
+        "PostToolBatch",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "PreCompact",
+        "PreToolUse",
+        "SessionEnd",
+        "SessionStart",
+        "Setup",
+        "Stop",
+        "StopFailure",
+        "SubagentStart",
+        "SubagentStop",
+        "TaskCompleted",
+        "TaskCreated",
+        "TeammateIdle",
+        "UserPromptExpansion",
+        "UserPromptSubmit",
+        "WorktreeCreate",
+        "WorktreeRemove"
+      ],
+      "x-audited": {
+        "date": "2026-09-04",
+        "source": ".claude/vendor/sources/hooks-2026-08-28-0408.md"
+      }
+    },
+    "HK003.valid_hook_types": {
+      "rule_code": "HK003",
+      "claim_name": "valid_hook_types",
+      "description": "The set of recognized hook type values for the type field in hook entries",
+      "claim_type": "enum_set",
+      "authority": {
+        "vendor_file": ".claude/vendor/sources/hooks-2026-08-28-0408.md",
+        "anchor_selector": "#common-fields",
+        "authority_url": "https://code.claude.com/docs/en/hooks.md"
+      },
+      "extraction": {
+        "prompt_template": "The following markdown section is the \"Common fields\" table for Claude Code hook entries. List every valid value for the \"type\" field. Return as a JSON array of lowercase strings. {{section}}",
+        "output_schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "post_processing": "sort"
+      },
+      "assertion_location": {
+        "file": "packages/skilllint/rules/hk_series.py",
+        "symbol": "VALID_HOOK_TYPES",
+        "source_type": "python_constant"
+      },
+      "expected_value": ["agent", "command", "http", "mcp_tool", "prompt"],
+      "x-audited": {
+        "date": "2026-09-04",
+        "source": ".claude/vendor/sources/hooks-2026-08-28-0408.md"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- `VALID_EVENT_TYPES` was 22 names, missing 9 that the cached hooks reference documents (CwdChanged, DirectoryAdded, FileChanged, MessageDisplay, PermissionDenied, PostToolBatch, Setup, TaskCreated, UserPromptExpansion) — strict subset, zero removals
- `VALID_HOOK_TYPES` lacked `mcp_tool`, which requires two fields (`server`, `tool`); widened `_REQUIRED_FIELD_BY_HOOK_TYPE` from `dict[str, str]` to `dict[str, tuple[str, ...]]`
- Moves both claims from opinion-catalog.json to provenance-registry.json, since the "no vendor source" rationale was false

## Why
A plugin registering `Setup` or an `mcp_tool` handler got an error today for something Claude Code actually supports. Diffed against `code.claude.com/docs/en/hooks.md` this session.

Stacked on #178 (the shared claim guard this fix lands through).

## Test plan
- [x] `uv run prek run --all-files`
- [x] `uv run pytest` (1490 passed, 10 skipped)
- [x] Fixture plugin registering a `Setup` hook and an `mcp_tool` handler → zero findings (both were errors before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XATWGbELHG23qfNfvJVbDk