### PR TITLE
chore(provenance): sync vendor-backed claim values

### DIFF
--- a/packages/skilllint/schemas/provenance-registry.json
+++ b/packages/skilllint/schemas/provenance-registry.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "Rule Provenance Registry — maps lint rule claims to upstream authority sources",
+  "description": "Rule Provenance Registry \u2014 maps lint rule claims to upstream authority sources",
   "version": "1",
   "claims": {
     "FM010.max_name_length": {
@@ -53,7 +53,9 @@
         "symbol": "_AGENTSKILLS_TOOL_FIELD_NAMES",
         "source_type": "python_constant"
       },
-      "expected_value": ["allowed-tools"],
+      "expected_value": [
+        "allowed-tools"
+      ],
       "x-audited": {
         "date": "2026-03-14",
         "source": "packages/skilllint/schemas/agentskills_io/v1.json"
@@ -125,10 +127,12 @@
         "PermissionDenied",
         "PermissionRequest",
         "PostCompact",
+        "PostModelSwitch",
         "PostToolBatch",
         "PostToolUse",
         "PostToolUseFailure",
         "PreCompact",
+        "PreModelSwitch",
         "PreToolUse",
         "SessionEnd",
         "SessionStart",
@@ -147,7 +151,7 @@
       ],
       "x-audited": {
         "date": "2026-09-04",
-        "source": ".claude/vendor/sources/hooks-2026-08-28-0408.md"
+        "source": ".claude/vendor/sources/hooks-2026-09-04-0550.md"
       }
     },
     "HK003.valid_hook_types": {
@@ -175,7 +179,13 @@
         "symbol": "VALID_HOOK_TYPES",
         "source_type": "python_constant"
       },
-      "expected_value": ["agent", "command", "http", "mcp_tool", "prompt"],
+      "expected_value": [
+        "agent",
+        "command",
+        "http",
+        "mcp_tool",
+        "prompt"
+      ],
       "x-audited": {
         "date": "2026-09-04",
         "source": ".claude/vendor/sources/hooks-2026-08-28-0408.md"


### PR DESCRIPTION
Automated run of `scripts/refresh_claim_values.py` found upstream documentation drift. See the diff for which claim(s) changed and what values were added or removed.

Additions are usually safe to merge as-is. A removal means Claude Code stopped documenting something this repo's code still accepts — read `packages/skilllint/rules/hk_series.py`'s corresponding constant before merging, since the code may need a matching change, not just the registry.