### PR TITLE
fix(SK004,SK005): suppress description-quality checks when model invocation is disabled

### DIFF
--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -2578,18 +2578,30 @@ class DescriptionValidator:
         if description is None or not isinstance(description, str):
             return ValidationResult(passed=True, errors=errors, warnings=warnings, info=info)
 
-        self._check_description_quality(description, warnings)
+        self._check_description_quality(data, description, warnings)
         return ValidationResult(passed=len(errors) == 0, errors=errors, warnings=warnings, info=info)
 
-    def _check_description_quality(self, description: str, warnings: list[ValidationIssue]) -> None:
+    def _check_description_quality(
+        self, data: dict[str, YamlValue], description: str, warnings: list[ValidationIssue]
+    ) -> None:
         """Append warnings for description length and trigger phrases.
 
         Delegates to sk_series check_sk004/check_sk005 — the series module is
         the single source of truth for SK-series rule logic.
+
+        Args:
+            data: Full parsed frontmatter dict, needed so sk_series can read
+                `disable-model-invocation` and suppress both checks when a
+                skill has opted out of model-driven activation.
+            description: The frontmatter `description` value.
+            warnings: Mutable list to append warnings to.
         """
         from pathlib import Path as _Path  # ruff: ignore[import-outside-top-level]
 
-        frontmatter: dict[str, object] = {"description": description}
+        frontmatter: dict[str, object] = {
+            "description": description,
+            "disable-model-invocation": data.get("disable-model-invocation"),
+        }
         sentinel = _Path()
         file_type_str = self.file_type.value
         # Coerce through _coerce_validation_issues so that ValidationIssue

