### PR TITLE
fix(PR005): downgrade to info, replace placeholder authority

### DIFF
--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -3046,7 +3046,7 @@ class PluginRegistrationValidator:
         # Registration checks — detection lives in skilllint.rules.pr_series.
         warnings.extend(check_pr001(plugin_config, plugin_dir))
         errors.extend(check_pr002(plugin_config, plugin_dir))
-        errors.extend(check_pr005(plugin_config, plugin_dir))
+        info.extend(check_pr005(plugin_config, plugin_dir))
 
         # SK009 — manual skill selection mode (informational)
         if "skills" in plugin_config:

--- a/packages/skilllint/rules/pr_series.py
+++ b/packages/skilllint/rules/pr_series.py
@@ -22,7 +22,7 @@ Rule IDs and default severities:
     | PR002 | Registered capability path does not exist                 | error     |
     | PR003 | Plugin metadata fields not populated                      | info      |
     | PR004 | Plugin metadata repository URL mismatches git remote URL  | warning   |
-    | PR005 | Registered command path is a skill directory              | error     |
+    | PR005 | Registered command path is a skill directory              | info      |
     +-------+-----------------------------------------------------------+-----------+
 """
 
@@ -466,26 +466,32 @@ def check_pr004(manifest: dict[str, YamlValue], git_metadata: dict[str, YamlValu
 
 @skilllint_rule(
     "PR005",
-    severity="error",
+    severity="info",
     category="plugin-registration",
     platforms=["agentskills"],
-    authority={"origin": "github.com/jamie-bitflight/claude_skills"},
+    authority={
+        "origin": "code.claude.com",
+        "reference": "https://code.claude.com/docs/en/plugins-reference.md#component-path-fields",
+    },
 )
 def check_pr005(manifest: dict[str, YamlValue], plugin_dir: Path) -> list[ValidationIssue]:
     """## PR005 — Registered command path is a skill directory
 
     A path listed in the ``commands`` array of ``plugin.json`` resolves to a
-    directory that contains a ``SKILL.md`` file.  Skill directories must be
-    listed under ``skills``, not ``commands``.  Listing a skill directory as a
-    command causes incorrect runtime behaviour and may prevent the skill from
-    loading.
+    directory that contains a ``SKILL.md`` file.  Per
+    code.claude.com/docs/en/plugins-reference, ``commands`` accepts "custom
+    flat .md skill files or directories", so this is valid configuration, not
+    a load-blocking error.  Listing it under ``commands`` instead of
+    ``skills`` does forgo skill-only features (e.g. supporting files) that
+    code.claude.com/docs/en/skills gives as the reason skills are recommended
+    over commands.
 
     **Source:** ``PluginRegistrationValidator.validate`` in
     ``plugin_validator.py`` — checks whether each registered command path is a
     directory containing a ``SKILL.md`` file.
 
