### PR TITLE
refactor(FM010): import MAX_NAME_LENGTH from _spec_constants

### DIFF
--- a/packages/skilllint/rules/fm_series.py
+++ b/packages/skilllint/rules/fm_series.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Literal
 
+from skilllint._spec_constants import MAX_NAME_LENGTH
 from skilllint.rule_registry import rule_reference, skilllint_rule
 
 if TYPE_CHECKING:
@@ -39,10 +40,6 @@ _AGENTS_SPEC_URL = "https://docs.anthropic.com/en/docs/claude-code/sub-agents"
 # Source: sub-agents.md — "Unique identifier using lowercase letters and hyphens"
 _NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
 _CONSECUTIVE_HYPHENS_RE = re.compile(r"--")
-
-# Source: skills.md — "Lowercase letters, numbers, and hyphens only (max 64 characters)"
-# Source: sub-agents.md — max 64 chars implied by same pattern constraint
-_MAX_NAME_LENGTH = 64
 
 # Tool allow/deny field defined by the AgentSkills specification.
 # Source: packages/skilllint/schemas/agentskills_io/v1.json — the schema declares
@@ -529,14 +526,14 @@ def check_fm010(frontmatter: dict, path: Path, file_type: str) -> list[Validatio
     issues: list[ValidationIssue] = []
 
     # Pattern validation
-    if len(name) == 0 or len(name) > _MAX_NAME_LENGTH:
+    if len(name) == 0 or len(name) > MAX_NAME_LENGTH:
         issues.append(
             _make_issue(
                 field="name",
                 severity="error",
-                message=f"Name must be 1-{_MAX_NAME_LENGTH} characters (got {len(name)})",
+                message=f"Name must be 1-{MAX_NAME_LENGTH} characters (got {len(name)})",
                 code="FM010",
-                suggestion=f"Shorten the name to {_MAX_NAME_LENGTH} characters or less",
+                suggestion=f"Shorten the name to {MAX_NAME_LENGTH} characters or less",
             )
         )
     elif _CONSECUTIVE_HYPHENS_RE.search(name):

--- a/packages/skilllint/schemas/provenance-registry.json
+++ b/packages/skilllint/schemas/provenance-registry.json
@@ -21,8 +21,8 @@
         "post_processing": null
       },
       "assertion_location": {
-        "file": "packages/skilllint/rules/fm_series.py",
-        "symbol": "_MAX_NAME_LENGTH",
+        "file": "packages/skilllint/_spec_constants.py",
+        "symbol": "MAX_NAME_LENGTH",
         "source_type": "python_constant"
       },
       "expected_value": 64,


### PR DESCRIPTION
## Summary
- `fm_series.py` duplicated `_spec_constants.MAX_NAME_LENGTH` as a local `_MAX_NAME_LENGTH = 64` literal; imports it directly instead
- Repoints `provenance-registry.json`'s `FM010.max_name_length` locator at the canonical `_spec_constants.py` definition

## Why
Closes the last live item in #41 (`_NAME_RE` duplication observation #4) that was still open — `as_series.py` has no equivalent constant to migrate (AS001 only asserts name presence), so `fm_series.py` was the sole remaining series with its own copy.

Verified this session that #40 and most of #41's other observations are already resolved (vendor cache populated, `RULE_REGISTRY`/`ErrorCode` at exact 51/51 parity, FM008 in neither, SK004-007 sourced via the opinion-catalog.json pattern). Will comment and close both issues with the specifics once this merges.

## Test plan
- [x] `uv run prek run --all-files`
- [x] `uv run pytest` (1493 passed, 10 skipped)
- [x] `test_provenance_registry_locators.py` confirms the repointed locator resolves and its value still matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XATWGbELHG23qfNfvJVbDk