### PR TITLE
test(CU,CX): add registry-presence coverage and fix tautological assertion

### DIFF
--- a/packages/skilllint/tests/test_adapters.py
+++ b/packages/skilllint/tests/test_adapters.py
@@ -119,14 +119,11 @@ def test_cursor_adapter_mdc_validation():
 
 
 def test_cursor_mdc_unknown_fields():
-    """CursorAdapter reports a violation for unknown field in .mdc frontmatter."""
+    """CursorAdapter reports CU002 for an unknown field in .mdc frontmatter."""
     adapter = CursorAdapter()
     violations = adapter.validate(CURSOR_FIXTURES / "invalid_rule.mdc")
     codes = [v["code"] for v in violations]
-    assert any("cursor" in c.lower() or "unknown" in c.lower() or c for c in codes), (
-        f"Expected a violation for unknown .mdc field, got: {violations}"
-    )
-    assert len(violations) > 0
+    assert codes == ["CU002"], f"Expected a CU002 violation for unknown .mdc field, got: {violations}"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/skilllint/tests/test_cu_cx_registry.py
+++ b/packages/skilllint/tests/test_cu_cx_registry.py
@@ -15,16 +15,15 @@ non-empty code string.
 This module asserts the same invariant set for both series:
     1. CU001/CU002/CX001/CX002 are registered in ``RULE_REGISTRY``.
     2. Their ``platforms`` metadata matches the single owning adapter.
-    3. The Cursor adapter's ``validate()`` returns ``list[dict]`` (the
-       unchanged external contract).
-    4. No raw-dict ``ValidationIssue(...)`` construction remains in
-       ``adapters/cursor/adapter.py`` — issues must come from the registered
-       rule functions, not be hand-built at the adapter boundary.
+    3. Each adapter's ``validate()`` returns ``list[dict]`` (the unchanged
+       external contract).
+    4. No raw-dict ``ValidationIssue(...)`` construction remains in either
+       adapter module — issues must come from the registered rule
+       functions, not be hand-built at the adapter boundary.
 """
 
 from __future__ import annotations
 
-import ast
 import inspect
 import pathlib
 
@@ -34,6 +33,7 @@ from skilllint.rule_registry import RULE_REGISTRY
 
 FIXTURES = pathlib.Path(__file__).parent / "fixtures"
 CURSOR_FIXTURES = FIXTURES / "cursor"
+CODEX_FIXTURES = FIXTURES / "codex"
 
 
 class TestCuCxRegistration:
@@ -97,17 +97,30 @@ class TestCursorAdapterBoundary:
         import skilllint.adapters.cursor.adapter as cursor_adapter_module
 
         source = inspect.getsource(cursor_adapter_module)
-        tree = ast.parse(source)
-        constructor_calls = [
-            node
-            for node in ast.walk(tree)
-            if isinstance(node, ast.Call)
-            and (
-                (isinstance(node.func, ast.Name) and node.func.id == "ValidationIssue")
-                or (isinstance(node.func, ast.Attribute) and node.func.attr == "ValidationIssue")
-            )
-        ]
-        assert constructor_calls == [], (
-            f"adapters/cursor/adapter.py must not construct ValidationIssue directly, "
-            f"found {len(constructor_calls)} call(s)"
+        assert "ValidationIssue(" not in source, (
+            "adapters/cursor/adapter.py must not construct ValidationIssue directly"
         )
+
+
+class TestCodexAdapterBoundary:
+    """The Codex adapter's external contract and internal construction."""
+
+    def test_validate_returns_list_of_dict(self) -> None:
+        """CodexAdapter.validate() returns list[dict], the unchanged external contract."""
+        adapter = CodexAdapter()
+        violations = adapter.validate(CODEX_FIXTURES / "invalid_rules.rules")
+        assert isinstance(violations, list)
+        assert violations, "expected at least one violation from invalid_rules.rules"
+        assert all(isinstance(v, dict) for v in violations)
+
+    def test_no_raw_validationissue_construction_in_adapter(self) -> None:
+        """adapters/codex/adapter.py never constructs ValidationIssue directly.
+
+        Issues must be produced by the registered CX rule functions and only
+        converted to dicts at the adapter boundary — not hand-built as raw
+        ``ValidationIssue(...)`` calls.
+        """
+        import skilllint.adapters.codex.adapter as codex_adapter_module
+
+        source = inspect.getsource(codex_adapter_module)
+        assert "ValidationIssue(" not in source, "adapters/codex/adapter.py must not construct ValidationIssue directly"

