### PR TITLE
refactor(rule-registry): constrain category/platforms to Literal types

### DIFF
--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -38,7 +38,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from io import StringIO
 from pathlib import Path, PurePath
-from typing import TYPE_CHECKING, Annotated, Literal, NoReturn, Protocol, TypeAlias, cast, get_args
+from typing import TYPE_CHECKING, Annotated, Literal, NoReturn, Protocol, TypeAlias, cast
 
 # YAML/JSON at the edge: dict, list, or JSON-serializable scalars. More specific than Any.
 YamlValue: TypeAlias = dict[str, "YamlValue"] | list["YamlValue"] | str | int | float | bool | None
@@ -4640,10 +4640,8 @@ from rich.table import Table as _Table
 
 from skilllint.fixture_loader import FIXTURES_ROOT as _FIXTURES_ROOT, discover_fixtures as _discover_fixtures
 from skilllint.rule_registry import get_rule as _get_rule, list_rules as _list_rules
-from skilllint.rules._constants import RuleCategory
+from skilllint.rules._constants import RuleCategory, RulePlatform
 from skilllint.rules.pa_series import PluginAgentFrontmatterValidator
-
-_VALID_RULE_CATEGORIES = get_args(RuleCategory)
 
 
 def _make_rule_console(*, record: bool = False) -> _Console:
