### PR TITLE
fix(PR001,PR003,TC001): final 3 rules of the #40 authority-origin sweep

### DIFF
--- a/packages/skilllint/rules/pr_series.py
+++ b/packages/skilllint/rules/pr_series.py
@@ -130,7 +130,10 @@ def parse_registered_paths(manifest: dict[str, YamlValue], plugin_dir: Path, fie
     severity="warning",
     category="plugin-registration",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
+    authority={
+        "origin": "code.claude.com",
+        "reference": "https://code.claude.com/docs/en/plugins-reference.md#path-behavior-rules",
+    },
 )
 def check_pr001(manifest: dict[str, YamlValue], plugin_dir: Path) -> list[ValidationIssue]:
     """## PR001 — Capability exists but not explicitly registered
@@ -320,7 +323,10 @@ def check_pr002(manifest: dict[str, YamlValue], plugin_dir: Path) -> list[Valida
     severity="info",
     category="plugin-registration",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
+    authority={
+        "origin": "code.claude.com",
+        "reference": "https://code.claude.com/docs/en/plugins-reference.md#metadata-fields",
+    },
 )
 def check_pr003(manifest: dict[str, YamlValue], git_metadata: dict[str, YamlValue]) -> list[ValidationIssue]:
     """## PR003 — Plugin metadata fields not populated

--- a/packages/skilllint/rules/tc_series.py
+++ b/packages/skilllint/rules/tc_series.py
@@ -74,7 +74,11 @@ def _make_issue(
     severity="info",
     category="token-count",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
+    # No authority: TC001 is a measurement/telemetry rule, not a pass/fail
+    # check. It reports raw tiktoken (cl100k_base) counts with no threshold
+    # comparison and always emits severity="info" — cl100k_base is an OpenAI
+    # tokenizer choice, unrelated to any Claude Code or agentskills.io spec,
+    # so there is no vendor claim here for "authority" to anchor.
 )
 def check_tc001(content: str) -> list[ValidationIssue]:
     """## TC001 — Token count info


### PR DESCRIPTION
## Summary

Closes the last 3 rules of the 23-rule authority-origin cleanup sweep from #40:

- **PR001** (`packages/skilllint/rules/pr_series.py`) — checks that a capability found on disk is explicitly registered in `plugin.json`. Cited to `code.claude.com/docs/en/plugins-reference.md#path-behavior-rules`, which documents exactly this auto-discovery-vs-explicit-registration semantics (verified via `skilllint docs fetch`/`docs section`).
- **PR003** (same file) — checks that `plugin.json`'s `repository`/`homepage`/`author` metadata fields are populated. Cited to `code.claude.com/docs/en/plugins-reference.md#metadata-fields`, which documents these three fields by name and meaning. The rule's info-level "consider populating" nudge is skilllint's own policy layered on a real field definition, same pattern already accepted for PD001/PD003/HK005/PL003.
- **TC001** (`packages/skilllint/rules/tc_series.py`) — reports raw token counts (total/frontmatter/body) via `tiktoken`'s `cl100k_base` encoding, always at `severity="info"`, with no threshold comparison anywhere in the function. Confirmed by reading `check_tc001` directly. There is no vendor spec for `authority` to anchor to, so `authority=` was removed and replaced with an inline "No authority" comment (house style, matching the wording used for other no-authority rules). No `opinion-catalog.json` entry was added — TC001 has no underlying named constant to anchor one to, and the task brief flagged that inventing one (as happened once before for HK004) was reverted as an unjustified constraint.

**PR005 is deliberately excluded** — tracked separately by #195 as a possibly-stale check needing its own investigation. The pre-existing gap where `PluginRegistrationValidator` isn't wired into `_get_validators_for_path` (so PR001/PR003/PR005 don't fire during a normal `skilllint check` run) is unrelated and out of scope for this change.

All three changes are metadata-only (authority citation / comment) — no check logic, severity, or other behavior changed.

## Test plan

- [x] `uv run prek run --all-files` — all hooks pass (ruff, ruff-format, ty, actionlint, markdownlint, shellcheck, ...)
- [x] `uv run pytest` — 1504 passed, 10 skipped
- [x] `uv run pytest packages/skilllint/tests/test_provider_validation.py` — 41 passed (confirms PR001/PR003's new references resolve)
- [x] `uv run skilllint docs fetch-authorities` — both new URLs (`#path-behavior-rules`, `#metadata-fields`) cache successfully (FRESH)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4