### PR TITLE
test: measure import-time cost of skilllint.rules (issue #41 item 6)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -322,10 +322,112 @@ jobs:
           path: scripts/results/bench_cpu_base_gh.json
           retention-days: 30
 
+  benchmark-import:
+    name: Import-Time Performance Benchmark
+    runs-on: ubuntu-latest
+    if: github.event_name != 'release'
+    steps:
+      - name: Checkout compare ref
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.compare_ref || github.sha }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          enable-cache: true
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Drop OS page cache (import benchmark)
+        run: echo 3 | sudo tee /proc/sys/vm/drop_caches || true
+
+      - name: Run bench_import for github-action-benchmark output
+        run: |
+          source .venv/bin/activate
+          mkdir -p scripts/results
+          python scripts/bench_import.py --output scripts/results/bench_import_gh.json
+
+      - name: Store import-time benchmark result
+        if: github.ref == 'refs/heads/main'
+        uses: benchmark-action/github-action-benchmark@v1.22.1
+        with:
+          tool: customSmallerIsBetter
+          output-file-path: scripts/results/bench_import_gh.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          alert-threshold: '130%'
+          comment-on-alert: true
+          fail-on-alert: false
+          benchmark-data-dir-path: docs/bench
+
+      - name: Upload import compare benchmark results
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: benchmark-results-import-compare
+          path: scripts/results/bench_import_gh.json
+          retention-days: 30
+
+      - name: Compute base_ref
+        id: base_ref_import
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "ref=${{ github.event.pull_request.base.ref }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.base_ref }}" ]; then
+            echo "ref=${{ inputs.base_ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Preserve bench_import.py before base-ref checkout
+        if: steps.base_ref_import.outputs.ref != ''
+        run: |
+          if [ -f scripts/bench_import.py ]; then
+            cp scripts/bench_import.py /tmp/bench_import.py
+          fi
+
+      - name: Checkout base ref for import comparison
+        if: steps.base_ref_import.outputs.ref != ''
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.base_ref_import.outputs.ref }}
+          fetch-depth: 0
+          clean: false
+
+      - name: Reinstall dependencies for base ref
+        if: steps.base_ref_import.outputs.ref != ''
+        run: uv sync --locked
+
+      - name: Drop OS page cache (base import benchmark)
+        if: steps.base_ref_import.outputs.ref != ''
+        run: echo 3 | sudo tee /proc/sys/vm/drop_caches || true
+
+      - name: Run base import benchmark
+        if: steps.base_ref_import.outputs.ref != ''
+        run: |
+          source .venv/bin/activate
+          BENCH_IMPORT=scripts/bench_import.py
+          if [ ! -f "$BENCH_IMPORT" ]; then
+            BENCH_IMPORT=/tmp/bench_import.py
+          fi
+          python "$BENCH_IMPORT" --output scripts/results/bench_import_base_gh.json
+
+      - name: Upload import base benchmark results
+        if: steps.base_ref_import.outputs.ref != ''
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: benchmark-results-import-base
+          path: scripts/results/bench_import_base_gh.json
+          retention-days: 30
+
   post-pr-comment:
     name: Post Benchmark PR Comment
     runs-on: ubuntu-latest
-    needs: [benchmark-io, benchmark-cpu]
+    needs: [benchmark-io, benchmark-cpu, benchmark-import]
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v7
@@ -354,6 +456,18 @@ jobs:
           name: benchmark-results-cpu-base
           path: scripts/results/base/
 
+      - name: Download import compare results
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: benchmark-results-import-compare
+          path: scripts/results/
+
+      - name: Download import base results
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: benchmark-results-import-base
+          path: scripts/results/base/
+
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
         with:
@@ -371,6 +485,7 @@ jobs:
             --scenario "scan-violations:scripts/results/bench_io_violations_gh.json:scripts/results/base/bench_io_violations_base_gh.json" \
             --scenario "fix-violations:scripts/results/bench_io_fix_gh.json:scripts/results/base/bench_io_fix_base_gh.json" \
             --scenario "cpu:scripts/results/bench_cpu_gh.json:scripts/results/base/bench_cpu_base_gh.json" \
+            --scenario "import:scripts/results/bench_import_gh.json:scripts/results/base/bench_import_base_gh.json" \
             --output /tmp/bench_comment.md \
             --threshold 1.30 \
             --pages-url "https://bitflight-devops.github.io/agentskills-linter/"

