### PR TITLE
feat(AG): close the #109 follow-up cluster (#150, #149, #151, #153)

### DIFF
--- a/packages/skilllint/frontmatter_core.py
+++ b/packages/skilllint/frontmatter_core.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator
 
 from skilllint.limits import DESCRIPTION_MAX_LENGTH
 
@@ -204,7 +204,14 @@ class AgentFrontmatter(BaseModel):
     # then normalizes strings and the string members of lists at consumption
     # time. Keep that authored value untouched so model_dump() and --fix retain
     # scalar-vs-sequence shape; normalized_skills exposes the loader's view.
-    skills: object | None = None
+    #
+    # JsonValue (not a hand-rolled recursive alias) because Pydantic cannot
+    # build a schema for an implicit recursive TypeAlias used as a model
+    # field under `from __future__ import annotations` -- it raises
+    # RecursionError at class-definition time. pydantic.JsonValue is
+    # Pydantic's own fast-pathed equivalent, already used the same way in
+    # rules/hk_series.py.
+    skills: JsonValue = None
     mcp_servers: list[Any] | dict[str, Any] | None = Field(None, alias="mcpServers")
     hooks: dict[str, Any] | None = None
     memory: Literal["user", "project", "local"] | None = None

--- a/packages/skilllint/frontmatter_core.py
+++ b/packages/skilllint/frontmatter_core.py
@@ -44,7 +44,16 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    FieldSerializationInfo,
+    JsonValue,
+    SkipValidation,
+    field_serializer,
+    field_validator,
+)
 
 from skilllint.limits import DESCRIPTION_MAX_LENGTH
 
@@ -216,15 +225,40 @@ class AgentFrontmatter(BaseModel):
     # build a schema for an implicit recursive TypeAlias used as a model
     # field under `from __future__ import annotations` -- it raises
     # RecursionError at class-definition time. pydantic.JsonValue is
-    # Pydantic's own fast-pathed equivalent, already used the same way in
-    # rules/hk_series.py.
-    skills: JsonValue = None
+    # Pydantic's own fast-pathed equivalent; rules/hk_series.py uses the same
+    # type for hook-config annotations, though only as a TYPE_CHECKING-only
+    # function-signature annotation, not a live Pydantic model field.
+    #
+    # SkipValidation because a YAML author can write a scalar ruamel.yaml
+    # resolves to a type JsonValue rejects (e.g. an unquoted date), and
+    # normalize_agent_skills_value already classifies any non-str/non-list
+    # value as unsupported (AG003 warns) -- JsonValue's runtime validation
+    # would instead hard-fail with an uninformative FM005 before AG003 ever
+    # runs. The field_serializer bypasses a Pydantic serializer warning that
+    # SkipValidation's schema/runtime-value mismatch would otherwise emit for
+    # exactly that case; dump behavior (the value passed through unchanged)
+    # is identical without it.
+    skills: SkipValidation[JsonValue] = None
     mcp_servers: list[Any] | dict[str, Any] | None = Field(None, alias="mcpServers")
     hooks: dict[str, Any] | None = None
     memory: Literal["user", "project", "local"] | None = None
     background: bool | None = None
     isolation: Literal["worktree"] | None = None
     color: str | None = None
+
+    @field_serializer("skills")
+    def _serialize_skills(self, value: JsonValue, _info: FieldSerializationInfo) -> object:
+        """Pass ``skills`` through unchanged; see the field's SkipValidation comment.
+
+        Returns:
+            The unchanged input value, typed ``object`` rather than
+            ``JsonValue``: a ``JsonValue``-typed return makes Pydantic
+            re-validate the returned value against the same tagged union
+            that ``SkipValidation`` was declared to bypass on input,
+            re-emitting the serializer warning ``SkipValidation`` exists to
+            avoid. Nothing else reads this method's static return type.
+        """
+        return value
 
     @property
     def normalized_skills(self) -> list[str]:

