### PR TITLE
fix: correct AsSeriesValidator.validate docstring, refute #138

### DIFF
--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -1718,8 +1718,10 @@ class AsSeriesValidator:
         """Run AS-series checks on a skill file.
 
         Args:
-            path: Path to a SKILL.md file. Only ``FileType.SKILL`` reaches
-                this validator; see the class docstring for why.
+            path: Path to a SKILL.md file. Default dispatch wires only
+                ``FileType.SKILL`` to this validator (see the class
+                docstring for why); this method itself does not check the
+                file type, so tests may call it directly with other paths.
             policy: Optional resolved per-plugin policy.
 
         Returns:

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -1715,10 +1715,11 @@ class AsSeriesValidator:
     """
 
     def validate(self, path: Path, policy: ValidationPolicy | None = None) -> ValidationResult:
-        """Run AS-series checks on a skill or agent file.
+        """Run AS-series checks on a skill file.
 
         Args:
-            path: Path to a SKILL.md or agent .md file.
+            path: Path to a SKILL.md file. Only ``FileType.SKILL`` reaches
+                this validator; see the class docstring for why.
             policy: Optional resolved per-plugin policy.
 
         Returns:


### PR DESCRIPTION
## Summary
- Fixes `AsSeriesValidator.validate`'s docstring, which still said it runs on "a skill or agent file" — contradicting the class docstring immediately above it, which correctly says AS-series is wired only to `FileType.SKILL` since #108

## Why
Closes #138. That issue claimed AS001 and FM001 both report a missing skill name on the claude_code path with disagreeing severities. Verified false: FM001's name check has one call site, filtered to the description field only, and that site never runs on the claude_code path. A live fixture confirms exactly one finding (AS001) for a SKILL.md with no name field.

## Test plan
- [x] `uv run prek run --all-files`
- [x] `uv run pytest` (1489 passed, 10 skipped)
- [x] Live fixture: SKILL.md with missing `name` → exactly one finding, AS001, no FM001 duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XATWGbELHG23qfNfvJVbDk