### PR TITLE
fix(LK001): resolve skill_dir to absolute before variable substitution

### DIFF
--- a/packages/skilllint/rules/lk_series.py
+++ b/packages/skilllint/rules/lk_series.py
@@ -244,7 +244,14 @@ def check_lk001(content: str, path: Path) -> list[ValidationIssue]:
     <!-- examples: LK001 -->
     """
     issues: list[ValidationIssue] = []
-    skill_dir = path.parent
+    # Resolve to absolute up front: callers (pre-commit, in particular) pass
+    # relative paths, and every downstream use of skill_dir -- the
+    # ${CLAUDE_SKILL_DIR} substitution, the find_plugin_dir() walk behind
+    # ${CLAUDE_PLUGIN_ROOT}, and the final join below -- must operate on an
+    # absolute base or a relative substituted path (e.g. "plugins/foo/README.md")
+    # gets appended onto skill_dir instead of replacing it (Path.__truediv__
+    # only discards the left operand when the right operand is absolute).
+    skill_dir = path.parent.resolve()
 
     for link_text, link_url, link_url_no_fragment in _iter_links(content):
         # Resolve documented ${CLAUDE_*} substitution variables before the

--- a/packages/skilllint/tests/test_internal_link_validator.py
+++ b/packages/skilllint/tests/test_internal_link_validator.py
@@ -529,6 +529,46 @@ See [foo](${CLAUDE_PLUGIN_ROOT}/docs/foo.md) for details.
         assert result.passed is True
         assert not any(issue.code == "LK001" for issue in result.errors)
 
+    def test_claude_plugin_root_resolves_with_relative_invocation_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """${CLAUDE_PLUGIN_ROOT} must resolve correctly even when SKILL.md is
+        passed as a path relative to cwd (as pre-commit always invokes hooks).
+
+        Regression test for a real-world false positive: ``skill_dir =
+        path.parent`` stayed relative, so substituting a relative
+        ``plugin_root`` into the link and then joining it onto the
+        already-relative ``skill_dir`` *extended* the path instead of
+        replacing it (``Path.__truediv__`` only discards the left operand
+        when the right operand is absolute).
+        """
+        plugin_dir = tmp_path / "my-plugin"
+        claude_plugin_dir = plugin_dir / ".claude-plugin"
+        claude_plugin_dir.mkdir(parents=True)
+        (claude_plugin_dir / "plugin.json").write_text('{"name": "my-plugin"}', encoding="utf-8")
+
+        (plugin_dir / "README.md").write_text("# Plugin\n")
+
+        skill_dir = plugin_dir / "skills" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text("""---
+description: Test skill
+---
+
+See [readme](${CLAUDE_PLUGIN_ROOT}/README.md) for details.
+""")
+
+        monkeypatch.chdir(tmp_path)
+        relative_skill_md = skill_md.relative_to(tmp_path)
+        assert not relative_skill_md.is_absolute()
+
+        validator = InternalLinkValidator()
+        result = validator.validate(relative_skill_md)
+
+        assert result.passed is True
+        assert not any(issue.code == "LK001" for issue in result.errors)
+
     def test_claude_plugin_root_skipped_when_no_plugin_json_found(self, tmp_path: Path) -> None:
         """${CLAUDE_PLUGIN_ROOT} is skipped (not reported broken) when no
         plugin.json exists anywhere above the skill -- skilllint has no basis


### PR DESCRIPTION
## Summary

Fixes an LK001 false positive reported by another Claude Code session (and independently reproduced) against skilllint 1.17.4: a valid `${CLAUDE_PLUGIN_ROOT}`/`${CLAUDE_SKILL_DIR}` markdown link is flagged as broken whenever `SKILL.md` is validated via a path relative to cwd — which is always the case under pre-commit, since pre-commit passes hooks relative paths.

## Root cause

In `packages/skilllint/rules/lk_series.py`, `check_lk001` set `skill_dir = path.parent` without resolving it. When `skill_dir` is relative:

- `_resolve_claude_variables` substitutes `str(skill_dir)` for `${CLAUDE_SKILL_DIR}` — relative.
- It also substitutes `str(find_plugin_dir(skill_dir))` for `${CLAUDE_PLUGIN_ROOT}` — also relative, since `find_plugin_dir` walks parents of whatever path it's given without resolving.
- The final join, `(skill_dir / resolved_url).resolve()`, then combines two relative paths. Because the substituted `resolved_url` is itself a relative path fragment (e.g. `plugins/foo/README.md`) rather than an absolute one, `Path.__truediv__` doesn't replace `skill_dir` — it *appends* onto it, producing something like `.../skills/skilllint/plugins/foo/README.md` instead of `.../plugins/foo/README.md`. The trailing `.resolve()` only makes the wrong path absolute; it can't undo the bad join since it runs after it.

## Fix

One-line change: `skill_dir = path.parent.resolve()`. This fixes all three downstream consumers (the `${CLAUDE_SKILL_DIR}` substitution, the `find_plugin_dir` walk behind `${CLAUDE_PLUGIN_ROOT}`, and the final join) from a single source of truth, rather than patching each substitution site individually as a peer session's alternative fix proposed. Per this repo's AGENTS.md diagnostic-discipline rule ("smallest diff that addresses the observed failure"), the upstream one-line fix was preferred over the two-site patch after tracing the full call chain confirmed it covers every consumer.

## Symlink interaction

`.resolve()` follows symlinks, and the join already called `.resolve()` on the final path (just too late to matter for this bug). Moving the resolve to `skill_dir` earlier doesn't change symlink semantics: for ordinary relative links, resolving the base first vs. resolving the full joined path afterward is equivalent. For the `${CLAUDE_PLUGIN_ROOT}` case, `find_plugin_dir` now walks an already-resolved (symlink-following) directory tree, which is strictly more correct than before (previously it could walk a relative, non-symlink-resolved tree).

There is no dedicated SL001/symlink test file in this repo (confirmed via search — `find`/`grep` turned up no `test_sl_series.py` or similar). The closest existing coverage is `test_destroyed_symlink_plain_file_passes` in `packages/skilllint/tests/test_internal_link_validator.py`, which still passes.

## Verification

- Wrote a regression test, `test_claude_plugin_root_resolves_with_relative_invocation_path`, in `packages/skilllint/tests/test_internal_link_validator.py` (confirmed this is the correct/existing home for LK001 tests).
- **Before the fix**: ran the new test against the unfixed code — it failed as expected:
  ```
  FAILED ...test_claude_plugin_root_resolves_with_relative_invocation_path - AssertionError: assert False is True
   +  where False = ValidationResult(..., errors=[ValidationIssue(..., message='Broken link: [readme](${CLAUDE_PLUGIN_ROOT}/README.md) (file not found)', code='LK001', ...)], ...).passed
  ```
- **After the fix**: same test passes, along with the rest of `test_internal_link_validator.py` (30 passed).
- Confirmed all *existing* LK001 tests use pytest's `tmp_path` fixture, which is always absolute — the bug shipped silently because coverage was absolute-path-only before this PR.
- `uv run prek run --all-files` — all hooks pass (ruff, ruff-format, ty, actionlint, markdownlint, shellcheck, etc.).
- `uv run pytest` — full suite green: 1519 passed, 10 skipped, 86.40% coverage.

## Test plan

- [x] New regression test fails on unfixed code, passes after the fix
- [x] Full `test_internal_link_validator.py` suite passes (30/30)
- [x] `uv run prek run --all-files` fully green
- [x] `uv run pytest` fully green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4