--- a/packages/skilllint/frontmatter_core.py
+++ b/packages/skilllint/frontmatter_core.py
@@ -105,14 +105,21 @@ class SkillFrontmatter(BaseModel):
     argument_hint: str | None = Field(None, alias="argument-hint")
     allowed_tools: str | None = Field(None, alias="allowed-tools")
     model: str | None = None
-    skills: str | None = None
+    # No `skills` field: the agentskills.io specification defines exactly six
+    # SKILL.md properties (name, description, license, compatibility,
+    # metadata, allowed-tools) and `skills` is not among them -- it is
+    # documented only as subagent frontmatter (sub-agents.md). FM008 was
+    # deleted in #105 for asserting a `skills` shape on SKILL.md for the same
+    # reason. `model_config.extra = "allow"` still captures an authored
+    # `skills:` key untouched, with no CSV coercion of a YAML list -- the
+    # same silent-mutation concern #147 fixed on the agent side (#151).
     context: Literal["fork"] | None = None
     agent: str | None = None
     user_invocable: bool | None = Field(None, alias="user-invocable")
     disable_model_invocation: bool | None = Field(None, alias="disable-model-invocation")
     hooks: dict[str, Any] | None = None
 
-    @field_validator("skills", "allowed_tools", mode="before")
+    @field_validator("allowed_tools", mode="before")
     @classmethod
     def normalize_comma_separated(cls, v: object) -> str | None:
         """Convert YAML arrays to comma-separated strings.

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -2240,8 +2240,10 @@ class FrontmatterValidator:
         fixes = list(colon_fixes)
         if file_type == FileType.SKILL and file_path is not None:
             normalized_dict = fix_skill_name_field(normalized_dict, file_path, fixes)
-        # Both frontmatter models expose runtime-friendly views of `skills`,
-        # but --fix must preserve its parsed value and scalar/sequence/null shape.
+        # SkillFrontmatter has no declared `skills` field (passthrough only via
+        # extra="allow"); AgentFrontmatter exposes a runtime-friendly view via
+        # `normalized_skills`. Either way, --fix must preserve the originally
+        # authored value's parsed shape (scalar/sequence/null) untouched.
         if "skills" in original_data:
             normalized_dict["skills"] = original_data["skills"]
         tool_fields = {"tools", "disallowedTools", "allowed-tools"}

--- a/packages/skilllint/rules/ag_series.py
+++ b/packages/skilllint/rules/ag_series.py
@@ -68,6 +68,30 @@ _AVAILABLE_TOOLS_URL = f"{_SUBAGENTS_URL}#available-tools"
 # constraint, so only this exact literal is treated as fatal.
 _UNRESOLVABLE_WILDCARD_TOOLS: frozenset[str] = frozenset({"mcp__*"})
 
+# Source: sub-agents.md, "Available tools" -- "The first filter removes these
+# tools, even when listed in the `tools` field:" (.claude/vendor/sources/
+# sub-agents-2026-08-30-1123.md:375-384). Every subagent, foreground or
+# background, unconditionally loses these tool names regardless of what
+# `tools` lists. Two names from that same bullet list are deliberately
+# excluded because their removal is conditional, not provable from
+# frontmatter alone: `Agent` is removed only when the subagent is at the
+# depth limit, and `ExitPlanMode` is removed unless `permissionMode` is
+# `plan` (a case AG001 cannot rule out without also inspecting that field).
+_UNCONDITIONALLY_REMOVED_TOOLS: frozenset[str] = frozenset({
+    "AskUserQuestion",
+    "EndConversation",
+    "EnterPlanMode",
+    "ScheduleWakeup",
+    "TaskOutput",
+    "WaitForMcpServers",
+    "Workflow",
+})
+
+# The full provable-zero set: an entry in `tools` is provably non-functional
+# when it either names no server (an unresolvable wildcard) or is stripped by
+# the first filter before the subagent ever sees it (unconditionally removed).
+_PROVABLY_ZERO_TOOLS: frozenset[str] = _UNRESOLVABLE_WILDCARD_TOOLS | _UNCONDITIONALLY_REMOVED_TOOLS
+
 # Fields the "Supported frontmatter fields" table defines for MCP tool
 # grants/denials on an agent file.
 _AGENT_TOOL_FIELD_NAMES: tuple[str, ...] = ("tools", "disallowedTools")
@@ -88,44 +112,62 @@ _AGENT_TOOL_FIELD_NAMES: tuple[str, ...] = ("tools", "disallowedTools")
 def check_ag001(frontmatter: dict) -> list[ValidationIssue]:
     """## AG001 — `tools` field resolves to no tool
 
