### PR TITLE
fix(PR001): suppress default-discovery false positives for agents/commands

### DIFF
--- a/packages/skilllint/rules/pr_series.py
+++ b/packages/skilllint/rules/pr_series.py
@@ -139,15 +139,22 @@ def check_pr001(manifest: dict[str, YamlValue], plugin_dir: Path) -> list[Valida
     """## PR001 — Capability exists but not explicitly registered
 
     A skill, agent, or command directory was found on the filesystem but is
-    not listed in the corresponding array in ``plugin.json``.  When
-    ``plugin.json`` contains an explicit ``skills``, ``agents``, or
-    ``commands`` array, Claude Code uses only the listed paths and will not
-    auto-discover unregistered capabilities.
+    not listed in the corresponding array in ``plugin.json``.
 
-    Note: when the ``skills`` field is absent from ``plugin.json`` entirely,
-    standard-path skills (under ``./skills/``) are auto-discovered by Claude
-    Code and PR001 is suppressed for them.  PR001 is only emitted when the
-    plugin has opted into explicit registration by declaring the array.
+    Per the vendor path-behavior rules, an explicit ``agents`` or
+    ``commands`` array *replaces* default directory discovery: once either
+    field is declared, Claude Code stops auto-discovering unregistered files
+    under the matching default directory, so anything PR001 still finds
+    there is a genuine gap.  When the field is absent, the default directory
+    is auto-discovered wholesale and PR001 is suppressed.
+
+    ``skills`` behaves differently: the default ``./skills/`` directory is
+    *always* scanned, whether or not ``skills`` is declared (additive, not
+    replacing).  An unregistered standard-path skill therefore always loads.
+    PR001 still flags it once the plugin has opted into explicit
+    registration by declaring the ``skills`` array (even empty), as a
+    consistency nudge, but is suppressed while no ``skills`` array is
+    declared at all.
 
     **Source:** ``PluginRegistrationValidator.validate`` in
     ``plugin_validator.py`` — scans the filesystem for actual capability
@@ -180,13 +187,12 @@ def check_pr001(manifest: dict[str, YamlValue], plugin_dir: Path) -> list[Valida
 
     issues: list[ValidationIssue] = []
 
-    # When plugin.json has no ``skills`` field at all, the plugin relies
-    # entirely on Claude Code's auto-discovery of the ./skills/ directory.
-    # Standard-path skills (under ./skills/) are auto-discovered and need
-    # no explicit registration — suppress PR001 for them in this case.
-    # When an explicit ``skills`` array is present (even if empty), the
-    # plugin has opted into explicit registration and unregistered
-    # standard-path skills should still be flagged.
+    # ``skills`` is additive (path-behavior-rules): the default ./skills/
+    # directory is always scanned regardless of declaration, so an
+    # unregistered standard-path skill always loads.  PR001 only nudges for
+    # explicit registration once the plugin has opted in by declaring the
+    # array (even empty); it is suppressed while no ``skills`` array exists
+    # at all.  (Mirrors the SK009 gate in plugin_validator.py.)
     issues.extend(
         _make_issue(
             field="plugin.json",
@@ -196,9 +202,14 @@ def check_pr001(manifest: dict[str, YamlValue], plugin_dir: Path) -> list[Valida
             suggestion=f"Add './{orphan}' to the skills array in plugin.json",
         )
         for orphan in actual_skills - registered_skills
-        if "skills" in manifest or not str(orphan).startswith("skills/")
+        if "skills" in manifest
     )
 
+    # ``agents``/``commands`` replace default discovery once declared
+    # (path-behavior-rules): an unregistered file under the default
+    # directory is then a genuine gap.  When the field is absent, the
+    # default directory is still auto-discovered wholesale, so PR001 is
+    # suppressed for it.
     issues.extend(
         _make_issue(
             field="plugin.json",
@@ -208,6 +219,7 @@ def check_pr001(manifest: dict[str, YamlValue], plugin_dir: Path) -> list[Valida
             suggestion=f"Add './{orphan}' to the agents array in plugin.json",
         )
         for orphan in actual_agents - registered_agents
+        if "agents" in manifest
     )
 
     issues.extend(
@@ -219,6 +231,7 @@ def check_pr001(manifest: dict[str, YamlValue], plugin_dir: Path) -> list[Valida
             suggestion=f"Add './{orphan}' to the commands array in plugin.json",
         )
         for orphan in actual_commands - registered_commands
+        if "commands" in manifest
     )
 
     return issues

--- a/packages/skilllint/tests/test_plugin_registration_validator.py
+++ b/packages/skilllint/tests/test_plugin_registration_validator.py
@@ -323,6 +323,33 @@ class TestUnregisteredSkill:
         pr001_warnings = [w for w in result.warnings if w.code == "PR001"]
         assert len(pr001_warnings) >= 2
 
+    def test_pr001_still_fires_when_skills_array_explicitly_empty(self, tmp_path: Path) -> None:
+        """Test PR001 still fires for an orphan skill when 'skills' is an explicit empty array.
+
+        Tests: PR001 must not be suppressed merely because 'skills' is declared (issue #200)
+        How: plugin.json declares 'skills': [] explicitly; an unregistered skill exists
+            under the standard ./skills/ path; validate
+        Why: The vendor path-behavior rules make 'skills' additive -- the default
+            ./skills/ directory is scanned regardless of declaration. Declaring the
+            array (even empty) must never, by itself, suppress PR001 for skills that
+            still are not listed in it. A prior condition (`"skills" in manifest or
+            not str(orphan).startswith("skills/")`) risked being "corrected" into a
+            form that always evaluates to False for standard-path skills, silently
+            disabling this warning entirely -- this regression test guards against
+            exactly that.
+        """
+        plugin_dir = _make_plugin(
+            tmp_path, plugin_json_content=msgspec.json.encode({"name": "test-plugin", "skills": []}).decode()
+        )
+        _add_skill(plugin_dir, "orphan-skill")
+
+        validator = PluginRegistrationValidator()
+        result = validator.validate(plugin_dir)
+
+        pr001_warnings = [w for w in result.warnings if w.code == "PR001"]
+        assert len(pr001_warnings) >= 1
+        assert any("orphan-skill" in w.message for w in pr001_warnings)
+
 
 class TestUnregisteredAgent:
     """Test PR001 warning when agent file exists but is not in plugin.json."""
@@ -382,6 +409,47 @@ class TestUnregisteredAgent:
         pr001_warnings = [w for w in result.warnings if w.code == "PR001"]
         assert len(pr001_warnings) == 0
 
+    def test_no_pr001_for_unregistered_agent_when_agents_field_absent(self, tmp_path: Path) -> None:
+        """Test no PR001 warning for an agent when 'agents' is absent from plugin.json.
+
+        Tests: PR001 suppression for agents when the field is undeclared
+        How: plugin.json has no 'agents' key at all; an agent file exists; validate
+        Why: Per the vendor path-behavior rules, an explicit 'agents' array replaces
+            default discovery of ./agents/ -- only once declared. When the field is
+            absent, Claude Code still auto-discovers ./agents/ wholesale, so an
+            unregistered agent there is not a genuine gap and must not be flagged.
+        """
+        plugin_dir = _make_plugin(tmp_path, plugin_json_content=msgspec.json.encode({"name": "test-plugin"}).decode())
+        _add_agent(plugin_dir, "auto-discovered-agent")
+
+        validator = PluginRegistrationValidator()
+        result = validator.validate(plugin_dir)
+
+        pr001_warnings = [w for w in result.warnings if w.code == "PR001"]
+        assert len(pr001_warnings) == 0
+
+    def test_pr001_fires_for_unregistered_agent_when_agents_field_explicitly_empty(self, tmp_path: Path) -> None:
+        """Test PR001 fires for an orphan agent when 'agents' is an explicit empty array.
+
+        Tests: PR001 for agents once the plugin has opted into explicit registration
+        How: plugin.json declares 'agents': [] explicitly; an unregistered agent
+            file exists; validate
+        Why: Declaring 'agents' (even empty) replaces default discovery of
+            ./agents/, per the vendor path-behavior rules, so any file Claude Code
+            still finds there is a genuine gap that PR001 must flag.
+        """
+        plugin_dir = _make_plugin(
+            tmp_path, plugin_json_content=msgspec.json.encode({"name": "test-plugin", "agents": []}).decode()
+        )
+        _add_agent(plugin_dir, "orphan-agent")
+
+        validator = PluginRegistrationValidator()
+        result = validator.validate(plugin_dir)
+
+        pr001_warnings = [w for w in result.warnings if w.code == "PR001"]
+        assert len(pr001_warnings) >= 1
+        assert any("orphan-agent" in w.message for w in pr001_warnings)
+
 
 class TestUnregisteredCommand:
     """Test PR001 warning when command file exists but is not in plugin.json."""
@@ -401,6 +469,47 @@ class TestUnregisteredCommand:
 
         pr001_warnings = [w for w in result.warnings if w.code == "PR001"]
         assert len(pr001_warnings) >= 1
+
+    def test_no_pr001_for_unregistered_command_when_commands_field_absent(self, tmp_path: Path) -> None:
+        """Test no PR001 warning for a command when 'commands' is absent from plugin.json.
+
+        Tests: PR001 suppression for commands when the field is undeclared
+        How: plugin.json has no 'commands' key at all; a command file exists; validate
+        Why: Per the vendor path-behavior rules, an explicit 'commands' array
+            replaces default discovery of ./commands/ -- only once declared. When
+            the field is absent, Claude Code still auto-discovers ./commands/
+            wholesale, so an unregistered command there is not a genuine gap.
+        """
+        plugin_dir = _make_plugin(tmp_path, plugin_json_content=msgspec.json.encode({"name": "test-plugin"}).decode())
+        _add_command(plugin_dir, "auto-discovered-command")
+
+        validator = PluginRegistrationValidator()
+        result = validator.validate(plugin_dir)
+
+        pr001_warnings = [w for w in result.warnings if w.code == "PR001"]
+        assert len(pr001_warnings) == 0
+
+    def test_pr001_fires_for_unregistered_command_when_commands_field_explicitly_empty(self, tmp_path: Path) -> None:
+        """Test PR001 fires for an orphan command when 'commands' is an explicit empty array.
+
+        Tests: PR001 for commands once the plugin has opted into explicit registration
+        How: plugin.json declares 'commands': [] explicitly; an unregistered command
+            file exists; validate
+        Why: Declaring 'commands' (even empty) replaces default discovery of
+            ./commands/, per the vendor path-behavior rules, so any file Claude Code
+            still finds there is a genuine gap that PR001 must flag.
+        """
+        plugin_dir = _make_plugin(
+            tmp_path, plugin_json_content=msgspec.json.encode({"name": "test-plugin", "commands": []}).decode()
+        )
+        _add_command(plugin_dir, "orphan-command")
+
+        validator = PluginRegistrationValidator()
+        result = validator.validate(plugin_dir)
+
+        pr001_warnings = [w for w in result.warnings if w.code == "PR001"]
+        assert len(pr001_warnings) >= 1
+        assert any("orphan-command" in w.message for w in pr001_warnings)
 
     def test_registered_command_no_pr001(self, tmp_path: Path) -> None:
         """Test no PR001 warning when command is registered in plugin.json.


### PR DESCRIPTION
## Summary

Investigated issue #200 (PR001's `skills`-array suppression logic) against
the vendor doc it cites. **The issue's premise does not hold**: a runnable
check against `check_pr001` (see below) shows the *current* code does the
opposite of what the issue describes — declaring an explicit `skills` array
(even empty) does **not** suppress PR001 today; it already warns in that
case, and only suppresses when `skills` is absent from `plugin.json`
entirely. That is in fact the doc-correct behavior, since `skills` is
additive (`./skills/` is always scanned regardless of declaration) while an
explicit array being present is treated as the plugin opting into an
explicit-registration nudge.

Verbatim doc quote (`code.claude.com/docs/en/plugins-reference.md#path-behavior-rules`,
re-fetched 2026-09-05):

> **Adds to the default**: `skills`. The default `skills/` directory is
> always scanned, and directories listed in `skills` are loaded alongside
> it.

> **Replaces the default**: `commands`, `agents`, ... For example, when the
> manifest specifies `commands`, the default `commands/` directory is not
> scanned.

Because the `skills` half of the issue's stated failure scenario does not
reproduce, **this PR does not close #200 as originally framed** — see
"Investigation note" below. It does, however, fix a real, mirror-image bug
the same doc research surfaced: `agents`/`commands` genuinely *replace*
default discovery once declared (per the second quote above), but
`check_pr001` had **no** suppression logic for them at all, so a plugin
relying on full auto-discovery (no `agents`/`commands` key in `plugin.json`)
got a PR001 false positive for every agent/command file on disk. This PR
adds the same "suppressed while absent, warned once declared" gate skills
already had (also precedented by the existing SK009 gate in
`plugin_validator.py`: `if "skills" in plugin_config`).

## Changes

- `packages/skilllint/rules/pr_series.py`
  - Rewrote `check_pr001`'s docstring to accurately state the vendor
    doc's distinction: `agents`/`commands` replace default discovery once
    declared; `skills` is additive and always scanned.
  - Simplified the `skills` filter to `if "skills" in manifest` (dropping a
    dead `not str(orphan).startswith("skills/")` clause that could never
    evaluate `True`, since `find_actual_capabilities` only ever populates
    `actual_skills` with `skills/`-prefixed paths). No observable behavior
    change for skills.
  - Added `if "agents" in manifest` / `if "commands" in manifest` gates to
    the agent/command blocks (previously unconditional) — the actual bug
    fix.
- `packages/skilllint/tests/test_plugin_registration_validator.py`
  - Added a regression test asserting PR001 still fires for an
    unregistered skill when `skills: []` is explicitly declared (guards
    against a naive "fix" that disables the check entirely by relying on
    the now-removed dead clause).
  - Added regression tests for the new agents/commands behavior: no PR001
    when the field is absent (auto-discovered), PR001 fires once the field
    is explicitly declared (even empty).

## Investigation note (why this isn't "Closes #200")

I reproduced the issue's exact scenario against the current, unmodified
code with a standalone script before making any change:

```
skills key ABSENT -> issues: []
skills key PRESENT (empty array) -> issues: ["Skill 'skills/orphan-skill' exists but is not registered ..."]
```

This is the opposite polarity from what #200 describes ("PR001 stops
warning ... the moment `skills` appears in the manifest"). I also confirmed
the literal code change #200 suggests
(`if not str(orphan).startswith("skills/")`, dropping the `"skills" in
manifest` clause) would have **regressed** this to zero warnings in both
states, since that clause alone is always `False` for every skill orphan
`check_pr001` can currently produce — which would have broken the exact
scenario the issue wants preserved. I did not apply it. Recommend closing
#200 as based on a mis-read of the current boolean logic, or repurposing it
to track this PR's agents/commands fix instead.

## Test plan

- [x] `uv run pytest` — 1523 passed, 10 skipped
- [x] `uv run prek run --all-files` — all hooks passed (ruff, ruff-format,
      ty, markdownlint, shellcheck, etc.)
- [x] Manual verification script against `check_pr001` covering all
      present/absent combinations for skills/agents/commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4