--- a/scripts/bench_comment.py
+++ b/scripts/bench_comment.py
@@ -12,6 +12,7 @@ Usage::
       --scenario scan-violations:scripts/results/bench_io_violations_gh.json:scripts/results/bench_io_violations_base_gh.json \\
       --scenario fix-violations:scripts/results/bench_io_fix_gh.json:scripts/results/bench_io_fix_base_gh.json \\
       --scenario cpu:scripts/results/bench_cpu_gh.json:scripts/results/bench_cpu_base_gh.json \\
+      --scenario import:scripts/results/bench_import_gh.json:scripts/results/bench_import_base_gh.json \\
       --output /tmp/bench_comment.md \\
       --threshold 1.30 \\
       --pages-url https://bitflight-devops.github.io/skilllint/
@@ -38,6 +39,12 @@ _SMALLER_IS_BETTER: frozenset[str] = frozenset({
     "cpu_clean_mean_ms",
     "cpu_violations_mean_ms",
     "cpu_fix_mean_ms",
+    "import_package_min_ms",
+    "import_package_mean_ms",
+    "import_package_max_ms",
+    "import_rules_min_ms",
+    "import_rules_mean_ms",
+    "import_rules_max_ms",
 })
 
 # Hidden marker so sticky-pull-request-comment can find and update the comment.