-    Every entry in the agent's `tools` field is the literal string `mcp__*`,
-    which names no MCP server. A *server-scoped* grant such as `mcp__Ref__*`
-    is supported and NOT reported here — Claude Code resolves it to every
-    tool that server exposes, identically to the bare `mcp__Ref` form.
+    Every entry in the agent's `tools` field is provably non-functional, by
+    one of two documented mechanisms:
 
-    This rule is deliberately narrow: only the exact literal `mcp__*` is
-    treated as unresolvable. No other wildcard-bearing token — a bare `*`, or
-    a non-MCP form like `Bash(git:*)` — is established by sub-agents.md to
-    fail; the absence of a documented *resolving* meaning for a token is not
-    proof it is *invalid*, and asserting otherwise would be an unsourced
-    constraint (see the AS007 rule #108 deleted for the same reason).
+    - **Unscoped wildcard.** The literal string `mcp__*`, which names no MCP
+      server. A *server-scoped* grant such as `mcp__Ref__*` is supported and
+      NOT reported here — Claude Code resolves it to every tool that server
+      exposes, identically to the bare `mcp__Ref` form.
+    - **Unconditionally removed.** One of `AskUserQuestion`,
+      `EndConversation`, `EnterPlanMode`, `ScheduleWakeup`, `TaskOutput`,
+      `WaitForMcpServers`, or `Workflow` — Claude Code's first tool filter
+      strips these from every subagent regardless of what `tools` lists, so
+      listing one has no effect.
 
-    This only fires when **every** entry in `tools` is exactly `mcp__*`. A
-    single `mcp__*` alongside an ordinary tool name (`Read`, `mcp__Ref__*`)
-    is not reported: skilllint has no registry of live tool names, so it
-    cannot prove the sibling entry fails to resolve too.
+    Both checks are deliberately narrow. For the wildcard case: no other
+    wildcard-bearing token — a bare `*`, or a non-MCP form like
+    `Bash(git:*)` — is established by sub-agents.md to fail; the absence of a
+    documented *resolving* meaning for a token is not proof it is *invalid*,
+    and asserting otherwise would be an unsourced constraint (see the AS007
+    rule #108 deleted for the same reason). For the removed-tools case: two
+    names from the same documented list are deliberately excluded because
+    their removal is conditional, not provable from frontmatter alone —
+    `Agent` (removed only at the subagent depth limit) and `ExitPlanMode`
+    (removed unless `permissionMode` is `plan`).
 
-    **Source:** sub-agents.md, "Available tools" — "When nothing in the
-    `tools` list resolves to a tool ... Claude Code usually refuses to launch
-    the subagent and the Agent tool returns an error naming the unresolved
-    entries." Same section, same paragraph: "`mcp__<server>` or
+    This only fires when **every** entry in `tools` is provably
+    non-functional. A single such entry alongside an ordinary tool name
+    (`Read`, `mcp__Ref__*`) is not reported: skilllint has no registry of
+    live tool names, so it cannot prove the sibling entry fails to resolve
+    too.
+
+    **Source (wildcard):** sub-agents.md, "Available tools" — "When nothing
+    in the `tools` list resolves to a tool ... Claude Code usually refuses to
+    launch the subagent and the Agent tool returns an error naming the
+    unresolved entries." Same section, same paragraph: "`mcp__<server>` or
     `mcp__<server>__*` grants or removes every tool from the named server. In
     `disallowedTools`, `mcp__*` also removes every MCP tool from any server."
     `mcp__*` is therefore defined *only* for `disallowedTools`; in `tools` it
     matches neither documented grant pattern (a real server name is required)
     and so names no server there.
 
-    **Fix:** Replace `mcp__*` with a server-scoped grant (e.g. `mcp__Ref__*`)
-    or the exact tool names, or remove `tools` entirely to inherit the
-    default set.
+    **Source (removed tools):** sub-agents.md, "Available tools" — "The
+    first filter removes these tools, even when listed in the `tools`
+    field:" followed by the bullet list naming the seven tools above (plus
+    the two conditional exclusions).
+
+    **Fix:** Replace the offending entry with a server-scoped grant (e.g.
+    `mcp__Ref__*`), an exact tool name that the first filter does not strip,
+    or remove `tools` entirely to inherit the default set.
 
     Args:
         frontmatter: Raw parsed agent frontmatter dict (pre-Pydantic).
 
     Returns:
-        One error issue per `mcp__*` entry when every entry in `tools` is
-        `mcp__*`; empty list otherwise, including when `tools` is absent,
-        blank, or an empty list.
+        One error issue per provably non-functional entry when every entry
+        in `tools` is provably non-functional; empty list otherwise,
+        including when `tools` is absent, blank, or an empty list.
 
     <!-- examples: AG001 -->
     """
@@ -133,28 +175,34 @@ def check_ag001(frontmatter: dict) -> list[ValidationIssue]:
     if not tools:
         return []
 
-    unscoped = [t for t in tools if t in _UNRESOLVABLE_WILDCARD_TOOLS]
-    if not unscoped or len(unscoped) != len(tools):
-        # Not fatal: either no unresolvable wildcard is present, or at least
-        # one entry is not one and may resolve to a real tool.
+    provably_zero = [t for t in tools if t in _PROVABLY_ZERO_TOOLS]
+    if not provably_zero or len(provably_zero) != len(tools):
+        # Not fatal: either no provably non-functional entry is present, or
+        # at least one entry is not one and may resolve to a real tool.
         return []
 
-    return [
-        _make_issue(
-            field="tools",
-            severity="error",
-            message=(
+    issues: list[ValidationIssue] = []
+    for tool_name in provably_zero:
+        if tool_name in _UNRESOLVABLE_WILDCARD_TOOLS:
+            message = (
                 f"Unscoped wildcard '{tool_name}' in the tools field names no server. Every entry in tools "
                 "resolves to nothing, so Claude Code will refuse to launch this subagent."
-            ),
-            code="AG001",
-            suggestion=(
+            )
+            suggestion = (
                 f"Replace '{tool_name}' with a server-scoped grant (e.g. 'mcp__Ref__*'), the exact tool "
                 "names (e.g. 'mcp__Ref__ref_read_url'), or remove 'tools' to inherit the default set."
-            ),
+            )
+        else:
+            message = (
+                f"'{tool_name}' in the tools field is unconditionally removed by Claude Code's first tool "
+                "filter. Every entry in tools resolves to nothing, so Claude Code will refuse to launch "
+                "this subagent."
+            )
+            suggestion = f"Remove '{tool_name}' from tools, or remove 'tools' entirely to inherit the default set."
+        issues.append(
+            _make_issue(field="tools", severity="error", message=message, code="AG001", suggestion=suggestion)
         )
-        for tool_name in unscoped
-    ]
+    return issues
 
 
 # ---------------------------------------------------------------------------

--- a/packages/skilllint/rules/ag_series.py
+++ b/packages/skilllint/rules/ag_series.py
@@ -70,7 +70,7 @@ _UNRESOLVABLE_WILDCARD_TOOLS: frozenset[str] = frozenset({"mcp__*"})
 
 # Source: sub-agents.md, "Available tools" -- "The first filter removes these
 # tools, even when listed in the `tools` field:" (.claude/vendor/sources/
-# sub-agents-2026-08-30-1123.md:375-384). Every subagent, foreground or
+# sub-agents-2026-08-30-1123.md:374-384). Every subagent, foreground or
 # background, unconditionally loses these tool names regardless of what
 # `tools` lists. Two names from that same bullet list are deliberately
 # excluded because their removal is conditional, not provable from
@@ -190,7 +190,7 @@ def check_ag001(frontmatter: dict) -> list[ValidationIssue]:
             )
             suggestion = (
                 f"Replace '{tool_name}' with a server-scoped grant (e.g. 'mcp__Ref__*'), the exact tool "
-                "names (e.g. 'mcp__Ref__ref_read_url'), or remove 'tools' to inherit the default set."
+                "names (e.g. 'mcp__Ref__ref_read_url'), or remove 'tools' entirely to inherit the default set."
             )
         else:
             message = (

--- a/packages/skilllint/tests/fixtures/providers/claude/failing-examples/AG001/fixture.toml
+++ b/packages/skilllint/tests/fixtures/providers/claude/failing-examples/AG001/fixture.toml
@@ -1,9 +1,14 @@
 [fixture]
 rule_id = "AG001"
 tier = 1
-description = "Claude agent tools grant uses an unscoped wildcard that resolves to no server"
+description = "Claude agent tools grant is provably non-functional (unscoped wildcard, or a tool Claude Code unconditionally removes)"
 
 [[variants]]
 name = "unscoped-mcp-wildcard"
+kind = "failing"
+expected_count = 1
+
+[[variants]]
+name = "unconditionally-removed-tool"
 kind = "failing"
 expected_count = 1

--- a/packages/skilllint/tests/fixtures/providers/claude/failing-examples/AG001/unconditionally-removed-tool/agents/removed-tool.md
+++ b/packages/skilllint/tests/fixtures/providers/claude/failing-examples/AG001/unconditionally-removed-tool/agents/removed-tool.md
@@ -1,0 +1,7 @@
+---
+name: removed-tool
+description: Demonstrates a tools grant naming only a tool Claude Code unconditionally removes
+tools: AskUserQuestion
+---
+
+Ask the user a question to complete the requested task.

--- a/packages/skilllint/tests/test_ag_series.py
+++ b/packages/skilllint/tests/test_ag_series.py
@@ -11,7 +11,9 @@ the scalar-versus-sequence shape authored in YAML.
 
 from __future__ import annotations
 
+import datetime
 import json
+import warnings
 from typing import TYPE_CHECKING
 
 import pytest
@@ -471,6 +473,26 @@ class TestAgentFrontmatterSkillsShape:
     def test_skills_absent_is_none(self) -> None:
         model = AgentFrontmatter.model_validate({"name": "a", "description": "d"})
         assert model.skills is None
+        assert model.normalized_skills == []
+
+    def test_skills_date_scalar_does_not_raise(self) -> None:
+        """A YAML scalar ruamel.yaml resolves to datetime.date must not crash validation.
+
+        Regression test for a finding on PR #185's code review: retyping
+        `skills` from `object | None` to `JsonValue` made Pydantic reject any
+        value JSON cannot represent (JsonValue's schema has no `date` arm),
+        turning an unquoted date-like scalar into a hard ValidationError
+        instead of the AG003 warning normalize_agent_skills_value already
+        classifies it as. Also asserts no serializer warning fires on dump
+        (SkipValidation without a plain-returning field_serializer emits one
+        for exactly this case).
+        """
+        value = datetime.date(2024, 1, 1)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            model = AgentFrontmatter.model_validate({"name": "a", "description": "d", "skills": value})
+            assert model.skills == value
+            assert model.model_dump()["skills"] == value
         assert model.normalized_skills == []
 
     @pytest.mark.parametrize(

--- a/packages/skilllint/tests/test_ag_series.py
+++ b/packages/skilllint/tests/test_ag_series.py
@@ -190,6 +190,52 @@ class TestCheckAg001:
         """`tools: []` has no documented consequence — not flagged (see #109 analysis)."""
         assert check_ag001({"tools": []}) == []
 
+    def test_unconditionally_removed_tool_is_fatal(self) -> None:
+        """A single entry naming an unconditionally-removed tool is fatal.
+
+        Sourced from sub-agents.md, "Available tools" — the first filter
+        strips these tools from every subagent regardless of what `tools`
+        lists (#150). `AskUserQuestion` is one of the seven unconditional
+        entries (the two conditional ones, `Agent` and `ExitPlanMode`, are
+        deliberately excluded — see the module-level constant comment).
+        """
+        issues = check_ag001({"tools": ["AskUserQuestion"]})
+        assert len(issues) == 1
+        assert issues[0].code == "AG001"
+
+    def test_all_seven_unconditionally_removed_tools_are_fatal(self) -> None:
+        """Every documented unconditional-removal name is individually fatal."""
+        for tool_name in (
+            "AskUserQuestion",
+            "EndConversation",
+            "EnterPlanMode",
+            "ScheduleWakeup",
+            "TaskOutput",
+            "WaitForMcpServers",
+            "Workflow",
+        ):
+            issues = check_ag001({"tools": [tool_name]})
+            assert len(issues) == 1, f"{tool_name} should be fatal alone"
+            assert issues[0].code == "AG001"
+
+    def test_agent_is_not_provably_fatal(self) -> None:
+        """`Agent` is removed only at the subagent depth limit — not statically provable."""
+        assert check_ag001({"tools": ["Agent"]}) == []
+
+    def test_exit_plan_mode_is_not_provably_fatal(self) -> None:
+        """`ExitPlanMode` is removed only when `permissionMode` isn't `plan` — not statically provable."""
+        assert check_ag001({"tools": ["ExitPlanMode"]}) == []
+
+    def test_mixed_wildcard_and_removed_tool_is_fatal(self) -> None:
+        """An unscoped wildcard alongside an unconditionally-removed tool: both provably fail."""
+        issues = check_ag001({"tools": ["mcp__*", "AskUserQuestion"]})
+        assert len(issues) == 2
+        assert {issue.code for issue in issues} == {"AG001"}
+
+    def test_removed_tool_alongside_a_real_tool_is_not_fatal(self) -> None:
+        """skilllint cannot prove a sibling ordinary tool name also fails to resolve."""
+        assert check_ag001({"tools": ["Read", "AskUserQuestion"]}) == []
+
 
 # ---------------------------------------------------------------------------
 # AG002 unit tests

--- a/packages/skilllint/tests/test_frontmatter_validator.py
+++ b/packages/skilllint/tests/test_frontmatter_validator.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from skilllint.frontmatter_core import SkillFrontmatter
 from skilllint.plugin_validator import FrontmatterValidator
 
 if TYPE_CHECKING:
@@ -688,3 +689,36 @@ description: Skill with mismatched name field
         assert any(issue.code == "FM010" and "actual-dir-name" in issue.message for issue in result.errors), (
             f"Expected an FM010 directory-mismatch error, got: {result.errors}"
         )
+
+
+class TestSkillFrontmatterSkillsField:
+    """SkillFrontmatter declares no `skills` field, so no CSV coercion (#151).
+
+    The agentskills.io specification defines exactly six SKILL.md properties
+    (name, description, license, compatibility, metadata, allowed-tools);
+    `skills` is not among them -- it is documented only as subagent
+    frontmatter (sub-agents.md). FM008 was deleted in #105 for asserting a
+    `skills` shape on SKILL.md for the same reason. Silently rewriting an
+    authored list into a comma-separated string -- what the removed field's
+    validator did -- is the same class of silent mutation #114 and #147
+    fixed elsewhere; that mutation is what these tests guard against
+    reappearing.
+    """
+
+    def test_skills_list_survives_model_validation_untouched(self) -> None:
+        """A YAML list value for `skills` is not coerced to a CSV string."""
+        model = SkillFrontmatter.model_validate({
+            "description": "A" * 25,
+            "skills": ["api-conventions", "error-handling-patterns"],
+        })
+        dumped = model.model_dump(by_alias=True, exclude_none=True, mode="python")
+        assert dumped["skills"] == ["api-conventions", "error-handling-patterns"]
+
+    def test_skills_scalar_survives_model_validation_untouched(self) -> None:
+        """A scalar string value for `skills` also passes through unchanged."""
+        model = SkillFrontmatter.model_validate({
+            "description": "A" * 25,
+            "skills": "api-conventions, error-handling-patterns",
+        })
+        dumped = model.model_dump(by_alias=True, exclude_none=True, mode="python")
+        assert dumped["skills"] == "api-conventions, error-handling-patterns"

--- a/packages/skilllint/tests/test_provider_validation.py
+++ b/packages/skilllint/tests/test_provider_validation.py
@@ -433,6 +433,36 @@ Body content.
 
         _assert_authority(fm010[0])
 
+    def test_cli_json_output_includes_ag001_authority(self, tmp_path: pathlib.Path) -> None:
+        """JSON output format includes authority field for an AG-series violation (#153).
+
+        #132's own checklist named JSON/text reporters as in scope for the AG
+        series; the only existing JSON-output authority test used an FM rule.
+        Same pattern as test_cli_json_output_includes_authority, against
+        AG001's mcp__* case instead.
+        """
+        agent_dir = tmp_path / "agents"
+        agent_dir.mkdir()
+        agent_file = agent_dir / "broken.md"
+        agent_file.write_text(
+            """---
+name: broken
+description: Agent with an unscoped MCP wildcard.
+tools: mcp__*
+---
+
+Body content.
+"""
+        )
+
+        adapters = {a.id(): a for a in load_adapters()}
+        violations = validate_file(agent_file, adapters, platform_override="claude_code")
+
+        ag001 = [v for v in violations if v.get("code") == "AG001"]
+        assert len(ag001) == 1, f"Expected exactly one AG001 violation, got: {violations}"
+
+        _assert_authority(ag001[0])
+
 
 # ---------------------------------------------------------------------------
 # Shared SKILL.md checks for adapters that skip the frontmatter pipeline


### PR DESCRIPTION
## Summary

Four sourced, independently-verified fixes closing the AG-series follow-up cluster from #109/#147:

- **#150** — AG001's provable-zero detection was wildcard-only. Widened to also catch the seven tool names Claude Code's first filter unconditionally removes (`AskUserQuestion`, `EndConversation`, `EnterPlanMode`, `ScheduleWakeup`, `TaskOutput`, `WaitForMcpServers`, `Workflow`), sourced verbatim from `sub-agents.md`'s "Available tools" section — matches #150's proposed list exactly, including its exclusion of the two conditional names (`Agent`, `ExitPlanMode`).
- **#149** — `AgentFrontmatter.skills` was typed `object | None`, forbidden by `TYPING_POLICY.md` §3 outside boundary modules. Retyped to `pydantic.JsonValue` (a hand-rolled recursive alias hit a real Pydantic RecursionError when used as a model field — see commit for the dead end and the reason `JsonValue` is correct).
- **#151** — `SkillFrontmatter.skills` still CSV-coerced a YAML list, same class of silent mutation #147 fixed on the agent side. Verified `skills` isn't one of the six SKILL.md properties the agentskills.io schema defines, so removed the field (not retyped) — `extra="allow"` now passes it through untouched.
- **#153** — closed the JSON-output authority test gap for an AG rule, mirroring the existing FM010 test.

## Test plan
- [x] `uv run prek run --all-files`
- [x] `uv run pytest` (1503 passed, 10 skipped)
- [x] #150: unit tests for all 7 removed-tool names individually, both conditional exclusions staying clean, mixed-wildcard case, sibling-real-tool case; new fixture-driven failing example
- [x] #149: confirmed the RecursionError reproduces with the naive approach, confirmed `JsonValue` doesn't; full frontmatter test suite green
- [x] #151: new model-level regression test verified to fail against the pre-fix model shape (a `--fix`-level test was tried first and found not to discriminate — a separate restore-guard already neutralizes CSV coercion at that layer; documented in the commit)
- [x] #153: new test passes, follows the established (if loosely-named) "CLI JSON output" pattern in `test_provider_validation.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XATWGbELHG23qfNfvJVbDk