### PR TITLE
feat(RuleEntry): add client_load_behavior field for loads-anyway distinction

### DIFF
--- a/docs/maintainer-extension-guide.md
+++ b/docs/maintainer-extension-guide.md
@@ -367,6 +367,37 @@ class RuleAuthority:
     reference: str | None = None  # URL or doc path
 ```
 
+### Client Load Behavior
+
+`RuleEntry.client_load_behavior` is a separate, optional field recording what a
+real Claude Code / agent-skill client actually *does* at load time for a
+rule's finding — `"warn-and-load"` (the client logs a warning and loads the
+skill anyway) or `"skip-skill"` (the client refuses to load the skill). It is
+distinct from `authority`: `authority` says where a constraint comes from,
+`client_load_behavior` says what happens when a client encounters a
+violation of it.
+
+Set it only when the client-implementation guide
+(`https://agentskills.io/client-implementation/adding-skills-support#lenient-validation`)
+is explicit about client behavior for that exact check. Pass it as a keyword
+argument to `@skilllint_rule`, the same way as `authority`:
+
+```python
+@skilllint_rule(
+    "FM010",
+    severity="error",
+    category="frontmatter",
+    client_load_behavior="warn-and-load",
+)
+```
+
+It defaults to `None` — "the guide does not say" — matching how `authority`
+defaults to `None` for "no external reference." There is no third literal
+member for "unknown"; `None` already covers it. Most rules will leave this
+unset: only classify a rule when the guide states the client's behavior for
+the specific branch the rule checks, and note any branch-granularity gap
+(a rule checking more than the guide classifies) in the rule's docstring.
+
 ### In Violation Dicts
 
 Rules can include authority directly in violation outputs:

--- a/packages/skilllint/rule_registry.py
+++ b/packages/skilllint/rule_registry.py
@@ -31,7 +31,7 @@ from urllib.parse import urljoin
 
 from pydantic import BaseModel, Field
 
-from skilllint.rules._constants import RuleCategory, RulePlatform
+from skilllint.rules._constants import ClientLoadBehavior, RuleCategory, RulePlatform
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -105,6 +105,7 @@ class RuleEntry(BaseModel):
     platforms: list[RulePlatform]  # ["agentskills"] = all platforms, or specific like ["claude-code"]
     docstring: str
     authority: RuleAuthority | None = None
+    client_load_behavior: ClientLoadBehavior | None = None
 
 
 # Global registry: rule ID → RuleEntry
@@ -125,6 +126,7 @@ def skilllint_rule(
     category: RuleCategory,
     platforms: list[RulePlatform] | None = None,
     authority: dict | None = None,
+    client_load_behavior: ClientLoadBehavior | None = None,
 ) -> Callable[[Callable], Callable]:
     """Decorator to register a validator function as a rule.
 
@@ -136,6 +138,10 @@ def skilllint_rule(
                    Defaults to ["agentskills"].
         authority: Optional authority metadata dict with 'origin' and optional 'reference' keys.
                    Converted to RuleAuthority dataclass.
+        client_load_behavior: Optional declarative record of what a real client does for this
+                   rule's finding ("warn-and-load" or "skip-skill"), per the client-implementation
+                   guide. Defaults to None when the guide does not say, mirroring authority's
+                   None-means-unstated semantics.
 
     Returns:
         Decorated function (unchanged) that's registered in RULE_REGISTRY.
@@ -170,6 +176,7 @@ def skilllint_rule(
             platforms=platforms,
             docstring=fn.__doc__ or f"Rule {rule_id}",
             authority=rule_authority,
+            client_load_behavior=client_load_behavior,
         )
         RULE_REGISTRY[rule_id.upper()] = entry
         return fn

--- a/packages/skilllint/rules/_constants.py
+++ b/packages/skilllint/rules/_constants.py
@@ -28,6 +28,16 @@ RuleCategory = Literal[
 # platforms= and take the @skilllint_rule decorator's ["agentskills"] default.
 RulePlatform = Literal["agentskills", "claude-code", "codex", "cursor"]
 
+# Live value space of RuleEntry.client_load_behavior. Populated only when the
+# client-implementation guide is explicit about what a real client does for a
+# rule's finding — "warn-and-load" (validation is lenient; the client logs a
+# warning and loads the skill anyway) or "skip-skill" (the client refuses to
+# load the skill and logs an error). None (the RuleEntry default) means the
+# guide does not say, mirroring RuleEntry.authority's None-means-unstated
+# semantics rather than adding a separate "unknown" member.
+# Source: https://agentskills.io/client-implementation/adding-skills-support#lenient-validation
+ClientLoadBehavior = Literal["warn-and-load", "skip-skill"]
+
 # Full set of expected series prefixes: the 14 series from P038 plus the AG
 # agent-frontmatter series added for issue #132.
 # CM001 is scoped out — reserved, no validator logic (P038 architect spec §9).

--- a/packages/skilllint/rules/fm_series.py
+++ b/packages/skilllint/rules/fm_series.py
@@ -102,6 +102,9 @@ def _make_issue(
     # docstring that `skilllint rule <CODE>` renders, and claim-level provenance
     # lives in schemas/provenance-registry.json.
     authority={"origin": "anthropic.com"},
+    # Only the missing/empty-description branch matches the guide's classified
+    # behavior — see the "Client behaviour" docstring paragraph below.
+    client_load_behavior="skip-skill",
 )
 def check_fm001(frontmatter: dict, path: Path, file_type: str) -> list[ValidationIssue]:
     """## FM001 — Missing required field