--- a/packages/skilllint/tests/test_cu_cx_registry.py
+++ b/packages/skilllint/tests/test_cu_cx_registry.py
@@ -1,0 +1,113 @@
+"""Registry and adapter-boundary invariants for the CU and CX rule series.
+
+CU (Cursor ``.mdc`` frontmatter) and CX (OpenAI Codex file validation) are
+the two rule series where detection was originally owned by a platform
+adapter rather than the core validator (see ``rules/cu_series.py`` and
+``rules/cx_series.py`` docstrings, "Architectural note — adapter-backed
+series"). Per architect spec §8.3, the resolution is: the series module owns
+the ``@skilllint_rule`` registration; the adapter imports the module's public
+entry point and converts its output to ``list[dict]`` at the adapter
+boundary. Before this file, no test exercised that resolution directly for
+either series — the only indirect assertion (``test_cursor_mdc_unknown_fields``
+in ``test_adapters.py``) contained an ``or c`` tautology that passed for any
+non-empty code string.
+
+This module asserts the same invariant set for both series:
+    1. CU001/CU002/CX001/CX002 are registered in ``RULE_REGISTRY``.
+    2. Their ``platforms`` metadata matches the single owning adapter.
+    3. The Cursor adapter's ``validate()`` returns ``list[dict]`` (the
+       unchanged external contract).
+    4. No raw-dict ``ValidationIssue(...)`` construction remains in
+       ``adapters/cursor/adapter.py`` — issues must come from the registered
+       rule functions, not be hand-built at the adapter boundary.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+
+from skilllint.adapters.codex import CodexAdapter
+from skilllint.adapters.cursor import CursorAdapter
+from skilllint.rule_registry import RULE_REGISTRY
+
+FIXTURES = pathlib.Path(__file__).parent / "fixtures"
+CURSOR_FIXTURES = FIXTURES / "cursor"
+
+
+class TestCuCxRegistration:
+    """CU001, CU002, CX001, and CX002 are registered with the correct platform."""
+
+    def test_cu_rules_registered(self) -> None:
+        """CU001 and CU002 are present in RULE_REGISTRY."""
+        assert {"CU001", "CU002"} <= RULE_REGISTRY.keys()
+
+    def test_cx_rules_registered(self) -> None:
+        """CX001 and CX002 are present in RULE_REGISTRY."""
+        assert {"CX001", "CX002"} <= RULE_REGISTRY.keys()
+
+    def test_cu_rules_scoped_to_cursor_platform(self) -> None:
+        """CU001 and CU002 declare platforms=["cursor"]."""
+        assert RULE_REGISTRY["CU001"].platforms == ["cursor"]
+        assert RULE_REGISTRY["CU002"].platforms == ["cursor"]
+
+    def test_cx_rules_scoped_to_codex_platform(self) -> None:
+        """CX001 and CX002 declare platforms=["codex"]."""
+        assert RULE_REGISTRY["CX001"].platforms == ["codex"]
+        assert RULE_REGISTRY["CX002"].platforms == ["codex"]
+
+
+class TestCuCxAdapterOwnership:
+    """Only the owning adapter declares CU/CX in its applicable rule prefixes."""
+
+    def test_only_cursor_adapter_owns_cu_series(self) -> None:
+        """CU is owned by the Cursor adapter, not Codex."""
+        cursor = CursorAdapter()
+        codex = CodexAdapter()
+        assert "CU" in cursor.applicable_rules()
+        assert "CU" not in codex.applicable_rules()
+
+    def test_only_codex_adapter_owns_cx_series(self) -> None:
+        """CX is owned by the Codex adapter, not Cursor."""
+        cursor = CursorAdapter()
+        codex = CodexAdapter()
+        assert "CX" in codex.applicable_rules()
+        assert "CX" not in cursor.applicable_rules()
+
+
+class TestCursorAdapterBoundary:
+    """The Cursor adapter's external contract and internal construction."""
+
+    def test_validate_returns_list_of_dict(self) -> None:
+        """CursorAdapter.validate() returns list[dict], the unchanged external contract."""
+        adapter = CursorAdapter()
+        violations = adapter.validate(CURSOR_FIXTURES / "invalid_rule.mdc")
+        assert isinstance(violations, list)
+        assert violations, "expected at least one violation from invalid_rule.mdc"
+        assert all(isinstance(v, dict) for v in violations)
+
+    def test_no_raw_validationissue_construction_in_adapter(self) -> None:
+        """adapters/cursor/adapter.py never constructs ValidationIssue directly.
+
+        Issues must be produced by the registered CU rule functions
+        (via ``validate_mdc_frontmatter``) and only converted to dicts at the
+        adapter boundary — not hand-built as raw ``ValidationIssue(...)`` calls.
+        """
+        import skilllint.adapters.cursor.adapter as cursor_adapter_module
+
+        source = inspect.getsource(cursor_adapter_module)
+        tree = ast.parse(source)
+        constructor_calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and (
+                (isinstance(node.func, ast.Name) and node.func.id == "ValidationIssue")
+                or (isinstance(node.func, ast.Attribute) and node.func.attr == "ValidationIssue")
+            )
+        ]
+        assert constructor_calls == [], (
+            f"adapters/cursor/adapter.py must not construct ValidationIssue directly, "
+            f"found {len(constructor_calls)} call(s)"
+        )