--- a/scripts/bench_import.py
+++ b/scripts/bench_import.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Import-time benchmark for the ``skilllint`` package and its rule registry.
+
+Measures the wall-clock cost of ``import skilllint.rules`` in a fresh
+subprocess. A subprocess is required because Python caches imports after the
+first import in a process, so the cost cannot be measured in-process after
+warmup.
+
+``import skilllint.rules`` is what ``packages/skilllint/plugin_validator.py``
+does eagerly at module load (see the ``import skilllint.rules`` line there)
+so that all 51 ``@skilllint_rule(...)`` decorator calls register into
+``RULE_REGISTRY``. Each call constructs a Pydantic ``RuleEntry`` (and, for
+most rules, a nested ``RuleAuthority``), so this import triggers 51 Pydantic
+validation passes on every ``skilllint`` CLI cold start.
+
+For context/comparison, this script also measures ``import skilllint`` alone.
+``packages/skilllint/__init__.py`` only imports ``skilllint.schemas`` and
+``skilllint.version`` — it does not import ``plugin_validator`` or
+``skilllint.rules`` — so this is a genuinely separate, lighter import path,
+not an artificial split of the same work.
+
+Usage::
+
+    python scripts/bench_import.py
+    python scripts/bench_import.py --output scripts/results/bench_import_gh.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_MODULES: dict[str, str] = {"import_package": "skilllint", "import_rules": "skilllint.rules"}
+
+
+def _run_once(module: str) -> float:
+    """Import *module* in a fresh subprocess and return wall-clock seconds.
+
+    Args:
+        module: Fully-qualified module name to import (e.g. ``"skilllint.rules"``).
+
+    Returns:
+        Elapsed wall-clock time in seconds, as reported by the subprocess.
+
+    Raises:
+        subprocess.CalledProcessError: If the subprocess exits non-zero.
+        ValueError: If the subprocess did not print a parseable float.
+    """
+    code = f"import time; t = time.perf_counter(); import {module}; print(time.perf_counter() - t)"
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True, timeout=30)
+    return float(result.stdout.strip())
+
+
+def run_benchmark(runs: int = 3) -> dict[str, float | int]:
+    """Run the import-time benchmark and return aggregated timing data.
+
+    Args:
+        runs: Number of measurement repetitions per module.
+
+    Returns:
+        Dictionary with ``{label}_min_ms``, ``{label}_mean_ms``, and
+        ``{label}_max_ms`` keys for each module in :data:`_MODULES`, plus
+        ``runs``.
+    """
+    result: dict[str, float | int] = {"runs": runs}
+    for label, module in _MODULES.items():
+        timings = [_run_once(module) * 1000.0 for _ in range(runs)]
+        result[f"{label}_min_ms"] = round(min(timings), 3)
+        result[f"{label}_mean_ms"] = round(sum(timings) / len(timings), 3)
+        result[f"{label}_max_ms"] = round(max(timings), 3)
+    return result
+
+
+def build_gh_benchmark_array(result: dict[str, float | int]) -> list[dict[str, float | str]]:
+    """Build a ``customSmallerIsBetter`` JSON array for github-action-benchmark.
+
+    Args:
+        result: Aggregated timing data returned by :func:`run_benchmark`.
+
+    Returns:
+        List of benchmark entry dicts, each with ``name``, ``value``, and
+        ``unit`` keys, suitable for the ``customSmallerIsBetter`` tool format.
+    """
+    entries: list[dict[str, float | str]] = []
+    for label in _MODULES:
+        for stat in ("min", "mean", "max"):
+            key = f"{label}_{stat}_ms"
+            entries.append({"name": key, "value": float(result[key]), "unit": "ms"})
+    return entries
+
+
+def main() -> None:
+    """Entry point: parse CLI args, run benchmark, print JSON to stdout.
+
+    When ``--output`` is provided, also write the ``customSmallerIsBetter``
+    JSON array to the given file path.
+    """
+    parser = argparse.ArgumentParser(description="Import-time benchmark for skilllint and skilllint.rules")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="Write customSmallerIsBetter JSON array to this file path",
+    )
+    parser.add_argument(
+        "--runs",
+        type=int,
+        default=3,
+        metavar="N",
+        help="Number of subprocess measurement repetitions per module (default: 3)",
+    )
+    args = parser.parse_args()
+    output_path: Path | None = args.output
+
+    result = run_benchmark(runs=args.runs)
+    print(json.dumps(result, indent=2))
+
+    if output_path is not None:
+        gh_array = build_gh_benchmark_array(result)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(gh_array, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_import.py
+++ b/scripts/bench_import.py
@@ -51,7 +51,9 @@ def _run_once(module: str) -> float:
     """
     code = f"import time; t = time.perf_counter(); import {module}; print(time.perf_counter() - t)"
     result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True, timeout=30)
-    return float(result.stdout.strip())
+    # Only the last line is the timing print; anything printed earlier during
+    # import (e.g. a future warning) must not break parsing.
+    return float(result.stdout.strip().splitlines()[-1])
 
 
 def run_benchmark(runs: int = 3) -> dict[str, float | int]:
@@ -114,6 +116,8 @@ def main() -> None:
         help="Number of subprocess measurement repetitions per module (default: 3)",
     )
     args = parser.parse_args()
+    if args.runs < 1:
+        parser.error("--runs must be >= 1")
     output_path: Path | None = args.output
 
     result = run_benchmark(runs=args.runs)

--- a/tests/test_bench_import.py
+++ b/tests/test_bench_import.py
@@ -1,0 +1,37 @@
+"""Tests for scripts/bench_import.py's aggregation and validation logic."""
+
+from __future__ import annotations
+
+import pytest
+from scripts.bench_import import _MODULES, build_gh_benchmark_array, run_benchmark
+
+
+def test_run_benchmark_reports_min_mean_max_for_each_module() -> None:
+    """A single-run benchmark produces min/mean/max/runs keys for every module."""
+    result = run_benchmark(runs=1)
+
+    assert result["runs"] == 1
+    for label in _MODULES:
+        for stat in ("min", "mean", "max"):
+            key = f"{label}_{stat}_ms"
+            assert key in result
+            assert isinstance(result[key], float)
+            assert result[key] >= 0
+
+
+def test_run_benchmark_rejects_zero_runs() -> None:
+    """Zero runs must fail loudly instead of crashing on an empty min()/max()."""
+    with pytest.raises(ValueError, match="empty"):
+        run_benchmark(runs=0)
+
+
+def test_build_gh_benchmark_array_matches_customsmallerisbetter_shape() -> None:
+    """Every entry has the name/value/unit keys github-action-benchmark expects."""
+    result = run_benchmark(runs=1)
+    entries = build_gh_benchmark_array(result)
+
+    assert len(entries) == len(_MODULES) * 3
+    for entry in entries:
+        assert entry.keys() == {"name", "value", "unit"}
+        assert entry["unit"] == "ms"
+        assert isinstance(entry["value"], float)


### PR DESCRIPTION
## What

Measurement only, no migration. Addresses part of #41 (item 6) — the issue's
own research question says "measure before acting" before migrating
`RuleEntry`/`RuleAuthority` in `packages/skilllint/rule_registry.py` from
Pydantic `BaseModel` to `@dataclass(slots=True, frozen=True)`. This PR adds
that measurement; it does not touch `rule_registry.py`, any `*_series.py`
file, or do the dataclass migration.

## What was added

- `scripts/bench_import.py` — measures the wall-clock cost of
  `import skilllint.rules` in a fresh subprocess (subprocess is required
  because Python caches imports after the first import in a process — this
  cannot be measured in-process after warmup). All 51
  `@skilllint_rule(...)` decorator calls across `packages/skilllint/rules/*_series.py`
  construct a Pydantic `RuleEntry` (and ~46 also a nested `RuleAuthority`),
  and `packages/skilllint/plugin_validator.py:56` eagerly does
  `import skilllint.rules` on every CLI cold start.

  For context, the script also measures `import skilllint` alone.
  `packages/skilllint/__init__.py` imports only `skilllint.schemas` and
  `skilllint.version` — not `plugin_validator` or `rules` — so this is a
  genuinely separate, lighter import path, verified by reading the file
  (not an artificial split of the same work).

  Follows `scripts/bench_io.py`'s shape (the existing subprocess-based
  benchmark) since import cost is inherently a subprocess measurement:
  min/mean/max over N runs (default 3), `customSmallerIsBetter` JSON output
  for `github-action-benchmark`. No invented pass/fail threshold — like
  `bench_cpu.py`/`bench_io.py`, this script is pure-reporting.