--- a/packages/skilllint/rules/sk_series.py
+++ b/packages/skilllint/rules/sk_series.py
@@ -91,11 +91,15 @@ def check_sk004(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     if file_type not in {"skill", "agent"}:
         return []
 
-    if frontmatter.get("disable-model-invocation"):
+    if file_type == "skill" and frontmatter.get("disable-model-invocation") is True:
         # Model-driven activation is opted out (client-implementation guide:
         # a `disable-model-invocation: true` skill is hidden from the catalog
         # and never model-selected), so description-quality lint opinions
-        # aimed at activation matching no longer apply.
+        # aimed at activation matching no longer apply. `disable-model-invocation`
+        # is a SkillFrontmatter-only field (frontmatter_core.py has no such
+        # field on AgentFrontmatter), so this only applies to file_type=="skill".
+        # `is True` (not truthy) so a malformed non-bool value (e.g. a quoted
+        # YAML string "false") never masks a real SK004 warning.
         return []
 
     desc_val = frontmatter.get("description")
@@ -195,10 +199,12 @@ def check_sk005(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     if file_type != "skill":
         return []
 
-    if frontmatter.get("disable-model-invocation"):
+    if frontmatter.get("disable-model-invocation") is True:
         # Model-driven activation is opted out; trigger-phrase quality in
         # the description is irrelevant for a skill that is never
-        # model-selected.
+        # model-selected. `is True` (not truthy) so a malformed non-bool
+        # value (e.g. a quoted YAML string "false") never masks a real
+        # SK005 warning.
         return []
 
     desc_val = frontmatter.get("description")

--- a/packages/skilllint/rules/sk_series.py
+++ b/packages/skilllint/rules/sk_series.py
@@ -91,6 +91,13 @@ def check_sk004(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     if file_type not in {"skill", "agent"}:
         return []
 
+    if frontmatter.get("disable-model-invocation"):
+        # Model-driven activation is opted out (client-implementation guide:
+        # a `disable-model-invocation: true` skill is hidden from the catalog
+        # and never model-selected), so description-quality lint opinions
+        # aimed at activation matching no longer apply.
+        return []
+
     desc_val = frontmatter.get("description")
     if not isinstance(desc_val, str):
         return []
@@ -186,6 +193,12 @@ def check_sk005(frontmatter: dict[str, object], path: Path, file_type: str) -> l
     from skilllint.plugin_validator import ValidationIssue  # noqa: PLC0415
 
     if file_type != "skill":
+        return []
+
+    if frontmatter.get("disable-model-invocation"):
+        # Model-driven activation is opted out; trigger-phrase quality in
+        # the description is irrelevant for a skill that is never
+        # model-selected.
         return []
 
     desc_val = frontmatter.get("description")

--- a/packages/skilllint/tests/test_description_validator.py
+++ b/packages/skilllint/tests/test_description_validator.py
@@ -509,6 +509,16 @@ description: "test skill"
         assert "SK004" in warning_codes
         assert "SK005" in warning_codes
 
+    def test_cm001_error_code_is_defined(self) -> None:
+        """Test CM001 error code constant is exported from plugin_validator.
+
+        Tests: CM001 stub defined for command-specific description checks
+        How: Import CM001 from plugin_validator, verify it is a non-empty string
+        Why: CM001 is reserved for future command-specific validation rules;
+             its presence confirms the error code namespace is correctly established
+        """
+        assert CM001 == "CM001", f"CM001 constant must equal 'CM001', got {CM001!r}"
+
 
 class TestDisableModelInvocationSuppression:
     """Test SK004/SK005 are suppressed when disable-model-invocation is set.
@@ -588,13 +598,3 @@ disable-model-invocation: false
         warning_codes = {issue.code for issue in result.warnings}
         assert "SK004" in warning_codes
         assert "SK005" in warning_codes
-
-    def test_cm001_error_code_is_defined(self) -> None:
-        """Test CM001 error code constant is exported from plugin_validator.
-
-        Tests: CM001 stub defined for command-specific description checks
-        How: Import CM001 from plugin_validator, verify it is a non-empty string
-        Why: CM001 is reserved for future command-specific validation rules;
-             its presence confirms the error code namespace is correctly established
-        """
-        assert CM001 == "CM001", f"CM001 constant must equal 'CM001', got {CM001!r}"

--- a/packages/skilllint/tests/test_description_validator.py
+++ b/packages/skilllint/tests/test_description_validator.py
@@ -509,6 +509,86 @@ description: "test skill"
         assert "SK004" in warning_codes
         assert "SK005" in warning_codes
 
+
+class TestDisableModelInvocationSuppression:
+    """Test SK004/SK005 are suppressed when disable-model-invocation is set.
+
+    Per the client-implementation guide, a skill with
+    `disable-model-invocation: true` is hidden from the catalog and never
+    model-selected, so description length (SK004) and trigger-phrase
+    quality (SK005) — both aimed at model-driven activation — no longer
+    apply.
+    """
+
+    def test_short_no_trigger_description_suppressed_when_disabled(self, tmp_path: Path) -> None:
+        """Test SK004 and SK005 do not fire when disable-model-invocation is true.
+
+        Tests: A short, trigger-phrase-free description on an opted-out skill
+        How: Validate a SKILL.md with disable-model-invocation: true
+        Why: Model-driven activation quality lint opinions are moot for a
+             skill that is never model-selected
+        """
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text("""---
+description: "test skill"
+disable-model-invocation: true
+---
+""")
+
+        validator = DescriptionValidator(file_type=FileType.SKILL)
+        result = validator.validate(skill_md)
+
+        assert result.passed is True
+        warning_codes = {issue.code for issue in result.warnings}
+        assert "SK004" not in warning_codes
+        assert "SK005" not in warning_codes
+
+    def test_same_description_still_warns_when_flag_absent(self, tmp_path: Path) -> None:
+        """Test SK004 and SK005 still fire for the same description without the flag.
+
+        Tests: Same short, trigger-phrase-free description with no
+               disable-model-invocation key present
+        How: Validate a SKILL.md lacking the flag entirely
+        Why: Proves the gate keys off disable-model-invocation specifically,
+             not that the checks were broken outright
+        """
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text("""---
+description: "test skill"
+---
+""")
+
+        validator = DescriptionValidator(file_type=FileType.SKILL)
+        result = validator.validate(skill_md)
+
+        assert result.passed is True
+        warning_codes = {issue.code for issue in result.warnings}
+        assert "SK004" in warning_codes
+        assert "SK005" in warning_codes
+
+    def test_same_description_still_warns_when_flag_false(self, tmp_path: Path) -> None:
+        """Test SK004 and SK005 still fire when disable-model-invocation is false.
+
+        Tests: Same short, trigger-phrase-free description with the flag
+               explicitly set to false
+        How: Validate a SKILL.md with disable-model-invocation: false
+        Why: Only a truthy flag should suppress the checks
+        """
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text("""---
+description: "test skill"
+disable-model-invocation: false
+---
+""")
+
+        validator = DescriptionValidator(file_type=FileType.SKILL)
+        result = validator.validate(skill_md)
+
+        assert result.passed is True
+        warning_codes = {issue.code for issue in result.warnings}
+        assert "SK004" in warning_codes
+        assert "SK005" in warning_codes
+
     def test_cm001_error_code_is_defined(self) -> None:
         """Test CM001 error code constant is exported from plugin_validator.
 

--- a/packages/skilllint/tests/test_description_validator.py
+++ b/packages/skilllint/tests/test_description_validator.py
@@ -582,7 +582,7 @@ description: "test skill"
         Tests: Same short, trigger-phrase-free description with the flag
                explicitly set to false
         How: Validate a SKILL.md with disable-model-invocation: false
-        Why: Only a truthy flag should suppress the checks
+        Why: Only a real `True` boolean should suppress the checks
         """
         skill_md = tmp_path / "SKILL.md"
         skill_md.write_text("""---
@@ -598,3 +598,51 @@ disable-model-invocation: false
         warning_codes = {issue.code for issue in result.warnings}
         assert "SK004" in warning_codes
         assert "SK005" in warning_codes
+
+    def test_same_description_still_warns_when_flag_is_quoted_false_string(self, tmp_path: Path) -> None:
+        """Test SK004 and SK005 still fire when disable-model-invocation is the string "false".
+
+        Tests: Same short, trigger-phrase-free description with the flag
+               written as a quoted YAML string "false" rather than a boolean
+        How: Validate a SKILL.md with disable-model-invocation: "false"
+        Why: A non-empty string is truthy in Python — a raw `if frontmatter.get(...)`
+             check would wrongly suppress the checks for a quoted "false";
+             gating on `is True` avoids that
+        """
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text("""---
+description: "test skill"
+disable-model-invocation: "false"
+---
+""")
+
+        validator = DescriptionValidator(file_type=FileType.SKILL)
+        result = validator.validate(skill_md)
+
+        assert result.passed is True
+        warning_codes = {issue.code for issue in result.warnings}
+        assert "SK004" in warning_codes
+        assert "SK005" in warning_codes
+
+    def test_short_description_still_warns_for_agent_with_disable_flag(self, tmp_path: Path) -> None:
+        """Test SK004 still fires for an AGENT file with disable-model-invocation set.
+
+        Tests: A short description on an agent file that carries a
+               disable-model-invocation key (not a real AgentFrontmatter field)
+        How: Validate an agent .md with disable-model-invocation: true
+        Why: disable-model-invocation is a SkillFrontmatter-only concept;
+             an agent file setting it should not mask SK004
+        """
+        agent_md = tmp_path / "agent.md"
+        agent_md.write_text("""---
+description: "test agent"
+disable-model-invocation: true
+---
+""")
+
+        validator = DescriptionValidator(file_type=FileType.AGENT)
+        result = validator.validate(agent_md)
+
+        assert result.passed is True
+        warning_codes = {issue.code for issue in result.warnings}
+        assert "SK004" in warning_codes


### PR DESCRIPTION
## Summary

- A skill with `disable-model-invocation: true` is hidden from the catalog and never model-selected, so its `description` field never drives activation matching (per the client-implementation guide already cached at `.claude/vendor/sources/client-implementation--adding-skills-support-2026-09-06-0309.md`).
- SK004 (description minimum length) and SK005 (description missing trigger phrases) both exist purely to improve model-driven activation quality, so both are now suppressed when `disable-model-invocation` is truthy in frontmatter.
- Gate added in `packages/skilllint/rules/sk_series.py` `check_sk004`/`check_sk005`, keyed off the raw `disable-model-invocation` frontmatter dict key (the YAML alias, confirmed against `SkillFrontmatter.disable_model_invocation` in `frontmatter_core.py:128`).
- Also fixes the sole real call site (`DescriptionValidator._check_description_quality` in `packages/skilllint/plugin_validator.py`), which previously narrowed the frontmatter dict passed into these checks down to `{"description": ...}` only — the new gate would never have seen the flag without threading the full parsed frontmatter dict through.

## Test plan

- [x] Added `TestDisableModelInvocationSuppression` to `packages/skilllint/tests/test_description_validator.py` (the existing test file covering `DescriptionValidator`/SK004/SK005 — no `test_sk_series.py` file exists in the repo):
  - `disable-model-invocation: true` + short, trigger-phrase-free description → neither SK004 nor SK005 fires
  - Same description with the flag absent → both still fire (proves the gate, not a broken check)
  - Same description with `disable-model-invocation: false` → both still fire (only a truthy flag suppresses)
- [x] `uv run prek run --all-files` — fully green
- [x] `uv run pytest` — 1521 passed, 10 skipped, 86.41% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4