### PR TITLE
fix(scan): route plugin-path discovery through the exclusion helper

### DIFF
--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -179,9 +179,9 @@ def _discover_plugin_paths(manifest: PluginManifest) -> list[Path]:
             if path_list is not None:
                 discovered.update(root / rel for rel in path_list)
     else:
-        discovered.update(root.glob("agents/*.md"))
-        discovered.update(root.glob("commands/*.md"))
-        discovered.update(path.parent for path in root.glob("skills/*/SKILL.md"))
+        discovered.update(_glob_excluding(root, "agents/*.md"))
+        discovered.update(_glob_excluding(root, "commands/*.md"))
+        discovered.update(path.parent for path in _glob_excluding(root, "skills/*/SKILL.md"))
 
     discovered.add(root)
 

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -101,6 +101,33 @@ class TestDiscoverValidatablePaths:
         # Should return the plugin root directory, not the plugin.json file
         assert plugin_dir in discovered, f"Expected {plugin_dir} in discovered paths: {discovered}"
 
+    def test_plugin_skill_named_node_modules_is_excluded_consistently(self, tmp_path: Path) -> None:
+        """A convention-driven plugin's own skill/agent/command globs respect EXCLUDED_DIR_NAMES too.
+
+        Tests: _discover_plugin_paths's convention-driven glob calls route
+               through _glob_excluding the same way _discover_provider_paths
+               and _discover_bare_paths already do.
+        How: A plugin skill directory literally named "node_modules" must be
+             excluded the same way it would be under provider/bare discovery.
+        Why: Regression for an inconsistency — the plugin-classified code
+             path used raw root.glob(...) directly, bypassing the exclusion
+             helper, so a skill/agent/command named after an excluded
+             directory was silently treated differently depending only on
+             whether its containing tree was classified as PLUGIN vs.
+             PROVIDER/BARE.
+        """
+        plugin_dir = tmp_path / "my-plugin"
+        claude_plugin = plugin_dir / ".claude-plugin"
+        claude_plugin.mkdir(parents=True)
+        (claude_plugin / "plugin.json").write_text('{"name": "my-plugin"}')
+        skill_dir = plugin_dir / "skills" / "node_modules"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: Test\n---\n# Test\n")
+
+        discovered = _discover_validatable_paths(plugin_dir)
+
+        assert skill_dir not in discovered, f"Did not expect {skill_dir} in discovered paths: {discovered}"
+
     def test_returns_sorted_paths(self, tmp_path: Path) -> None:
         """_discover_validatable_paths returns sorted paths.
 


### PR DESCRIPTION
## Problem

Found during the integrated review of the last 48 hours of changes (PRs #188-#208).

PR #202 added `EXCLUDED_DIR_NAMES`/`_glob_excluding` so discovery never walks into `.git`/`node_modules`/`.venv`, applied via `_discover_provider_paths` and `_discover_bare_paths`. `_discover_plugin_paths` (the PLUGIN-classified code path) globs directly with raw `root.glob(...)`, bypassing that helper entirely.

## Failure scenario

A skill/agent/command literally named `node_modules`, `.venv`, or `.git` (e.g. `skills/node_modules/SKILL.md`) is silently excluded when the containing tree is classified as PROVIDER or BARE, but discovered when the same tree is classified as PLUGIN — an inconsistency in the exclusion mechanism itself.

Verified directly:
```
# skills/node_modules/SKILL.md under a plugin, before this fix:
[.../my-plugin, .../my-plugin/skills/node_modules]   # discovered — inconsistent

# after this fix:
[.../my-plugin]                                       # excluded — consistent
```

## Fix

Route `_discover_plugin_paths`'s three convention-driven glob calls (`agents/*.md`, `commands/*.md`, `skills/*/SKILL.md`) through `_glob_excluding`, matching the other two discovery code paths.

## Verification

Regression test confirmed to fail before the fix (skill discovered) and pass after (excluded). Full suite:
```sh
uv run prek run --all-files   # green
uv run pytest                 # 1542 passed, 10 skipped, 86.44% coverage
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4