### PR DESCRIPTION
## Summary

CU (Cursor `.mdc` frontmatter) and CX (OpenAI Codex file validation) are the
"adapter-backed series pair" described in issue #41 item 5 — almost no
direct test coverage existed. Verified this session:

- No test imported `cu_series`/`cx_series` or called
  `check_cu001`/`check_cu002`/`check_cx001`/`check_cx002` directly.
- The one existing indirect assertion,
  `test_cursor_mdc_unknown_fields` in `test_adapters.py`, contained an
  `or c` tautology (`assert any("cursor" in c.lower() or "unknown" in
  c.lower() or c for c in codes)`) that passed for **any** non-empty code
  string, regardless of which rule actually fired.

## Changes

1. **New file** `packages/skilllint/tests/test_cu_cx_registry.py`,
   mirroring the house style of `test_nr_series.py` and the series-scoped
   registration + adapter-ownership pattern in
   `test_ag_integration.py` (lines ~180-193), extending the architect spec
   §8.3 invariant set (previously only asserted for CU/Cursor) to both CU
   and CX:
   - `CU001`, `CU002`, `CX001`, `CX002` are present in `RULE_REGISTRY` after
     `import skilllint.rules`.
   - Their `platforms` metadata is `["cursor"]` / `["codex"]` respectively
     (read from the `@skilllint_rule` decorator calls in
     `cu_series.py`/`cx_series.py`, not assumed).
   - Only the owning adapter declares the `CU`/`CX` prefix in
     `applicable_rules()`.
   - `CursorAdapter.validate()` returns `list[dict]` (the unchanged
     external contract).
   - `adapters/cursor/adapter.py` never constructs `ValidationIssue(...)`
     directly — checked via an AST walk over the module source, since
     issues must come from the registered rule functions and only be
     converted to dicts at the adapter boundary.

2. **Fixed** the tautology in `test_cursor_mdc_unknown_fields`
   (`test_adapters.py`) to assert the actual code the fixture produces
   (`codes == ["CU002"]`, verified by running the adapter against
   `invalid_rule.mdc`) instead of the vacuous `... or c` clause.

Test-only changes — `cu_series.py`, `cx_series.py`, and the adapter files
themselves are untouched.

Closes part of #41 (item 5).

## Test plan

- [x] `uv run prek run --all-files` — all hooks pass (ruff, ruff-format, ty,
      markdownlint, shellcheck, ...)
- [x] `uv run pytest` — 1512 passed, 10 skipped, 86.37% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4