### PR TITLE
test: guard rule-catalog.md and stub docstrings against drift

### DIFF
--- a/packages/skilllint/rules/fm_series.py
+++ b/packages/skilllint/rules/fm_series.py
@@ -196,7 +196,7 @@ def check_fm002(frontmatter: dict, path: Path, file_type: str) -> list[Validatio
 
     Returns:
         Always an empty list. FM002 is emitted by the YAML parsing layer in
-        FrontmatterValidator before frontmatter is available; this function
+        `FrontmatterValidator` before frontmatter is available; this function
         exists for rule metadata registration only.
 
     <!-- examples: FM002 -->
@@ -231,7 +231,7 @@ def check_fm003(frontmatter: dict, path: Path, file_type: str) -> list[Validatio
 
     Returns:
         Always an empty list. FM003 is emitted by
-        FrontmatterValidator._extract_frontmatter() before frontmatter content
+        `FrontmatterValidator._extract_frontmatter` before frontmatter content
         is available; this function exists for rule metadata registration only.
 
     <!-- examples: FM003 -->
@@ -331,7 +331,7 @@ def check_fm005(frontmatter: dict, path: Path, file_type: str) -> list[Validatio
 
     Returns:
         Always an empty list. FM005 is emitted by the Pydantic validation
-        layer (_pydantic_error_to_validation_issue) from ValidationError
+        layer, `_pydantic_error_to_validation_issue`, from ValidationError
         details; this function exists for rule metadata registration only.
 
     <!-- examples: FM005 -->
@@ -371,7 +371,7 @@ def check_fm006(frontmatter: dict, path: Path, file_type: str) -> list[Validatio
 
     Returns:
         Always an empty list. FM006 is emitted by
-        _pydantic_error_to_validation_issue when a Literal constraint fails;
+        `_pydantic_error_to_validation_issue` when a Literal constraint fails;
         this function exists for rule metadata registration only.
 
     <!-- examples: FM006 -->
@@ -469,10 +469,10 @@ def check_fm009(frontmatter: dict, path: Path, file_type: str) -> list[Validatio
     ```
 
     Returns:
-        Always an empty list. FM009 is emitted by
-        ``_fm009_recovery_warnings()`` on a check-only run and by
-        ``_queue_fm009_info()`` after auto-fix; this function exists for rule
-        metadata registration only.
+        Always an empty list. FM009 is emitted by `_fm009_recovery_warnings`
+        on a check-only run and by ``FrontmatterValidator._queue_fm009_info``
+        after auto-fix; this function exists for rule metadata registration
+        only.
 
     <!-- examples: FM009 -->
     """

--- a/packages/skilllint/rules/sk_series.py
+++ b/packages/skilllint/rules/sk_series.py
@@ -325,7 +325,7 @@ def check_sk008(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     ```
 
     Returns:
-        Always an empty list. SK008 is emitted by `_check_skill_name_and_directory`
+        Always an empty list. SK008 is emitted by `_check_skill_directory_name`
         in `plugin_validator.py` after inspecting the filesystem path; this
         function exists for rule metadata registration only.
 

--- a/packages/skilllint/tests/test_rule_catalog_doc.py
+++ b/packages/skilllint/tests/test_rule_catalog_doc.py
@@ -1,0 +1,109 @@
+"""Guard rule-catalog.md and registration-only stub docstrings against drift.
+
+Two independent claims, checked here because both are cases of a
+hand-maintained artifact asserting something true about RULE_REGISTRY with
+nothing enforcing agreement (#130, #124):
+
+- rule-catalog.md is a hand-written markdown table mirroring every registered
+  rule's code and severity. #130 found 11 rows whose severity disagreed with
+  the registry, and 4 whose description named an entirely different rule
+  (FM005/FM006/SK008/SK009) -- all fixed by hand in the same change that added
+  this guard. Only code and severity are checked here: Description and
+  Auto-fix are prose, and RuleEntry carries no can_fix field to compare
+  against.
+  # ponytail: description/auto-fix columns unguarded; add a check when they
+  # rot again.
+- A registration-only stub (a rule function whose body is ``return []``,
+  existing purely so RULE_REGISTRY carries its metadata) names its real
+  emitter in its docstring's "Always an empty list." sentence. #124 found
+  that check_lk001 is not actually a stub -- it holds the real detection body
+  -- so a hand-listed stub set would have been wrong from the start; SK008's
+  docstring named a function, `_check_skill_name_and_directory`, that exists
+  nowhere in the package (the real emitter is `_check_skill_directory_name`).
+  This guard reads RULE_REGISTRY directly rather than hand-listing stub
+  codes, so a 10th stub is covered automatically.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import skilllint.plugin_validator as plugin_validator_module
+import skilllint.rules
+from skilllint.rule_registry import RULE_REGISTRY
+
+CATALOG_PATH = (
+    Path(__file__).parents[3]
+    / "plugins"
+    / "agentskills-skilllint"
+    / "skills"
+    / "skilllint"
+    / "references"
+    / "rule-catalog.md"
+)
+
+_ROW_PATTERN = re.compile(r"^\|\s*([A-Z]{2}\d{3})\s*\|\s*([a-z /]+?)\s*\|")
+_STUB_MARKER = "Always an empty list."
+_BACKTICKED_SYMBOL = re.compile(r"`([A-Za-z_]\w*)")
+
+
+def _catalog_rows() -> dict[str, str]:
+    """Parse {rule_id: severity_cell} from every table row in rule-catalog.md."""
+    rows: dict[str, str] = {}
+    for line in CATALOG_PATH.read_text(encoding="utf-8").splitlines():
+        match = _ROW_PATTERN.match(line)
+        if match is None:
+            continue
+        rows[match.group(1)] = match.group(2).strip()
+    return rows
+
+
+def test_rule_catalog_codes_match_registry() -> None:
+    """Every rule-catalog.md row must name a code that RULE_REGISTRY has, and vice versa."""
+    catalog_codes = set(_catalog_rows())
+    registry_codes = set(RULE_REGISTRY)
+    missing_from_catalog = registry_codes - catalog_codes
+    assert not missing_from_catalog, f"RULE_REGISTRY codes missing from rule-catalog.md: {sorted(missing_from_catalog)}"
+    extra_in_catalog = catalog_codes - registry_codes
+    assert not extra_in_catalog, f"rule-catalog.md codes not in RULE_REGISTRY: {sorted(extra_in_catalog)}"
+
+
+def test_rule_catalog_severities_match_registry() -> None:
+    """Every rule-catalog.md severity must match RULE_REGISTRY's declared severity.
+
+    RULE_REGISTRY is what `skilllint rules` and `skilllint rule <ID>` print,
+    so it is the declared contract; a disagreement means the catalog is wrong.
+    A row whose severity cell is not a single value (e.g. PA001's
+    "error / warning") is skipped -- RuleEntry.severity is a single Literal,
+    so there is nothing to compare a compound cell against.
+    """
+    for rule_id, catalog_severity in _catalog_rows().items():
+        if "/" in catalog_severity:
+            continue
+        registry_severity = RULE_REGISTRY[rule_id].severity
+        assert catalog_severity == registry_severity, (
+            f"{rule_id}: rule-catalog.md says severity={catalog_severity!r}, RULE_REGISTRY says {registry_severity!r}"
+        )
+
+
+def test_stub_docstrings_name_a_resolvable_emitter() -> None:
+    """A registration-only stub must name a real emitter symbol in backticks.
+
+    Finds stubs by their docstring's "Always an empty list." sentence rather
+    than a hand-maintained code list, so it self-scopes to whatever the
+    registry actually contains today.
+    """
+    for code, entry in RULE_REGISTRY.items():
+        marker_index = entry.docstring.find(_STUB_MARKER)
+        if marker_index == -1:
+            continue
+        tail = entry.docstring[marker_index + len(_STUB_MARKER) :]
+        match = _BACKTICKED_SYMBOL.search(tail)
+        assert match is not None, f"{code}: stub docstring must name its emitter in backticks"
+
+        symbol = match.group(1)
+        assert hasattr(plugin_validator_module, symbol) or hasattr(skilllint.rules, symbol), (
+            f"{code}: stub docstring names `{symbol}` as its emitter, "
+            f"but that symbol does not exist in plugin_validator or skilllint.rules"
+        )

--- a/packages/skilllint/tests/test_rule_catalog_doc.py
+++ b/packages/skilllint/tests/test_rule_catalog_doc.py
@@ -45,7 +45,12 @@ CATALOG_PATH = (
 
 _ROW_PATTERN = re.compile(r"^\|\s*([A-Z]{2}\d{3})\s*\|\s*([a-z /]+?)\s*\|")
 _STUB_MARKER = "Always an empty list."
-_BACKTICKED_SYMBOL = re.compile(r"`([A-Za-z_]\w*)")
+# `[\w.]*` (not `\w*`) so a dotted attribute path like `FrontmatterValidator.
+# _extract_frontmatter` captures whole -- `\w*` alone stops at the first
+# `.`, silently truncating the capture to just `FrontmatterValidator` and
+# letting the hasattr check below pass on the class existing without ever
+# checking the named method exists.
+_BACKTICKED_SYMBOL = re.compile(r"`([A-Za-z_][\w.]*)")
 
 
 def _catalog_rows() -> dict[str, str]:
@@ -87,6 +92,24 @@ def test_rule_catalog_severities_match_registry() -> None:
         )
 
 
+def _resolves(symbol: str) -> bool:
+    """True if *symbol* -- a plain name or a dotted `Class.method` path -- exists.
+
+    `hasattr` alone only resolves a single attribute hop, so a dotted path
+    (e.g. ``FrontmatterValidator._extract_frontmatter``) is walked one
+    segment at a time.
+    """
+    for module in (plugin_validator_module, skilllint.rules):
+        obj = module
+        for part in symbol.split("."):
+            if not hasattr(obj, part):
+                break
+            obj = getattr(obj, part)
+        else:
+            return True
+    return False
+
+
 def test_stub_docstrings_name_a_resolvable_emitter() -> None:
     """A registration-only stub must name a real emitter symbol in backticks.
 
@@ -103,7 +126,7 @@ def test_stub_docstrings_name_a_resolvable_emitter() -> None:
         assert match is not None, f"{code}: stub docstring must name its emitter in backticks"
 
         symbol = match.group(1)
-        assert hasattr(plugin_validator_module, symbol) or hasattr(skilllint.rules, symbol), (
+        assert _resolves(symbol), (
             f"{code}: stub docstring names `{symbol}` as its emitter, "
             f"but that symbol does not exist in plugin_validator or skilllint.rules"
         )

--- a/plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md
+++ b/plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md
@@ -10,14 +10,14 @@ Validate YAML frontmatter in SKILL.md, agent .md, and command .md files.
 
 | Rule | Severity | Auto-fix | Description |
 |------|----------|----------|-------------|
-| FM001 | error | no | Frontmatter block is missing entirely |
+| FM001 | warning | no | Frontmatter block is missing entirely |
 | FM002 | error | no | Frontmatter is not valid YAML |
 | FM003 | error | no | Required frontmatter field is missing (e.g. `name` per agentskills spec) |
-| FM004 | error | **yes** | `description` uses a YAML multiline block scalar (`` >- ``, `` \| ``, `` \|- ``); Claude Code skill indexer reads this as literal `>-`. Use a single-line string. |
-| FM005 | error | no | `name` field contains invalid characters (must be lowercase letters, numbers, hyphens only; max 64 chars) |
-| FM006 | error | no | `description` exceeds 1024 characters |
-| FM007 | error | **yes** | `tools`, `allowed-tools`, or `disallowedTools` is a YAML array instead of a comma-separated string |
-| FM009 | error | **yes** | Unquoted colon in `description` or other string field causes YAML parse failure |
+| FM004 | warning | **yes** | `description` uses a YAML multiline block scalar (`` >- ``, `` \| ``, `` \|- ``); Claude Code skill indexer reads this as literal `>-`. Use a single-line string. |
+| FM005 | error | no | A frontmatter field has the wrong data type (e.g. a boolean field given a string value) |
+| FM006 | error | no | A frontmatter field holds a value outside its closed enum (e.g. an invalid `effort` or `permissionMode`) |
+| FM007 | warning | **yes** | `tools`, `allowed-tools`, or `disallowedTools` is a YAML array instead of a comma-separated string |
+| FM009 | info | **yes** | Unquoted colon in `description` or other string field causes YAML parse failure |
 | FM010 | error | **yes** | Skill `name` syntax, length, pattern, and directory equality |
 
 ---
@@ -32,8 +32,8 @@ Validate skill name, description quality, and token budget.
 | SK005 | warning | no | Skill description lacks trigger phrases ("Use when...", keywords); Claude may not auto-invoke |
 | SK006 | warning | no | Skill body is large (over `TOKEN_WARNING_THRESHOLD` tokens); consider splitting |
 | SK007 | error | no | Skill body exceeds token limit (`TOKEN_ERROR_THRESHOLD`); must be split into sub-skills |
-| SK008 | info | no | Skill has no `argument-hint` but appears to accept arguments based on `$ARGUMENTS` usage |
-| SK009 | info | no | Token count report (informational; always emitted with `--verbose`) |
+| SK008 | error | no | Skill directory name violates the naming convention (lowercase, digits, hyphens; must match `name`) |
+| SK009 | info | no | `plugin.json` lists `skills` explicitly, so Claude Code uses manual selection instead of auto-discovery |
 
 **Token limit fix (SK006/SK007):** Move large sections to `skills/<name>/references/<file>.md` and add a link from SKILL.md. Thresholds are `TOKEN_WARNING_THRESHOLD` (warning) and `TOKEN_ERROR_THRESHOLD` (error) — body text only, frontmatter excluded. Run `skilllint rules` to see current values.
 
@@ -77,9 +77,9 @@ Validate the `references/` directory structure for progressive disclosure.
 
 | Rule | Severity | Auto-fix | Description |
 |------|----------|----------|-------------|
-| PD001 | warning | no | Large skill (approaching SK006 token threshold) has no `references/` directory; consider adding one |
-| PD002 | warning | no | `references/` directory exists but is not linked from SKILL.md |
-| PD003 | info | no | Files in `references/` are never referenced in SKILL.md |
+| PD001 | info | no | Skill directory has no `references/` subdirectory for supporting documentation |
+| PD002 | info | no | Skill directory has no `examples/` subdirectory for usage samples |
+| PD003 | info | no | Skill directory has no `scripts/` subdirectory for helper scripts |
 
 ---
 
@@ -133,7 +133,7 @@ Validate `hooks.json` and inline hook configurations.
 | HK001 | error | no | `hooks.json` is not valid JSON |
 | HK002 | error | no | Hook event name is not a recognized Claude Code event |
 | HK003 | error | no | Hook `type` is not one of: `command`, `prompt`, `agent` |
-| HK004 | warning | no | Hook script path does not exist on disk |
+| HK004 | error | no | Hook script path does not exist on disk |
 | HK005 | warning | no | Hook script is not executable (`chmod +x` required) |
 
 ---
@@ -144,8 +144,8 @@ Validate namespace-qualified skill references (e.g. `plugin-name:skill-name`).
 
 | Rule | Severity | Auto-fix | Description |
 |------|----------|----------|-------------|
-| NR001 | warning | no | Namespace reference uses a plugin name that is not installed |
-| NR002 | warning | no | Namespace reference attempts path traversal or uses disallowed path segments (e.g., `..`, `/`, `\`) within the plugin prefix or target name |
+| NR001 | error | no | Namespace reference uses a plugin name that is not installed |
+| NR002 | error | no | Namespace reference attempts path traversal or uses disallowed path segments (e.g., `..`, `/`, `\`) within the plugin prefix or target name |
 
 ---
 
@@ -153,7 +153,7 @@ Validate namespace-qualified skill references (e.g. `plugin-name:skill-name`).
 
 | Rule | Severity | Auto-fix | Description |
 |------|----------|----------|-------------|
-| SL001 | warning | **yes** | Symlink target has trailing whitespace or newline characters |
+| SL001 | error | **yes** | Symlink target has trailing whitespace or newline characters |
 
 ---
 


### PR DESCRIPTION
## Summary
- Fixes 11 wrong severities and multiple wrong descriptions in `rule-catalog.md` against `RULE_REGISTRY` (FM005/FM006/SK008/SK009 described a different rule entirely; PD001-003 described conditions the code doesn't check at all)
- Adds a test guarding rule codes + severity going forward
- Adds a test finding registration-only stubs by their docstring's "Always an empty list." sentence and asserting the emitter it names resolves — catches SK008's docstring naming a function that exists nowhere in the package

## Why
Closes the #130 and #124 gaps: nothing previously checked `rule-catalog.md` against the registry, and a hand-listed stub-code set (per #124) would have been wrong from the start, since `check_lk001` is not actually a stub.

## Test plan
- [x] `uv run prek run --all-files`
- [x] `uv run pytest` (1492 passed, 10 skipped)
- [x] Injected a wrong severity and a broken emitter reference; both guards failed naming the exact defect, then restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XATWGbELHG23qfNfvJVbDk