- `.github/workflows/benchmark.yml` — new `benchmark-import` job mirroring
  the existing `benchmark-cpu` job (base-ref comparison, `github-action-benchmark`
  store step, artifact upload), wired into `post-pr-comment` alongside the
  I/O and CPU scenarios.

- `scripts/bench_comment.py` — registered the six new metric names
  (`import_package_{min,mean,max}_ms`, `import_rules_{min,mean,max}_ms`) in
  `_SMALLER_IS_BETTER` so the PR comment table shows correct
  regression/improvement direction, and added the `import` scenario to the
  usage docstring.

## Measured numbers (local, macOS dev machine — not CI)

```
uv run --script scripts/bench_import.py --runs 5
{
  "runs": 5,
  "import_package_min_ms": 356.227,
  "import_package_mean_ms": 394.164,
  "import_package_max_ms": 442.886,
  "import_rules_min_ms": 762.05,
  "import_rules_mean_ms": 902.642,
  "import_rules_max_ms": 1058.305
}
```

Repeated 3x standalone runs (3 subprocess samples each) ranged
`import_package_min_ms` 306–541ms and `import_rules_min_ms` 568–1113ms,
with meaningful run-to-run variance from this being a shared dev laptop.
Directionally consistent across every run: `import skilllint.rules` costs
roughly **2x** the wall-clock time of `import skilllint` alone — a delta on
the order of 350–500ms locally. That delta covers both the 51 Pydantic
validation passes *and* importing the 15 `*_series.py` module files
themselves (YAML/regex/etc. imports inside them), so it is not a clean
measurement of Pydantic-validation cost alone — it's the total cost
attributable to the `import skilllint.rules` statement.

CI numbers (Linux runner, `uv sync --locked`, no dev-machine contention)
will be more representative once this workflow runs — the `benchmark-import`
job will report them directly, and `bench_comment.py` will surface a
base-vs-compare table on this PR.

## My read (informational, not a decision)

The absolute local numbers (700ms–1s for `import skilllint.rules`) are
large enough on a CLI tool meant for quick `skilllint check` invocations
that they're worth taking seriously, but the migration's actual payoff is
unclear from this measurement alone: the delta includes module-import cost
(the 15 series files themselves) as well as the 51 Pydantic validations, and
Pydantic model construction/validation for ~51 small, statically-known
objects is not typically the dominant cost in that delta — module import
and attribute/class-body execution usually is. Before committing to the
`@dataclass(slots=True, frozen=True)` migration, it would be worth isolating
the Pydantic-validation-only cost (e.g. constructing the 51 `RuleEntry`
instances against an already-imported module, with import time excluded)
rather than assuming the whole delta is attributable to Pydantic. That's a
natural follow-up measurement, not something this PR does.

## Verification

- `uv run prek run --all-files` — all hooks pass
- `uv run pytest` — 1504 passed, 10 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4
