### PR TITLE
fix(AS009): exclude from `rules --platform` listing for non-Claude-Code platforms

### DIFF
--- a/packages/skilllint/rules/as_series.py
+++ b/packages/skilllint/rules/as_series.py
@@ -386,6 +386,15 @@ def _check_as009(path: pathlib.Path) -> dict | None:
     limitation. It is scoped to ``platforms=["claude-code"]`` instead of the
     AS-series default of "applies to every platform" for that reason.
 
+    Scope of ``platforms=`` here: it affects only rule *listing* — it is what
+    makes ``skilllint rules --platform cursor``/``codex`` correctly omit
+    AS009. It has no effect on *enforcement*: ``skilllint check --platform
+    <any>`` still runs this check unconditionally on every SKILL.md, because
+    validator dispatch (``_get_validators_for_path`` in plugin_validator.py)
+    selects ``AsSeriesValidator`` by file type alone, never by platform. That
+    dispatch is pre-existing, deliberate architecture — unrelated to and
+    unchanged by this fix.
+
     Claude Code skills only support single-level namespacing. A SKILL.md must be
     a direct child of the ``skills/`` directory (e.g., ``skills/my-skill/SKILL.md``).
     If nested deeper (e.g., ``skills/category/my-skill/SKILL.md``), it will not be

--- a/packages/skilllint/rules/as_series.py
+++ b/packages/skilllint/rules/as_series.py
@@ -374,10 +374,17 @@ def _count_levels_under_skills(path: pathlib.Path) -> int:
     "AS009",
     severity="warning",
     category="skill",
+    platforms=["claude-code"],
     authority={"origin": "anthropic.com", "reference": "https://docs.anthropic.com/en/docs/claude-code/skills"},
 )
 def _check_as009(path: pathlib.Path) -> dict | None:
     """AS009 — Nested skill will not be auto-discovered.
+
+    Unlike its AS-series siblings (AS001, AS006, AS008), this rule is not
+    sourced from the agentskills.io specification — its ``authority`` above
+    cites Claude Code's own docs, and it describes a Claude Code auto-discovery
+    limitation. It is scoped to ``platforms=["claude-code"]`` instead of the
+    AS-series default of "applies to every platform" for that reason.
 
     Claude Code skills only support single-level namespacing. A SKILL.md must be
     a direct child of the ``skills/`` directory (e.g., ``skills/my-skill/SKILL.md``).

--- a/packages/skilllint/tests/test_as_series.py
+++ b/packages/skilllint/tests/test_as_series.py
@@ -654,3 +654,24 @@ def test_as009_dot_claude_skills_bare_context_warns(tmp_path: pathlib.Path) -> N
     assert as009 != [], "Expected AS009 warning for .claude/skills/category/nested-skill/ layout"
     assert as009[0]["severity"] == "warning"
     assert "will not activate in Claude Code" in as009[0]["message"]
+
+
+def test_as009_scoped_to_claude_code_platform() -> None:
+    """AS009's registry entry declares only the Claude Code platform.
+
+    Tests: AS009 platform scoping, distinct from its AS-series siblings.
+    How: Look up the AS009 registry entry and assert its platforms list.
+    Why: Unlike AS001/AS006/AS008 (agentskills.io spec rules, which apply to
+         every platform), AS009 describes a Claude Code-only auto-discovery
+         limitation and cites Claude Code's own docs as its authority — it
+         must not be listed under `skilllint rules --platform cursor` or
+         `--platform codex`, where the underlying constraint does not exist.
+    """
+    # Imported locally: importing rule_registry before skilllint.rules.as_series
+    # at module scope trips the rule_registry <-> rules circular-import trap
+    # documented in ag_series.py's module docstring.
+    from skilllint.rule_registry import get_rule
+
+    entry = get_rule("AS009")
+    assert entry is not None
+    assert entry.platforms == ["claude-code"], entry.platforms


### PR DESCRIPTION
## Summary

- AS009 warns that a skill nested more than one level under `skills/` will not auto-activate. Unlike its AS-series siblings (AS001, AS006, AS008), which cite `agentskills.io` and are correctly registered as applying to every platform, AS009's `authority` cites `docs.anthropic.com/.../claude-code/skills` and its content is entirely about a Claude Code auto-discovery limitation (`plugin.json` `skills` array workaround, "will not activate in Claude Code").
- It was nonetheless registered with the AS-series default `platforms=["agentskills"]` (meaning "applies to every platform" per `RuleEntry.platforms`'s own docstring), so `skilllint rules --platform cursor` and `skilllint rules --platform codex` incorrectly listed a rule that is only about Claude Code.
- Fix: scope AS009 to `platforms=["claude-code"]`, matching how the existing AG-series (Claude-Code-specific agent-frontmatter rules) already scopes itself. Verified with `skilllint rules --platform cursor|codex|claude-code` before and after.

## Evidence for the underlying claim

- The cached Claude Code skills doc (`docs.anthropic.com/.../claude-code/skills`, re-fetched fresh from `code.claude.com/docs/en/skills.md` during this investigation) does not explicitly state a depth-1 restriction — it only documents the canonical `skills/<skill-name>/SKILL.md` path pattern.
- Anthropic's own `plugin-dev` skill and agent, vendored at `.claude/vendor/claude_code/plugins/plugin-dev/skills/plugin-structure/SKILL.md` and `.../agents/plugin-validator.md`, explicitly document plugin skill auto-discovery as scanning `skills/*/SKILL.md` — a single wildcard, i.e. one level — which supports AS009's underlying claim for plugin skills even though the cited authority URL doesn't spell it out directly.
- No test or documented behavior in this repo depends on AS009's previous `platforms` value; `rule-catalog.md` has no platform column and needed no update.

## Known limitation

`platforms=` on `@skilllint_rule` is metadata consumed only by `skilllint rules --platform <X>` (the rule-listing command). It does **not** gate which validators run during `skilllint check`. That dispatch (`_get_validators_for_path` in `plugin_validator.py`) selects `AsSeriesValidator` purely by file type (any `SKILL.md`), not by platform — confirmed live: `skilllint check --platform cursor|codex|claude-code` (and with no `--platform` at all) all still run AS009 and emit its Claude-Code-specific message on a nested skill.

This is pre-existing, deliberate architecture across the whole `platforms=` field — not a regression introduced here, and out of scope for this PR. It means: after this change, AS009 correctly disappears from `skilllint rules --platform cursor`/`codex` listings, but `skilllint check --platform cursor`/`codex` on a real nested-skill fixture will still flag it. A reviewer should not read this PR as having changed `check` behavior for non-Claude-Code platforms.

## Test plan

- [x] Added `test_as009_scoped_to_claude_code_platform` in `packages/skilllint/tests/test_as_series.py`, mirroring the existing AG-series platform-scoping test pattern.
- [x] `uv run prek run --all-files` — all green.
- [x] `uv run pytest` — 1519 passed, 10 skipped, 86.40% coverage.
- [x] Manually confirmed `skilllint rules --platform cursor|codex` no longer list AS009 and `skilllint rules --platform claude-code` still does.
- [x] Manually confirmed `skilllint check --platform cursor|codex|claude-code` (via a plugin.json-registered nested skill fixture) all still fire AS009 — see "Known limitation" above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4
