### PR TITLE
fix(FM005,FM010): attribute over-length name to FM010, not FM005

### DIFF
--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -1279,6 +1279,12 @@ def _pydantic_error_to_validation_issue(error: ErrorDetails) -> ValidationIssue:
         max_len = _get_pydantic_ctx_val(error, "max_length", "unknown")
         msg = f"Exceeds maximum length of {max_len} characters"
         suggestion = f"Shorten to {max_len} characters or less"
+        if field == "name":
+            # FM010 owns name-length validation (see check_fm010 in fm_series.py).
+            # Routing here avoids a duplicate FM005+FM010 finding for the same
+            # over-length name (#139); _check_name_field_format's duplicate
+            # guard then suppresses the second FM010 source.
+            code = FM010
     elif "Input should be" in msg and "literal" in msg.lower():
         code = FM006
         valid_values = _get_pydantic_ctx_val(error, "expected")

--- a/packages/skilllint/tests/test_frontmatter_validator.py
+++ b/packages/skilllint/tests/test_frontmatter_validator.py
@@ -390,6 +390,36 @@ description: Test agent
         assert result.passed is False
         assert any(issue.code == "FM010" for issue in result.errors)
 
+    def test_overlength_name_reports_fm010_only(self, tmp_path: Path) -> None:
+        """Test an over-64-char name reports FM010 once, not FM005+FM010 (#139).
+
+        Tests: Frontmatter with a name exceeding the 64-character limit
+        How: Create a skill with a 65-character name, validate
+        Why: Pydantic's max_length rejection and check_fm010's own length
+             check both cover this case; FM010 is the sole documented owner
+             of name-length validation, so the Pydantic-triggered error must
+             be attributed to FM010, not the unrelated FM005 field-type code,
+             and must not also duplicate as a second FM010 finding.
+        """
+        long_name = "a" * 65
+        skill_dir = tmp_path / long_name
+        skill_dir.mkdir()
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text(f"""---
+name: {long_name}
+description: A valid description that is long enough to pass minimum checks.
+---
+
+# Content
+""")
+
+        validator = FrontmatterValidator()
+        result = validator.validate(skill_md)
+
+        assert result.passed is False
+        codes = [issue.code for issue in result.errors]
+        assert codes == ["FM010"], f"Expected exactly one FM010 finding, got: {codes}"
+
 
 class TestFrontmatterEdgeCases:
     """Test edge cases and boundary conditions."""


### PR DESCRIPTION
## Problem

A skill name over 64 characters produces two findings for the same violation:

- Pydantic's `max_length` constraint on `SkillFrontmatter.name` raises a validation error, mapped by `_pydantic_error_to_validation_issue` to **FM005** ("Exceeds maximum length of 64 characters").
- `check_fm010` independently checks `len(name) > MAX_NAME_LENGTH` and emits **FM010** ("Name must be 1-64 characters").

Both run and both fire — reported as issue #139.

FM005 is the field-type-mismatch rule; name-length and pattern validation belongs to FM010, which already owns the pattern-mismatch case (routed to FM010 since `"String should match pattern"` already maps there). The length case was the one path still misattributed to FM005.

## Fix

Route the Pydantic `max_length` error on the `name` field to FM010 instead of FM005 (`plugin_validator.py`, `_pydantic_error_to_validation_issue`).

`_check_name_field_format`'s existing duplicate guard (`if ... any(issue.code == FM010 for issue in (*errors, *warnings)): return`) then suppresses the second `check_fm010` call, so the result is exactly one FM010 finding — not zero, not two.

This is the smaller of the two fixes #139 itself considered: the issue also floated removing `max_length` from the Pydantic boundary model entirely, but flagged that as a typed-boundary decision affecting every consumer, not just this rule. This fix keeps the boundary model unchanged and only corrects which rule code the same rejection is attributed to.

## Verification

Confirmed the bug reproduces before the fix and is fixed after, via a new regression test in `test_frontmatter_validator.py` (`test_overlength_name_reports_fm010_only`) — asserted it fails with `['FM005', 'FM010']` against the pre-fix code, and passes with `['FM010']` after.

```sh
uv run prek run --all-files   # all green
uv run pytest                 # 1519 passed, 10 skipped, 86.40% coverage
```

Closes #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4