@@ -4689,18 +4687,15 @@ def rule_cmd(
 
 @app.command("rules")
 def rules_cmd(
-    platform: Annotated[str | None, typer.Option("--platform", "-p", help="Filter rules by platform")] = None,
-    category: Annotated[str | None, typer.Option("--category", "-c", help="Filter rules by category")] = None,
+    platform: Annotated[RulePlatform | None, typer.Option("--platform", "-p", help="Filter rules by platform")] = None,
+    category: Annotated[RuleCategory | None, typer.Option("--category", "-c", help="Filter rules by category")] = None,
     severity: Annotated[
-        str | None, typer.Option("--severity", "-s", help="Filter rules by severity (error, warning, info)")
+        Literal["error", "warning", "info"] | None, typer.Option("--severity", "-s", help="Filter rules by severity")
     ] = None,
     *,
     record: Annotated[Path | None, typer.Option("--record", help="Record terminal output to SVG or HTML file")] = None,
 ) -> None:
     """List all available validation rules."""
-    if category is not None and category not in _VALID_RULE_CATEGORIES:
-        valid = ", ".join(_VALID_RULE_CATEGORIES)
-        raise typer.BadParameter(f"Invalid category {category!r}. Valid categories: {valid}", param_hint="--category")
     console = _make_rule_console(record=record is not None)
     _show_rules_list(platform=platform, category=category, severity=severity, console=console)
     console.print("\n[dim]Run [bold]skilllint rule [yellow]RULE_ID[/yellow][/bold] for details.[/dim]")

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -38,7 +38,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from io import StringIO
 from pathlib import Path, PurePath
-from typing import TYPE_CHECKING, Annotated, Literal, NoReturn, Protocol, TypeAlias, cast
+from typing import TYPE_CHECKING, Annotated, Literal, NoReturn, Protocol, TypeAlias, cast, get_args
 
 # YAML/JSON at the edge: dict, list, or JSON-serializable scalars. More specific than Any.
 YamlValue: TypeAlias = dict[str, "YamlValue"] | list["YamlValue"] | str | int | float | bool | None
@@ -4640,7 +4640,10 @@ from rich.table import Table as _Table
 
 from skilllint.fixture_loader import FIXTURES_ROOT as _FIXTURES_ROOT, discover_fixtures as _discover_fixtures
 from skilllint.rule_registry import get_rule as _get_rule, list_rules as _list_rules
+from skilllint.rules._constants import RuleCategory
 from skilllint.rules.pa_series import PluginAgentFrontmatterValidator
+
+_VALID_RULE_CATEGORIES = get_args(RuleCategory)
 
 
 def _make_rule_console(*, record: bool = False) -> _Console:
@@ -4695,6 +4698,9 @@ def rules_cmd(
     record: Annotated[Path | None, typer.Option("--record", help="Record terminal output to SVG or HTML file")] = None,
 ) -> None:
     """List all available validation rules."""
+    if category is not None and category not in _VALID_RULE_CATEGORIES:
+        valid = ", ".join(_VALID_RULE_CATEGORIES)
+        raise typer.BadParameter(f"Invalid category {category!r}. Valid categories: {valid}", param_hint="--category")
     console = _make_rule_console(record=record is not None)
     _show_rules_list(platform=platform, category=category, severity=severity, console=console)
     console.print("\n[dim]Run [bold]skilllint rule [yellow]RULE_ID[/yellow][/bold] for details.[/dim]")

--- a/packages/skilllint/rule_registry.py
+++ b/packages/skilllint/rule_registry.py
@@ -31,6 +31,8 @@ from urllib.parse import urljoin
 
 from pydantic import BaseModel, Field
 
+from skilllint.rules._constants import RuleCategory, RulePlatform
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -99,8 +101,8 @@ class RuleEntry(BaseModel):
 
     id: Annotated[str, Field(pattern=r"^[A-Z]{2}\d{3}$")]
     severity: Literal["error", "warning", "info"]
-    category: str  # "frontmatter", "skill", "plugin", "hook", etc.
-    platforms: list[str]  # ["agentskills"] = all platforms, or specific like ["claude-code"]
+    category: RuleCategory
+    platforms: list[RulePlatform]  # ["agentskills"] = all platforms, or specific like ["claude-code"]
     docstring: str
     authority: RuleAuthority | None = None
 
@@ -120,8 +122,8 @@ def skilllint_rule(
     rule_id: str,
     *,
     severity: Literal["error", "warning", "info"],
-    category: str,
-    platforms: list[str] | None = None,
+    category: RuleCategory,
+    platforms: list[RulePlatform] | None = None,
     authority: dict | None = None,
 ) -> Callable[[Callable], Callable]:
     """Decorator to register a validator function as a rule.

--- a/packages/skilllint/rules/_constants.py
+++ b/packages/skilllint/rules/_constants.py
@@ -2,6 +2,32 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
+# Live value space of RuleEntry.category, grepped from every @skilllint_rule(...)
+# call site in packages/skilllint/rules/*_series.py (issue #41 item 3). Adding a
+# new category requires adding it here first, or Pydantic rejects the
+# registration at import time.
+RuleCategory = Literal[
+    "agent",
+    "codex",
+    "cursor",
+    "frontmatter",
+    "hook",
+    "link",
+    "namespace-reference",
+    "plugin",
+    "plugin-registration",
+    "progressive-disclosure",
+    "skill",
+    "symlink",
+    "token-count",
+]
+
+# Live value space of RuleEntry.platforms elements, including sites that omit
+# platforms= and take the @skilllint_rule decorator's ["agentskills"] default.
+RulePlatform = Literal["agentskills", "claude-code", "codex", "cursor"]
+
 # Full set of expected series prefixes: the 14 series from P038 plus the AG
 # agent-frontmatter series added for issue #132.
 # CM001 is scoped out — reserved, no validator logic (P038 architect spec §9).

--- a/packages/skilllint/tests/test_provider_contracts.py
+++ b/packages/skilllint/tests/test_provider_contracts.py
@@ -100,7 +100,7 @@ class TestRuleAuthority:
         entry = RuleEntry(
             id="TE001",
             severity="error",
-            category="test",
+            category="skill",
             platforms=["agentskills"],
             docstring="Test rule",
             authority=authority,
@@ -117,7 +117,7 @@ class TestRuleAuthority:
         entry = RuleEntry(
             id="TE002",
             severity="warning",
-            category="test",
+            category="skill",
             platforms=["agentskills"],
             docstring="Test rule without authority",
         )
@@ -133,7 +133,7 @@ class TestRuleAuthority:
         @skilllint_rule(
             "TA001",
             severity="error",
-            category="test",
+            category="skill",
             authority={"origin": "test-origin", "reference": "/test/rules/TA001"},
         )
         def test_rule_with_authority(frontmatter: dict) -> list:
@@ -151,7 +151,7 @@ class TestRuleAuthority:
         """skilllint_rule decorator should work without authority kwarg."""
         from skilllint.rule_registry import RULE_REGISTRY
 
-        @skilllint_rule("TN001", severity="info", category="test")
+        @skilllint_rule("TN001", severity="info", category="skill")
         def test_rule_without_authority(frontmatter: dict) -> list:
             """Test rule without authority."""
             return []

--- a/packages/skilllint/tests/test_rule_registry.py
+++ b/packages/skilllint/tests/test_rule_registry.py
@@ -14,7 +14,7 @@ def _entry(rule_id: str, reference: str | None, origin: str = "example.test") ->
     return RuleEntry(
         id=rule_id,
         severity="info",
-        category="test",
+        category="skill",
         platforms=["agentskills"],
         docstring=f"Rule {rule_id}",
         authority=authority,


### PR DESCRIPTION
## Summary

- `RuleEntry.category` (`str`) and `RuleEntry.platforms` (`list[str]`) were stringly-typed, unlike `severity` which already uses `Literal["error", "warning", "info"]`. A typo'd `category=` at registration silently registered a wrong-category rule, and worse, a typo'd `skilllint rules --category` CLI filter silently returned an empty table instead of erroring.
- Added `RuleCategory` and `RulePlatform` `Literal` type aliases to `packages/skilllint/rules/_constants.py`, derived by grepping every one of the 51 `@skilllint_rule(...)` call sites in `packages/skilllint/rules/*_series.py` (13 distinct categories, 4 distinct platform values, including sites that omit `platforms=` and take the decorator's `["agentskills"]` default).
- Wired `RuleEntry.category`/`RuleEntry.platforms` and the `skilllint_rule` decorator's `category`/`platforms` params to these Literals — Pydantic now rejects an unknown category/platform at import time.
- Added CLI validation: `skilllint rules --category <typo>` now raises `typer.BadParameter` listing the valid categories, instead of silently returning zero rows.
- Used `Literal`, not `StrEnum` — zero runtime/import-time cost, consistent with the not-yet-done import-time-cost goal referenced elsewhere in #41.
- Updated three test fixtures (`test_rule_registry.py`, `test_provider_contracts.py`) that used a synthetic `category="test"` value irrelevant to what they exercise — changed to a real category (`"skill"`) since the previous unconstrained `str` type is now gone.

Closes part of #41 (item 3).

## Test plan

- [x] `uv run prek run --all-files` — all hooks pass, including `ty check`
- [x] `uv run pytest` — 1504 passed, 10 skipped
- [x] `uv run skilllint rules --category skil` — now errors with `Invalid category 'skil'. Valid categories: agent, codex, cursor, frontmatter, hook, link, namespace-reference, plugin, plugin-registration, progressive-disclosure, skill, symlink, token-count` (exit 2)
- [x] `uv run skilllint rules --category skill` — still works, prints the filtered rule table (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4
