### PR TITLE
fix(AS006): recognize evals/evals.json, cite live agentskills.io authority

### DIFF
--- a/packages/skilllint/rules/as_series.py
+++ b/packages/skilllint/rules/as_series.py
@@ -37,6 +37,14 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 
+# AS006 authority: agentskills.io/specification.md has no eval-related
+# section (re-verified via `skilllint docs fetch` — zero matches for
+# "eval" in the full spec text). The real agentskills.io coverage of this
+# concept lives on a sibling page, skill-creation/evaluating-skills.md,
+# "Designing test cases" section, which states verbatim: "Store test
+# cases in `evals/evals.json` inside your skill directory."
+_AS006_EVALS_URL = "https://agentskills.io/skill-creation/evaluating-skills.md#designing-test-cases"
+
 # ---------------------------------------------------------------------------
 # Rule registry — maps code to human-readable description
 # ---------------------------------------------------------------------------
@@ -269,17 +277,16 @@ def _check_as008(tools: list[str], path: pathlib.Path) -> list[dict]:
 
 
 @skilllint_rule(
-    "AS006",
-    severity="info",
-    category="skill",
-    authority={"origin": "agentskills.io", "reference": "/specification#evaluation-queries"},
+    "AS006", severity="info", category="skill", authority={"origin": "agentskills.io", "reference": _AS006_EVALS_URL}
 )
 def _check_as006(path: pathlib.Path) -> dict | None:
     """AS006 — No evaluation queries file found.
 
-    Recommends adding an ``eval_queries.json`` file to the skill directory
-    to enable automated quality assessment. The file should contain test
-    queries that exercise the skill's functionality.
+    Recommends adding evaluation queries to the skill directory to enable
+    automated quality assessment, either as a top-level ``eval_queries.json``
+    (or any ``*eval*.json``/``*queries*.json`` file) or as ``evals/evals.json``
+    — the layout documented by agentskills.io's evaluating-skills guide and
+    Claude Code's skill-creator plugin.
 
     Args:
         path: Path to the SKILL.md file being validated.
@@ -288,8 +295,8 @@ def _check_as006(path: pathlib.Path) -> dict | None:
         Violation dict if no eval file found, None otherwise.
 
     Fix:
-        Create ``eval_queries.json`` in the skill directory with test queries
-        in JSON format.
+        Create ``eval_queries.json`` (or ``evals/evals.json``) in the skill
+        directory with test queries in JSON format.
 
     Note:
         This is an informational message, not an error. Skills work
@@ -300,6 +307,13 @@ def _check_as006(path: pathlib.Path) -> dict | None:
 
     # Check for eval_queries.json exact name first
     if (parent / "eval_queries.json").exists():
+        return None
+
+    # Check for evals/evals.json — a directory, so it's invisible to the
+    # file glob below (which only scans parent.iterdir(), not subdirs).
+    # The doc wording ("stores ... in evals/evals.json") is about the file's
+    # content, so an empty evals/ dir does not satisfy this.
+    if (parent / "evals" / "evals.json").is_file():
         return None
 
     # Check for any file matching *eval*.json or *queries*.json

--- a/packages/skilllint/rules/as_series.py
+++ b/packages/skilllint/rules/as_series.py
@@ -51,7 +51,7 @@ _AS006_EVALS_URL = "https://agentskills.io/skill-creation/evaluating-skills.md#d
 
 AS_RULES: dict[str, str] = {
     "AS001": "SKILL.md must declare a name field",
-    "AS006": "No eval_queries.json found — add evaluation queries for quality assurance",
+    "AS006": "No eval_queries.json or evals/evals.json found — add evaluation queries for quality assurance",
     "AS008": "MCP tool name may have incorrect casing — case is sensitive in the tools field",
     "AS009": "Nested skill will not be auto-discovered — skills must be direct children of the skills/ directory",
 }
@@ -285,8 +285,7 @@ def _check_as006(path: pathlib.Path) -> dict | None:
     Recommends adding evaluation queries to the skill directory to enable
     automated quality assessment, either as a top-level ``eval_queries.json``
     (or any ``*eval*.json``/``*queries*.json`` file) or as ``evals/evals.json``
-    — the layout documented by agentskills.io's evaluating-skills guide and
-    Claude Code's skill-creator plugin.
+    — the layout documented by agentskills.io's evaluating-skills guide.
 
     Args:
         path: Path to the SKILL.md file being validated.
@@ -326,7 +325,7 @@ def _check_as006(path: pathlib.Path) -> dict | None:
     return _make_violation(
         "AS006",
         "info",
-        "No eval_queries.json found in skill directory — add evaluation queries to enable automated quality assessment",
+        "No eval_queries.json or evals/evals.json found in skill directory — add evaluation queries to enable automated quality assessment",
     )
 
 

--- a/packages/skilllint/tests/test_as_series.py
+++ b/packages/skilllint/tests/test_as_series.py
@@ -215,6 +215,36 @@ def test_as006_no_eval_queries_info(tmp_path: pathlib.Path):
     )
 
 
+def test_as006_evals_json_in_evals_dir_satisfies_check(tmp_path: pathlib.Path):
+    """A skill with only evals/evals.json (no eval_queries.json) triggers no AS006.
+
+    agentskills.io's evaluating-skills guide and Claude Code's skill-creator
+    plugin both document ``evals/evals.json`` as the standard eval layout.
+    The old file-only glob over ``parent.iterdir()`` never sees content
+    inside a subdirectory, so this documented layout was a blind spot.
+    """
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(
+        textwrap.dedent("""\
+            ---
+            name: my-skill
+            description: A skill with evals/evals.json instead of eval_queries.json.
+            ---
+
+            Body content.
+        """)
+    )
+    evals_dir = skill_dir / "evals"
+    evals_dir.mkdir()
+    (evals_dir / "evals.json").write_text('{"skill_name": "my-skill", "evals": []}')
+
+    violations = check_skill_md(skill_md)
+    as006 = _violations_with_code(violations, "AS006")
+    assert as006 == [], f"Expected no AS006 when evals/evals.json is present, got: {as006}"
+
+
 # ---------------------------------------------------------------------------
 # AS008: MCP server name references in the allowed-tools field
 # ---------------------------------------------------------------------------

--- a/packages/skilllint/tests/test_as_series.py
+++ b/packages/skilllint/tests/test_as_series.py
@@ -218,10 +218,10 @@ def test_as006_no_eval_queries_info(tmp_path: pathlib.Path):
 def test_as006_evals_json_in_evals_dir_satisfies_check(tmp_path: pathlib.Path):
     """A skill with only evals/evals.json (no eval_queries.json) triggers no AS006.
 
