### PR TITLE
fix(scan): discover skills under known provider dirs (.claude/skills etc.)

### DIFF
--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -57,6 +57,14 @@ class ScanContext(StrEnum):
 
 KNOWN_PROVIDER_DIRS: frozenset[str] = frozenset({".claude", ".cursor", ".gemini", ".codex"})
 
+# Directory names skilllint never scans into during discovery. `.git` and
+# `node_modules` are the client-implementation guide's explicit recommendation
+# (agentskills.io/client-implementation/adding-skills-support); `.venv` is the
+# same class of irrelevant/vendored tree and is not reliably covered by the
+# separate gitignore-based filter in run_validation_loop (that filter only
+# applies when a git repo is present at all).
+EXCLUDED_DIR_NAMES: frozenset[str] = frozenset({".git", "node_modules", ".venv"})
+
 PLUGIN_FILTER_TYPE_MAP: dict[str, str] = {
     "skills": "skills/*/SKILL.md",
     "agents": "agents/*.md",
@@ -220,13 +228,28 @@ def _is_skill_folder(path: Path) -> bool:
     return path.is_dir() and (path / "SKILL.md").is_file()
 
 
+def _is_within_excluded_dir(path: Path) -> bool:
+    """Return whether any component of *path* is a directory skilllint skips."""
+    return any(part in EXCLUDED_DIR_NAMES for part in path.parts)
+
+
+def _glob_excluding(directory: Path, pattern: str) -> list[Path]:
+    """Glob *pattern* under *directory*, dropping matches under excluded dirs.
+
+    Returns:
+        Matching paths, excluding any under a directory named in EXCLUDED_DIR_NAMES.
+    """
+    return [p for p in directory.glob(pattern) if not _is_within_excluded_dir(p)]
+
+
 def _discover_provider_paths(directory: Path) -> list[Path]:
     """Discover validatable files in a provider directory.
 
-    Uses the provider's known agent location pattern:
+    Uses the provider's known locations:
         {directory}/agents/**/*.md
+        {directory}/skills/*/SKILL.md
 
-    No other files in the provider tree are discovered as agents.
+    No other files in the provider tree are discovered as agents or skills.
 
     Args:
         directory: The provider directory (e.g., .claude/).
@@ -234,7 +257,9 @@ def _discover_provider_paths(directory: Path) -> list[Path]:
     Returns:
         Sorted list of unique paths.
     """
-    return sorted(set(directory.glob("agents/**/*.md")))
+    discovered: set[Path] = set(_glob_excluding(directory, "agents/**/*.md"))
+    discovered.update(path.parent for path in _glob_excluding(directory, "skills/*/SKILL.md"))
+    return sorted(discovered)
 
 
 def _discover_bare_paths(directory: Path) -> list[Path]:
@@ -245,14 +270,14 @@ def _discover_bare_paths(directory: Path) -> list[Path]:
     """
     discovered: set[Path] = set()
     plugin_roots: set[Path] = set()
-    for plugin_json in directory.glob("**/.claude-plugin/plugin.json"):
+    for plugin_json in _glob_excluding(directory, "**/.claude-plugin/plugin.json"):
         plugin_root = plugin_json.parent.parent
         plugin_roots.add(plugin_root)
         discovered.update(_discover_plugin_paths(_parse_plugin_manifest(plugin_root)))
 
     provider_roots: set[Path] = set()
     for provider_name in KNOWN_PROVIDER_DIRS:
-        for provider_dir in directory.glob(f"**/{provider_name}"):
+        for provider_dir in _glob_excluding(directory, f"**/{provider_name}"):
             if not provider_dir.is_dir() or any(provider_dir.is_relative_to(root) for root in plugin_roots):
                 continue
             provider_roots.add(provider_dir)
@@ -260,7 +285,7 @@ def _discover_bare_paths(directory: Path) -> list[Path]:
 
     covered_roots = plugin_roots | provider_roots
     for pattern in DEFAULT_SCAN_PATTERNS:
-        for match in directory.glob(pattern):
+        for match in _glob_excluding(directory, pattern):
             if pattern.endswith("plugin.json"):
                 candidate = match.parent.parent
             elif pattern.endswith("skills/*/SKILL.md"):

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -228,18 +228,30 @@ def _is_skill_folder(path: Path) -> bool:
     return path.is_dir() and (path / "SKILL.md").is_file()
 
 
-def _is_within_excluded_dir(path: Path) -> bool:
-    """Return whether any component of *path* is a directory skilllint skips."""
-    return any(part in EXCLUDED_DIR_NAMES for part in path.parts)
+def _is_within_excluded_dir(relative_path: Path) -> bool:
+    """Return whether any component of *relative_path* is a directory skilllint skips.
+
+    ``relative_path`` must already be relative to the directory being walked —
+    checking components of an absolute/raw path would also match ancestor
+    segments belonging to the scan root itself (e.g. a target explicitly
+    named ``node_modules/my-plugin``), which is not what EXCLUDED_DIR_NAMES
+    is for: it exists to avoid walking *into* a vendored tree during
+    discovery, not to second-guess an explicitly named target.
+    """
+    return any(part in EXCLUDED_DIR_NAMES for part in relative_path.parts)
 
 
 def _glob_excluding(directory: Path, pattern: str) -> list[Path]:
     """Glob *pattern* under *directory*, dropping matches under excluded dirs.
 
+    Only path components discovered beneath *directory* are checked against
+    EXCLUDED_DIR_NAMES, so an excluded name in the scan root's own ancestry
+    does not suppress results.
+
     Returns:
         Matching paths, excluding any under a directory named in EXCLUDED_DIR_NAMES.
     """
-    return [p for p in directory.glob(pattern) if not _is_within_excluded_dir(p)]
+    return [p for p in directory.glob(pattern) if not _is_within_excluded_dir(p.relative_to(directory))]
 
 
 def _discover_provider_paths(directory: Path) -> list[Path]:

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -201,6 +201,26 @@ class TestDiscoverValidatablePaths:
 
         assert skill_dir not in discovered, f"Did not expect {skill_dir} in discovered paths: {discovered}"
 
+    def test_scan_root_own_ancestry_named_node_modules_is_not_excluded(self, tmp_path: Path) -> None:
+        """A scan target whose OWN path contains 'node_modules' still discovers its skills.
+
+        Tests: _glob_excluding/_is_within_excluded_dir only test path components
+               discovered *beneath* the scanned directory, not the scan root's
+               own ancestor segments.
+        How: Scan a directory literally named .../node_modules/my-plugin (e.g. a
+             real npm-installed plugin) and confirm a skill inside it is found.
+        Why: Regression for a false negative where naming a real target whose
+             path happens to contain an excluded segment silently returned [].
+        """
+        root = tmp_path / "node_modules" / "my-plugin"
+        skill_dir = root / "skills" / "x"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: Test\n---\n# Test\n")
+
+        discovered = _discover_validatable_paths(root)
+
+        assert discovered == [skill_dir], f"Expected the skill to be discovered: {discovered}"
+
     def test_direct_skill_folder_is_one_target(self, tmp_path: Path) -> None:
         skill_dir = tmp_path / "my-skill"
         skill_dir.mkdir()

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -129,6 +129,78 @@ class TestDiscoverValidatablePaths:
         discovered = _discover_validatable_paths(tmp_path)
         assert discovered == []
 
+    def test_discovers_provider_skills(self, tmp_path: Path) -> None:
+        """_discover_validatable_paths finds skills under a provider's skills/ dir.
+
+        Tests: {provider}/skills/*/SKILL.md is discovered the same way
+               {provider}/agents/*.md already is.
+        How: Create .claude/skills/my-skill/SKILL.md under a bare scan root
+             and verify the skill folder is discovered.
+        Why: Regression for the bug where .claude/skills/ (and other known
+             provider dirs) were never scanned — only {provider}/agents/ was.
+        """
+        skill_dir = tmp_path / ".claude" / "skills" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: Test\n---\n# Test\n")
+
+        discovered = _discover_validatable_paths(tmp_path)
+
+        assert skill_dir in discovered, f"Expected {skill_dir} in discovered paths: {discovered}"
+
+    def test_provider_skill_not_double_counted(self, tmp_path: Path) -> None:
+        """A skill reachable via the provider path and the generic bare pattern appears once.
+
+        Tests: _discover_bare_paths's covered_roots exclusion still holds once
+               _discover_provider_paths also globs skills/*/SKILL.md.
+        How: Create .claude/skills/my-skill/SKILL.md, which is matched both by
+             _discover_provider_paths(.claude) and by the generic
+             '**/skills/*/SKILL.md' DEFAULT_SCAN_PATTERNS entry.
+        Why: Guards against silently duplicating results in FileResults/reports.
+        """
+        skill_dir = tmp_path / ".claude" / "skills" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: Test\n---\n# Test\n")
+
+        discovered = _discover_validatable_paths(tmp_path)
+
+        assert discovered.count(skill_dir) == 1, f"Expected exactly one occurrence: {discovered}"
+
+    def test_excludes_git_directory(self, tmp_path: Path) -> None:
+        """A skill under .git/ is never discovered.
+
+        Tests: EXCLUDED_DIR_NAMES filtering during the discovery glob walk
+        How: Place a SKILL.md inside a nested .git directory and verify absence
+        Why: .git/ is explicitly called out by the client-implementation guide
+             as a tree that must never be scanned into.
+        """
+        skill_dir = tmp_path / ".git" / "skills" / "vendored-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: Test\n---\n# Test\n")
+
+        discovered = _discover_validatable_paths(tmp_path)
+
+        assert skill_dir not in discovered, f"Did not expect {skill_dir} in discovered paths: {discovered}"
+
+    def test_excludes_node_modules_directory(self, tmp_path: Path) -> None:
+        """A skill under node_modules/ is never discovered."""
+        skill_dir = tmp_path / "node_modules" / "some-pkg" / "skills" / "vendored-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: Test\n---\n# Test\n")
+
+        discovered = _discover_validatable_paths(tmp_path)
+
+        assert skill_dir not in discovered, f"Did not expect {skill_dir} in discovered paths: {discovered}"
+
+    def test_excludes_venv_directory(self, tmp_path: Path) -> None:
+        """A skill vendored inside a .venv/ site-packages tree is never discovered."""
+        skill_dir = tmp_path / ".venv" / "lib" / "site-packages" / "somepkg" / ".agents" / "skills" / "somepkg"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: Test\n---\n# Test\n")
+
+        discovered = _discover_validatable_paths(tmp_path)
+
+        assert skill_dir not in discovered, f"Did not expect {skill_dir} in discovered paths: {discovered}"
+
     def test_direct_skill_folder_is_one_target(self, tmp_path: Path) -> None:
         skill_dir = tmp_path / "my-skill"
         skill_dir.mkdir()


### PR DESCRIPTION
## Bug

`skilllint check` never discovered skills under a known provider directory's `skills/` subtree — e.g. `.claude/skills/x/SKILL.md`, `.cursor/skills/x/SKILL.md`. This is a silent false negative: the tool reports clean while never actually validating those files, across every rule series (FM, AG, SK, ...).

Root cause, in `packages/skilllint/scan_runtime.py`:

- `_discover_provider_paths(directory)` only globbed `{directory}/agents/**/*.md` — it never looked at `{directory}/skills/`.
- `_discover_bare_paths` computes generic patterns from `DEFAULT_SCAN_PATTERNS` (which does include `**/skills/*/SKILL.md`), but discards any match falling under a directory already recognized as a "covered" provider root (e.g. `.claude`) — so a match like `.claude/skills/foo/SKILL.md` was found by the generic glob and then thrown away, on the assumption the provider-specific discovery already handled it. It didn't.

This repo's own `.claude/skills/` (`linear-walkthrough`, `mmap-processor`, `rebase`, `receiving-pr-reviews`) was a live instance of the bug: `uv run skilllint check .` reported clean on a project whose primary skill directory was entirely unvalidated.

## Fix

- `_discover_provider_paths` now also globs `{directory}/skills/*/SKILL.md` (folder-backed, one level deep — same convention used elsewhere for skills), mirroring how `agents/` is already discovered.
- The existing `covered_roots` dedup in `_discover_bare_paths` already prevents double-counting once a skill is reachable via both the provider path and the generic bare pattern; added a regression test (`test_provider_skill_not_double_counted`) asserting a single occurrence.
- Added a by-name exclusion (`.git`, `node_modules`, `.venv`) applied to every discovery glob via a new `_glob_excluding` helper:
  - `.git/` is **not** covered by the existing gitignore-based filter in `run_validation_loop` — verified with `git check-ignore`, which does not match `.git/` paths (no `.gitignore` entry declares `.git` itself; git excludes it as a special directory, not via ignore rules).
  - `.venv/` and `node_modules/` are typically covered by this repo's `.gitignore`, but that filter only runs downstream in `run_validation_loop` and requires a git repo to exist at all — a non-git checkout (e.g. an extracted plugin zip) gets no protection from it. The by-name exclusion in the discovery walk is the one mechanism that also covers that case, and matches the [agentskills.io client-implementation guide's](https://agentskills.io/client-implementation/adding-skills-support.md) explicit recommendation to skip `.git/` and `node_modules/` by name (`.venv/` is the same class of vendored/irrelevant tree).
  - No numeric depth/directory-count cap was added — the guide presents that as an example bound for a from-scratch implementation, not a documented requirement, and this repo's `AGENTS.md` prohibits unsourced numeric constraints.

## Verification

```sh
uv run prek run --all-files   # all hooks green
uv run pytest                 # 1523 passed, 10 skipped, coverage gate met (86.42%)
```

New tests in `packages/skilllint/tests/test_scan_runtime.py`:
- `test_discovers_provider_skills` — `.claude/skills/x/SKILL.md` is discovered
- `test_provider_skill_not_double_counted` — a skill reachable via both the provider path and the generic bare pattern appears exactly once
- `test_excludes_git_directory`, `test_excludes_node_modules_directory`, `test_excludes_venv_directory` — skills under these trees are never discovered

Dogfooding, before/after `git stash` on `scan_runtime.py` (same working tree, same `skilllint check . --show-summary`):

| | Total files | Passed |
|---|---|---|
| Before fix | 72 | 62 |
| After fix | 76 | 66 |

The delta is exactly the four `.claude/skills/` skills in this repo, all validating clean (no findings surfaced on them) — confirming discovery now works without introducing new violations. Fixing any findings on those skills is out of scope for this PR.

Also confirmed directly: `.venv/lib/python3.14/site-packages/typer/.agents/skills/typer` (a vendored dependency's bundled skill) and any `.git/` paths are no longer returned by `_discover_validatable_paths`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4