-    **Fix:** Move the path from the ``commands`` array to the ``skills`` array
-    in ``plugin.json``:
+    **Fix (recommended, not required):** Move the path from the ``commands``
+    array to the ``skills`` array in ``plugin.json``:
 
     ```json
     {
@@ -499,18 +505,19 @@ def check_pr005(manifest: dict[str, YamlValue], plugin_dir: Path) -> list[Valida
         plugin_dir: Plugin directory containing ``.claude-plugin/plugin.json``.
 
     Returns:
-        One error per registered command path that is a directory containing a
-        ``SKILL.md``.
+        One info issue per registered command path that is a directory
+        containing a ``SKILL.md``.
 
     <!-- examples: PR005 -->
     """
     return [
         _make_issue(
             field="plugin.json",
-            severity="error",
+            severity="info",
             message=(
                 f"Registered command '{ref}' is a skill directory (contains SKILL.md). "
-                f"Skill directories must not be listed under 'commands'."
+                f"Consider listing it under 'skills' instead of 'commands' — skills support "
+                f"features (e.g. supporting files) that commands do not."
             ),
             code="PR005",
             suggestion=f"Move '{ref}' from the 'commands' array to the 'skills' array in plugin.json",

--- a/packages/skilllint/tests/test_plugin_registration_validator.py
+++ b/packages/skilllint/tests/test_plugin_registration_validator.py
@@ -7,6 +7,7 @@ Tests:
 - PR001 warning for unregistered agent (TestUnregisteredAgent)
 - PR001 warning for unregistered command (TestUnregisteredCommand)
 - PR002 error when registered path does not exist (TestMissingRegisteredFile)
+- PR005 info when a registered command path is a skill directory (TestCommandPathIsSkillDirectory)
 - No errors when all capabilities registered and files exist (TestFullyRegistered)
 - Empty plugin with no capabilities passes (TestEmptyPlugin)
 - PR003 info when metadata fields absent from plugin.json (TestMissingMetadata)
@@ -647,6 +648,94 @@ class TestMissingRegisteredFile:
         pr002_errors = [e for e in result.errors if e.code == "PR002"]
         assert len(pr002_errors) >= 1
         assert all(e.suggestion is not None for e in pr002_errors)
+
+
+class TestCommandPathIsSkillDirectory:
+    """Test PR005 info issue when a registered command path is a skill directory.
+
+    PR005 downgraded from error to info per issue #195: code.claude.com/docs/en/
+    plugins-reference documents 'commands' as accepting directories (not just
+    flat .md files), so this configuration is valid, not load-blocking -- it
+    only forgoes skill-only features that code.claude.com/docs/en/skills
+    describes as the reason skills are recommended over commands.
+    """
+
+    def test_command_path_that_is_skill_directory_produces_pr005_info(self, tmp_path: Path) -> None:
+        """Test PR005 info issue for a command path that is a SKILL.md directory.
+
+        Tests: PR005 detection and severity (check_pr005 in pr_series.py)
+        How: Register a directory containing SKILL.md under 'commands', validate
+        Why: PR005 must still detect this configuration, now as a recommendation
+        """
+        plugin_dir = _make_plugin(
+            tmp_path,
+            plugin_json_content=msgspec.json.encode({
+                "name": "test-plugin",
+                "commands": ["./commands/embedded-skill/"],
+            }).decode(),
+        )
+        skill_dir = plugin_dir / "commands" / "embedded-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: embedded-skill\n---\n\n# embedded-skill\n")
+
+        validator = PluginRegistrationValidator()
+        result = validator.validate(plugin_dir)
+
+        pr005_info = [i for i in result.info if i.code == "PR005"]
+        assert len(pr005_info) >= 1
+        assert not any(i.code == "PR005" for i in result.errors)
+        assert not any(i.code == "PR005" for i in result.warnings)
+
+    def test_pr005_does_not_fail_validation(self, tmp_path: Path) -> None:
+        """Test PR005 alone does not fail validation (result.passed stays True).
+
+        Tests: PR005 severity is info, not error
+        How: Register a skill directory under 'commands' with no other issues, validate
+        Why: An info-severity rule must not flip result.passed to False
+        """
+        plugin_dir = _make_plugin(
+            tmp_path,
+            plugin_json_content=msgspec.json.encode({
+                "name": "test-plugin",
+                "commands": ["./commands/embedded-skill/"],
+            }).decode(),
+        )
+        skill_dir = plugin_dir / "commands" / "embedded-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: embedded-skill\n---\n\n# embedded-skill\n")
+
+        validator = PluginRegistrationValidator()
+        result = validator.validate(plugin_dir)
+
+        assert result.passed is True
+
+    def test_pr005_message_does_not_claim_it_may_prevent_loading(self, tmp_path: Path) -> None:
+        """Test PR005's message no longer contains the unsourced load-blocking claim.
+
+        Tests: PR005 message content after issue #195's rewrite
+        How: Trigger PR005, inspect the message text
+        Why: The prior message claimed the config "may prevent the skill from
+            loading" with no vendor-doc citation backing that claim; issue #195
+            required removing it, not softening it
+        """
+        plugin_dir = _make_plugin(
+            tmp_path,
+            plugin_json_content=msgspec.json.encode({
+                "name": "test-plugin",
+                "commands": ["./commands/embedded-skill/"],
+            }).decode(),
+        )
+        skill_dir = plugin_dir / "commands" / "embedded-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: embedded-skill\n---\n\n# embedded-skill\n")
+
+        validator = PluginRegistrationValidator()
+        result = validator.validate(plugin_dir)
+
+        pr005_info = [i for i in result.info if i.code == "PR005"]
+        assert len(pr005_info) >= 1
+        assert not any("may prevent the skill from loading" in i.message for i in pr005_info)
+        assert not any("must not be listed" in i.message for i in pr005_info)
 
 
 class TestFullyRegistered:

--- a/plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md
+++ b/plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md
@@ -175,7 +175,7 @@ Validate `plugin.json` capability registration (skills, agents, commands arrays)
 | PR002 | error | no | Registered capability path does not exist on the filesystem |
 | PR003 | info | no | Plugin metadata fields not populated (`repository`, `homepage`, `author`) |
 | PR004 | warning | no | Plugin metadata repository URL mismatches git remote URL |
-| PR005 | error | no | Registered command path is a skill directory (contains `SKILL.md`) |
+| PR005 | info | no | Registered command path is a skill directory (contains `SKILL.md`) |
 
 ---
 


### PR DESCRIPTION
## Summary

PR005 (`packages/skilllint/rules/pr_series.py`) flagged a `SKILL.md`-bearing
directory registered under a plugin's `commands` field as an **error**, with
two problems:

1. Its `authority` field was a placeholder (`github.com/jamie-bitflight/claude_skills`, no `reference`) — not a real citation.
2. Its docstring claimed the configuration "may prevent the skill from loading," with no source backing that claim.

Issue #195 also raised whether the underlying check is even correct, since the vendor docs describe `commands` as accepting directories, not just flat files.

## What changed

- **Severity:** `error` → `info`. This is a style recommendation, not a load-blocking problem.
- **Message:** rewritten as a recommendation ("Consider listing it under 'skills' instead of 'commands' — skills support features … that commands do not"); the unsourced "may prevent the skill from loading" claim is deleted, not softened.
- **Authority:** replaced the placeholder with a real citation — `origin="code.claude.com"`, `reference="https://code.claude.com/docs/en/plugins-reference.md#component-path-fields"`. PR005 was the last rule in `RULE_REGISTRY` carrying the placeholder; the registry now has zero rules with it (`uv run python -c "..."` prints `[]`).
- **Bug fix:** `PluginRegistrationValidator.validate` in `plugin_validator.py` hardcoded `errors.extend(check_pr005(...))` regardless of the rule's declared severity. Downgrading the decorator's `severity=` alone would have had no effect — a PR005 finding would still have failed validation. Fixed to `info.extend(...)`, matching how PR003 (also `info`) is wired.
- **Docs:** updated PR005's row in `pr_series.py`'s module-level severity table and in `plugins/agentskills-skilllint/skills/skilllint/references/rule-catalog.md` (the latter is asserted against the live registry by `test_rule_catalog_doc.py`).
- **Tests:** added `TestCommandPathIsSkillDirectory` to `packages/skilllint/tests/test_plugin_registration_validator.py` — no prior test exercised PR005 at all. Covers: the info issue still fires, it lands in `result.info` (not `errors`/`warnings`), `result.passed` stays `True`, and the deleted claim is absent from the message.

## What I confirmed vs. could not confirm from the vendor doc

Read `.claude/vendor/sources/plugins-reference-2026-09-06-0921.md` and `.claude/vendor/sources/skills-2026-09-06-0439.md` via `skilllint docs` (the `docs sections`/`docs section` subcommands returned no matches against this doc's heading format, so I fell back to reading it directly on disk — same offline cache, no WebFetch/network fetch).

**Confirmed:**
- `plugins-reference.md`, "Component path fields" table: `commands` accepts "Custom flat `.md` skill files **or directories**" — directories are documented, valid input, not just flat files.
- `skills.md`: "Custom commands have been merged into skills… Skills are recommended since they support additional features like supporting files" — this documents *why* skills are preferred, not that a `SKILL.md` directory under `commands` is invalid or unsupported.

**Not confirmed (left as info-only, not auto-fixed or removed):**
- No section in either cached doc explicitly discusses a `SKILL.md`-bearing *directory* being registered specifically under the plugin manifest's `commands` array (as opposed to the general `.claude/commands/` project-level directory). I did not find text that either forbids or explicitly blesses that exact combination, so I did not go further than downgrading severity and fixing the citation — a full "is the underlying check even correct" verdict is out of scope here per the issue's own scope note.

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4