-    agentskills.io's evaluating-skills guide and Claude Code's skill-creator
-    plugin both document ``evals/evals.json`` as the standard eval layout.
-    The old file-only glob over ``parent.iterdir()`` never sees content
-    inside a subdirectory, so this documented layout was a blind spot.
+    agentskills.io's evaluating-skills guide documents ``evals/evals.json``
+    as the standard eval layout. The old file-only glob over
+    ``parent.iterdir()`` never sees content inside a subdirectory, so this
+    documented layout was a blind spot.
     """
     skill_dir = tmp_path / "my-skill"
     skill_dir.mkdir()


### PR DESCRIPTION
## Summary

- `_check_as006` (`packages/skilllint/rules/as_series.py`) only scanned **files** via `parent.iterdir()`, so it never saw a `evals/` **directory** — a skill following the documented `evals/evals.json` layout got falsely flagged "No eval_queries.json found". Added an explicit `(parent / "evals" / "evals.json").is_file()` check alongside the existing `eval_queries.json` exact-match and `*eval*.json`/`*queries*.json` glob checks (both left unchanged).
- Chose to require the **file's presence** (`evals/evals.json`), not just a bare `evals/` directory, because the doc wording is about what the file *stores* ("Store test cases in `evals/evals.json` inside your skill directory"), not about directory presence alone.
- Re-verified AS006's `authority=` citation live (`skilllint docs fetch https://agentskills.io/specification.md`, re-fetched fresh for this PR): the spec has **zero** eval-related content, so the old `{"origin": "agentskills.io", "reference": "/specification#evaluation-queries"}` citation was dangling — nothing at that anchor, in fact nothing eval-related anywhere on that page. Rather than falling back to Claude Code's docs or dropping to a lint-opinion, found the real coverage lives on a **sibling agentskills.io page**, `skill-creation/evaluating-skills.md` ("Designing test cases" section), which verbatim states: "Store test cases in `evals/evals.json` inside your skill directory." Rewrote the citation as an absolute URL to that page (`https://agentskills.io/skill-creation/evaluating-skills.md#designing-test-cases`), following the same origin (`agentskills.io`) and the absolute-URL pattern PD001/PD003 established in #197 — this is more correct than either alternative since it's the actual agentskills.io content that documents this exact convention, not a different vendor's docs or an unsupported claim.

## Relation to #199

Issue #199 proposed a **new rule** for an `evals/`-style directory. A prior pass in this session concluded AS006 already owns this exact concept (evaluation evidence for a skill) and was just missing directory recognition — so this PR fixes the existing rule rather than adding a new rule ID.

This closes the concrete bug (a compliant `evals/evals.json` skill was wrongly flagged) and the authority-citation gap the issue's "Authority to verify" section worried about. It does **not** implement everything #199 asked for — a configurable alternate-path escape hatch, and content-aware pass/fail-criteria checking beyond presence — so I'm not marking this as closing #199; leaving that decision, and any follow-up scope, to the issue.

## Test plan

- [x] Added `test_as006_evals_json_in_evals_dir_satisfies_check` (`packages/skilllint/tests/test_as_series.py`) — a skill with only `evals/evals.json` (no `eval_queries.json`, no other `*eval*.json`/`*queries*.json`).
- [x] Confirmed it **fails** against the pre-fix code (`git stash` on `as_series.py` only): `AssertionError: Expected no AS006 when evals/evals.json is present, got: [...]`
- [x] Confirmed it **passes** after the fix: `packages/skilllint/tests/test_as_series.py` — 31 passed
- [x] `uv run pytest` — full suite green (1519 passed, 10 skipped); one intermittent, order-sensitive failure in an unrelated file (`test_hooks_json_ingest.py::test_arbitrary_hooks_mapping_round_trips`) was seen once and reproduced as passing on a clean `main` checkout and on two subsequent reruns with this diff applied — pre-existing flakiness, unrelated to this change.
- [x] `uv run prek run --all-files` — all hooks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4