### PR TITLE
fix(PL): point authority origin at code.claude.com instead of a personal repo

### DIFF
--- a/packages/skilllint/rules/pl_series.py
+++ b/packages/skilllint/rules/pl_series.py
@@ -286,7 +286,7 @@ def claude_validation_failure_issue(stdout: str, stderr: str) -> ValidationIssue
     severity="error",
     category="plugin",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
+    authority={"origin": "code.claude.com", "reference": PLUGIN_MANIFEST_SCHEMA_URL},
 )
 def check_pl001(claude_output: str) -> list[ValidationIssue]:
     r"""## PL001 — Missing plugin.json file
@@ -338,7 +338,7 @@ def check_pl001(claude_output: str) -> list[ValidationIssue]:
     severity="error",
     category="plugin",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
+    authority={"origin": "code.claude.com", "reference": PLUGIN_MANIFEST_SCHEMA_URL},
 )
 def check_pl002(plugin_json_path: Path | None = None, claude_output: str = "") -> list[ValidationIssue]:
     """## PL002 — Invalid JSON syntax in plugin.json or marketplace.json
@@ -415,7 +415,7 @@ def check_pl002(plugin_json_path: Path | None = None, claude_output: str = "") -
     severity="error",
     category="plugin",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
+    authority={"origin": "code.claude.com", "reference": PLUGIN_MANIFEST_SCHEMA_URL},
 )
 def check_pl003(claude_output: str) -> list[ValidationIssue]:
     """## PL003 — Missing required field 'name' in plugin.json
@@ -458,7 +458,7 @@ def check_pl003(claude_output: str) -> list[ValidationIssue]:
     severity="error",
     category="plugin",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
+    authority={"origin": "code.claude.com", "reference": PLUGIN_MANIFEST_SCHEMA_URL},
 )
 def check_pl004(claude_output: str) -> list[ValidationIssue]:
     r"""## PL004 — Component path does not start with './'
@@ -501,7 +501,7 @@ def check_pl004(claude_output: str) -> list[ValidationIssue]:
     severity="error",
     category="plugin",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
+    authority={"origin": "code.claude.com", "reference": PLUGIN_MANIFEST_SCHEMA_URL},
 )
 def check_pl005(claude_output: str) -> list[ValidationIssue]:
     """## PL005 — Referenced component file does not exist
@@ -547,7 +547,7 @@ def check_pl005(claude_output: str) -> list[ValidationIssue]:
     severity="error",
     category="plugin",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
+    authority={"origin": "code.claude.com", "reference": MARKETPLACE_MANIFEST_SCHEMA_URL},
 )
 def check_pl006(plugin_dir: Path) -> list[ValidationIssue]:
     """## PL006 — marketplace.json has invalid top-level keys


### PR DESCRIPTION
## Summary

All six `@skilllint_rule` decorators in `packages/skilllint/rules/pl_series.py` registered `authority={"origin": "github.com/jamie-bitflight/claude_skills"}` with no `reference` — a personal repo, not the actual spec source. The module already defines the correct URLs as constants (`PLUGIN_MANIFEST_SCHEMA_URL`, `MARKETPLACE_MANIFEST_SCHEMA_URL`, both `code.claude.com`) and cites them throughout every docstring, message, and suggestion string. Only the decorator arguments were never updated to match.

- PL001–PL005 authority now uses `PLUGIN_MANIFEST_SCHEMA_URL` (`https://code.claude.com/docs/en/plugins-reference.md#plugin-manifest-schema`) — all five rules validate `.claude-plugin/plugin.json` (missing file, invalid JSON, missing `name`, path prefix, referenced-file existence).
- PL006 authority now uses `MARKETPLACE_MANIFEST_SCHEMA_URL` (`https://code.claude.com/docs/en/plugin-marketplaces.md#marketplace-schema`) — it validates `marketplace.json` root keys specifically, and `MARKETPLACE_JSON_ROOT_KEYS` matches that section's documented required/optional field set exactly.

Origin format (hostname as `origin`, full URL as `reference`) follows the existing precedent in `fm_series.py` and `as_series.py`.

Verified this session by fetching both pages fresh via `skilllint docs fetch` (never WebFetch) and confirming:
- `plugins-reference.md#required-fields`: "If you include a manifest, `name` is the only required field." (matches PL003)
- `plugins-reference.md#path-behavior-rules`: "All paths must be relative to the plugin root and start with `./`..." (matches PL004)
- `plugin-marketplaces.md#marketplace-schema`: required `name`/`owner`/`plugins`, optional `$schema`/`description`/`version`/`allowCrossMarketplaceDependenciesOn`/`renames` (`description`/`version` also under `metadata`) — exact match for `MARKETPLACE_JSON_ROOT_KEYS` (matches PL006)

Fixes #40. Partially addresses #152 (authority origin only, not the severity-tunability gap — `_KNOWN_POLICY_RULES` is untouched, out of scope for this PR).

Only the six decorator `authority=` arguments changed — no check logic, docstring prose, or URL constants were touched.

## Test plan

- [x] `uv run prek run --all-files` — all hooks pass (ruff, ruff-format, ty, actionlint, markdownlint, shellcheck, etc.)
- [x] `uv run pytest` — 1504 passed, 10 skipped
- [x] `uv run pytest packages/skilllint/tests/test_provider_validation.py` — 41 passed (authority-resolvability check)
- [x] `uv run skilllint docs fetch-authorities` — both `plugins-reference.md#plugin-manifest-schema` and `plugin-marketplaces.md#marketplace-schema` walked and cached successfully (`FRESH`, already warmed by the pre-write verification fetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4