@@ -119,6 +122,16 @@ def check_fm001(frontmatter: dict, path: Path, file_type: str) -> list[Validatio
     "description — Required: Recommended"
 
     **Fix:** Add the missing `name` and/or `description` field to the frontmatter.
+
+    **Client behaviour:** the client-implementation guide's lenient-validation
+    bullets cover only the missing/empty-**description** branch of this rule:
+    "Description is missing or empty → skip the skill (a description is
+    essential for disclosure), log the error"
+    (https://agentskills.io/client-implementation/adding-skills-support#lenient-validation).
+    FM001 also fires on a missing `name` and on agent files (where both fields
+    are error-severity, not warning) — the guide does not classify those
+    branches, so `client_load_behavior` describes only the description branch,
+    not everything this rule checks.
 
     Returns:
         List of ValidationIssue objects, one per missing field; empty when both
@@ -169,6 +182,7 @@ def check_fm001(frontmatter: dict, path: Path, file_type: str) -> list[Validatio
     category="frontmatter",
     platforms=["agentskills"],
     authority={"origin": "anthropic.com", "reference": _SKILLS_SPEC_URL},
+    client_load_behavior="skip-skill",
 )
 def check_fm002(frontmatter: dict, path: Path, file_type: str) -> list[ValidationIssue]:
     """## FM002 — Invalid YAML syntax
@@ -183,6 +197,13 @@ def check_fm002(frontmatter: dict, path: Path, file_type: str) -> list[Validatio
     **Fix:** Correct the YAML syntax in the frontmatter block. Common causes
     are unquoted colons in values (e.g. `description: Foo: bar` — quote it
     as `description: "Foo: bar"`).
+
+    **Client behaviour:** the client-implementation guide's lenient-validation
+    bullets state: "YAML is completely unparseable → skip the skill, log the
+    error"
+    (https://agentskills.io/client-implementation/adding-skills-support#lenient-validation). FM002 fires
+    on exactly that condition — completely unparseable frontmatter YAML — so
+    this classification covers the whole of what FM002 checks.
 
     Returns:
         Always an empty list. FM002 is emitted by the YAML parsing layer in
@@ -485,6 +506,10 @@ def check_fm009(frontmatter: dict, path: Path, file_type: str) -> list[Validatio
     # docstring that `skilllint rule <CODE>` renders, and claim-level provenance
     # lives in schemas/provenance-registry.json.
     authority={"origin": "anthropic.com"},
+    # Only 2 of FM010's 4 branches (directory mismatch, >64 chars) match the
+    # guide's classified behavior — see the "Client behaviour" docstring
+    # paragraph below. Charset and consecutive-hyphen branches are unclassified.
+    client_load_behavior="warn-and-load",
 )
 def check_fm010(frontmatter: dict, path: Path, file_type: str) -> list[ValidationIssue]:
     """## FM010 — Name field does not match directory name or violates naming pattern
@@ -502,6 +527,16 @@ def check_fm010(frontmatter: dict, path: Path, file_type: str) -> list[Validatio
 
     **Fix:** Set `name` to match the parent directory name, using only lowercase
     letters, digits, and hyphens.
+
+    **Client behaviour:** the client-implementation guide's lenient-validation
+    bullets classify two of FM010's four branches:
+    "Name doesn't match the parent directory name → warn, load anyway" and
+    "Name exceeds 64 characters → warn, load anyway"
+    (https://agentskills.io/client-implementation/adding-skills-support#lenient-validation).
+    FM010 also fires on a disallowed character set and on consecutive hyphens
+    — branches the guide's bullets do not enumerate — so `client_load_behavior`
+    describes only the directory-mismatch and length branches, not everything
+    this rule checks.
 
     Returns:
         List of error issues describing pattern violations or a directory-name

--- a/packages/skilllint/tests/test_client_load_behavior.py
+++ b/packages/skilllint/tests/test_client_load_behavior.py
@@ -1,0 +1,58 @@
+"""Tests for the ``client_load_behavior`` field on ``RuleEntry``.
+
+This field records what a real Claude Code / agent-skill client actually does
+for a rule's finding, per the client-implementation guide's "Lenient
+validation" section
+(https://agentskills.io/client-implementation/adding-skills-support#lenient-validation).
+It is purely additive metadata: ``None`` means the guide does not say,
+matching how ``RuleEntry.authority`` already works. See PR 10 in
+`.claude/plans/what-needs-to-happen-functional-bumblebee.md`.
+"""
+
+from __future__ import annotations
+
+import skilllint.rules  # noqa: F401 — registers every rule via import side effects
+from skilllint.rule_registry import RuleEntry, list_rules, skilllint_rule
+
+
+def test_rule_entry_client_load_behavior_defaults_to_none() -> None:
+    """A RuleEntry built without client_load_behavior leaves it unset (None)."""
+    entry = RuleEntry(id="ZZ001", severity="info", category="skill", platforms=["agentskills"], docstring="Rule ZZ001")
+
+    assert entry.client_load_behavior is None
+
+
+def test_skilllint_rule_decorator_threads_client_load_behavior_kwarg() -> None:
+    """The @skilllint_rule decorator accepts and stores client_load_behavior."""
+    from skilllint.rule_registry import RULE_REGISTRY
+
+    original = dict(RULE_REGISTRY)
+    try:
+
+        @skilllint_rule("ZZ002", severity="info", category="skill", client_load_behavior="skip-skill")
+        def _fake_rule() -> list:  # pragma: no cover — never invoked
+            """Fake rule for decorator threading test."""
+            return []
+
+        assert RULE_REGISTRY["ZZ002"].client_load_behavior == "skip-skill"
+    finally:
+        RULE_REGISTRY.clear()
+        RULE_REGISTRY.update(original)
+
+
+def test_exactly_fm001_fm002_fm010_are_classified() -> None:
+    """Pin the exact classified set so a future session cannot silently add a fourth.
+
+    Per the client-implementation guide's "Lenient validation" bullets:
+      - FM001 (missing/empty description branch) -> "skip-skill"
+      - FM002 (unparseable YAML) -> "skip-skill"
+      - FM010 (name/directory mismatch and >64 chars branches) -> "warn-and-load"
+
+    Every other rule in the registry must stay unset (None) — this is not
+    exhaustive of everything each rule checks, only the branches the guide is
+    explicit about. See each rule's "Client behaviour" docstring paragraph for
+    the branch-granularity caveat.
+    """
+    classified = sorted((r.id, r.client_load_behavior) for r in list_rules() if r.client_load_behavior)
+
+    assert classified == [("FM001", "skip-skill"), ("FM002", "skip-skill"), ("FM010", "warn-and-load")]


### PR DESCRIPTION
## Summary

Adds a purely additive `client_load_behavior` field to `RuleEntry` recording what a real Claude Code / agent-skill client actually does for a rule's finding, per the client-implementation guide's "Lenient validation" section (`https://agentskills.io/client-implementation/adding-skills-support#lenient-validation`).

- New `ClientLoadBehavior = Literal["warn-and-load", "skip-skill"]` in `packages/skilllint/rules/_constants.py`, matching the existing `RuleCategory`/`RulePlatform` precedent.
- `RuleEntry.client_load_behavior: ClientLoadBehavior | None = None`, placed immediately after `authority`, with the same `None`-means-"the guide does not say" semantics as `authority`. No third "unknown" literal member.
- `@skilllint_rule(...)` threads it through as a new keyword-only parameter, defaulting to `None`.
- Documented in `docs/maintainer-extension-guide.md` alongside the existing `authority` field docs.

**This classifies exactly 3 rule IDs, not 4** — the guide's lenient-validation bullets contain four statements, but two of them (name/directory mismatch, name > 64 chars) both belong to FM010, collapsing to one classified rule:

| Rule | `client_load_behavior` | Guide bullet |
|---|---|---|
| FM001 | `skip-skill` | "Description is missing or empty → skip the skill (a description is essential for disclosure), log the error" |
| FM002 | `skip-skill` | "YAML is completely unparseable → skip the skill, log the error" |
| FM010 | `warn-and-load` | "Name doesn't match the parent directory name → warn, load anyway" **and** "Name exceeds 64 characters → warn, load anyway" |

Every other rule in the registry stays unset (`None`).

## Known limitation — branch granularity

**FM001 and FM010 each fire on more branches than the guide's classification covers.** This is a real limitation of the design, not an implementation detail:

- **FM001** also fires on a missing `name` field and on agent files (where both fields are error-severity, not warning) — the guide only classifies the missing/empty-**description** branch.
- **FM010** also fires on a disallowed character set and on consecutive hyphens — the guide only classifies the directory-mismatch and >64-character branches (2 of FM010's 4 branches).

A reader must not read "this rule has a `client_load_behavior`" as "everything this rule flags matches that behavior." Each classified rule's docstring now carries a "Client behaviour" paragraph stating exactly which branch(es) the classification covers, quoting the guide bullet, and citing the guide URL — enforced by the pinned test below, not just documentation.

## Explicitly out of scope (unchanged)

- No severity changes to any rule, anywhere.
- No new rule IDs, no splitting FM001/FM010.
- No `--format json` or any new reporter/CLI surface — `skilllint rule <ID>` already renders `entry.docstring`, so the new docstring paragraphs are automatically surfaced with zero new plumbing.
- No column added to the `skilllint rules` summary table.
- No changes to `rule-catalog.md`'s columns.

## Test plan

- [x] `uv run pytest packages/skilllint/tests/test_client_load_behavior.py -v` — new tests, written first and confirmed failing (`AttributeError`/`TypeError`) before implementation, now pass
- [x] `uv run pytest packages/skilllint/tests/test_rule_registry.py packages/skilllint/tests/test_rule_truth.py packages/skilllint/tests/test_rules_completeness.py packages/skilllint/tests/test_rule_catalog_doc.py -v` — 28 passed
- [x] `uv run pytest` — 1545 passed, 10 skipped
- [x] `uv run prek run --all-files` — all hooks passed
- [x] `uv run skilllint rules | head -5` — unchanged 4-column table
- [x] `uv run skilllint rule FM010` — panel now contains a "Client behaviour" paragraph mentioning "warn, load anyway" and the guide URL
- [x] `uv run skilllint rule FM004` — no such paragraph (unclassified rule, unchanged)
- [x] FM010 regression check against `main` — byte-for-byte identical output for the same fixture (`'name' field value 'totally-different' does not match directory name 'my-skill'`)
- [x] Manual classified-set print matches exactly: `[('FM001', 'skip-skill'), ('FM002', 'skip-skill'), ('FM010', 'warn-and-load')]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4
