### PR TITLE
fix(PD001,PD003): cite real agentskills.io spec authority

### DIFF
--- a/packages/skilllint/rules/pd_series.py
+++ b/packages/skilllint/rules/pd_series.py
@@ -37,6 +37,12 @@ if TYPE_CHECKING:
 # Spec sources
 # ---------------------------------------------------------------------------
 
+# PD001 authority: agentskills.io/specification.md, "Optional directories"
+# section. Verified via `skilllint docs fetch` — the cached spec's
+# `references/` subsection states verbatim: "Contains additional
+# documentation that agents can read when needed."
+_PD001_REFERENCES_URL = "https://agentskills.io/specification.md#references"
+
 # PD002 authority: agentskills.io/specification.md, "Progressive disclosure"
 # section. Verified via `skilllint docs fetch` — the cached spec's `assets/`
 # subsection states verbatim: "Contains static resources: Templates ...
@@ -44,6 +50,12 @@ if TYPE_CHECKING:
 # and `assets/` as the three optional subdirectories; it never mentions an
 # `examples/` directory.
 _PD002_ASSETS_URL = "https://agentskills.io/specification.md#assets"
+
+# PD003 authority: agentskills.io/specification.md, "Optional directories"
+# section. Verified via `skilllint docs fetch` — the cached spec's
+# `scripts/` subsection states verbatim: "Contains executable code that
+# agents can run."
+_PD003_SCRIPTS_URL = "https://agentskills.io/specification.md#scripts"
 
 
 def _check_disclosure_dir(path: Path, dir_name: str, code: str) -> list[ValidationIssue]:
@@ -92,7 +104,7 @@ def _check_disclosure_dir(path: Path, dir_name: str, code: str) -> list[Validati
     severity="info",
     category="progressive-disclosure",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
+    authority={"origin": "agentskills.io", "reference": _PD001_REFERENCES_URL},
 )
 def check_pd001(path: Path) -> list[ValidationIssue]:
     """## PD001 — No references/ directory found
@@ -199,7 +211,7 @@ def check_pd002(path: Path) -> list[ValidationIssue]:
     severity="info",
     category="progressive-disclosure",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
+    authority={"origin": "agentskills.io", "reference": _PD003_SCRIPTS_URL},
 )
 def check_pd003(path: Path) -> list[ValidationIssue]:
     """## PD003 — No scripts/ directory found


### PR DESCRIPTION
## Summary

- Replaces the bogus `authority={"origin": "github.com/jamie-bitflight/claude_skills"}` on PD001 and PD003 with real citations to `agentskills.io/specification.md`, verified by fetching the spec via `skilllint docs fetch`.
- PD001 (`references/` directory check) → `https://agentskills.io/specification.md#references`, matching the spec's `references/` subsection: "Contains additional documentation that agents can read when needed."
- PD003 (`scripts/` directory check) → `https://agentskills.io/specification.md#scripts`, matching the spec's `scripts/` subsection: "Contains executable code that agents can run."
- Follows the `_<RULE>_<TOPIC>_URL` constant pattern already used by `nr_series.py` (NR002) and by the sibling PR #196 (PD002).
- Closes the part of #40 left out of #196's scope: #196 fixes PD002 (with a behavior change, checking `assets/` instead of `examples/`); this PR completes PD-series authority coverage by fixing PD001 and PD003 metadata only — no behavior change, no touch to PD002.

## Test plan

- [x] `uv run prek run --all-files` — all hooks pass
- [x] `uv run pytest` — 1504 passed, 10 skipped
- [x] `uv run pytest packages/skilllint/tests/test_provider_validation.py` — 41 passed (authority-resolvability check for the new references passes)
- [x] `uv run skilllint docs fetch-authorities` — both new URLs cache successfully (`FRESH https://agentskills.io/specification.md#references`, `FRESH https://agentskills.io/specification.md#scripts`)

Refs #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4