### PR TITLE
fix(scripts): remove hardcoded python3 shebang from bench_import.py

### DIFF
--- a/scripts/bench_import.py
+++ b/scripts/bench_import.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Import-time benchmark for the ``skilllint`` package and its rule registry.
 
 Measures the wall-clock cost of ``import skilllint.rules`` in a fresh


### PR DESCRIPTION
Found during the integrated review of the last 48 hours of changes (PRs #188-#208).

`scripts/bench_import.py` (added in PR #192) has `#!/usr/bin/env python3` and the executable bit set. This violates the global rule to always invoke Python via `uv run python`, never a hardcoded interpreter path — and diverges from its siblings `bench_io.py`/`bench_cpu.py`, which have neither.

Confirmed the shebang and exec bit are not load-bearing: `.github/workflows/benchmark.yml` always invokes it as `python scripts/bench_import.py` / `python "$BENCH_IMPORT"`, never `./scripts/bench_import.py`.

Removed the shebang line and dropped the executable bit to match the sibling scripts.

```sh
uv run prek run --all-files   # green
uv run pytest -k bench_import # 3 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4