### PR TITLE
fix(vendor-io): redirect VENDOR_DIR to primary checkout inside linked worktrees

### DIFF
--- a/docs/vendor-cache-reference.md
+++ b/docs/vendor-cache-reference.md
@@ -678,7 +678,9 @@ Vendor documentation directory inside `.claude/`.
 
 **Type**: `Path`
 
-**Value**: `{PROJECT_ROOT} / ".claude" / "vendor"`
+**Value**: `_shared_checkout_root(PROJECT_ROOT) / ".claude" / "vendor"`
+
+Redirected to the primary checkout root when running inside a linked git worktree (`git worktree add`), so the gitignored cache is shared instead of duplicated — and silently invisible — per worktree. A plain (non-worktree) checkout is unaffected: `_shared_checkout_root` returns `PROJECT_ROOT` unchanged.
 
 **Usage**
 
@@ -1007,7 +1009,7 @@ A file is considered stale when its age (time since `fetched_at` in the sidecar)
 
 **SOURCES_DIR**
 
-Default: `{PROJECT_ROOT} / ".claude" / "vendor" / "sources"`
+Default: `_shared_checkout_root(PROJECT_ROOT) / ".claude" / "vendor" / "sources"` (see VENDOR_DIR above)
 
 The constant is defined in `skilllint.vendor_io.SOURCES_DIR` and cannot be reconfigured via environment variables or config files. To use a different directory, pass `sources_dir` to `find_latest()` or create cached files manually in the desired location.
 

--- a/packages/skilllint/tests/test_vendor_io.py
+++ b/packages/skilllint/tests/test_vendor_io.py
@@ -7,9 +7,11 @@ Tests:
 - Sidecar: write_sidecar, load_sidecar
 - Timestamp: utc_now_iso
 - Directory constants: PROJECT_ROOT, VENDOR_DIR, SOURCES_DIR
+- Worktree detection: _shared_checkout_root
 
 How: Unit tests with tmp_path for file operations, mocker.patch for httpx,
-     known-input/known-output checks for hash functions.
+     known-input/known-output checks for hash functions, real `git init` /
+     `git worktree add` subprocess calls for worktree-detection tests.
 Why: vendor_io is the foundation layer used by all vendor documentation scripts;
      correctness here is required for cache integrity and offline-first behaviour.
 """
@@ -18,7 +20,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import subprocess
 from datetime import datetime
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import httpx
@@ -28,6 +32,7 @@ from skilllint.vendor_io import (
     PROJECT_ROOT,
     SOURCES_DIR,
     VENDOR_DIR,
+    _shared_checkout_root,
     fetch_url_text,
     load_json_or_none,
     load_sidecar,
@@ -40,8 +45,6 @@ from skilllint.vendor_io import (
 )
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from pytest_mock import MockerFixture
 
 # ---------------------------------------------------------------------------
@@ -698,16 +701,20 @@ class TestDirectoryConstants:
         # Arrange / Act / Assert
         assert (PROJECT_ROOT / "pyproject.toml").exists()
 
-    def test_vendor_dir_is_under_project_root_claude(self) -> None:
-        """VENDOR_DIR is PROJECT_ROOT / '.claude' / 'vendor'.
+    def test_vendor_dir_is_shared_checkout_root_claude_vendor(self) -> None:
+        """VENDOR_DIR is _shared_checkout_root(PROJECT_ROOT) / '.claude' / 'vendor'.
 
         Tests: VENDOR_DIR path derivation
-        How: Compare VENDOR_DIR against the expected composed path.
+        How: Compare VENDOR_DIR against the expected composed path, deriving the
+             base via _shared_checkout_root rather than assuming PROJECT_ROOT
+             directly — VENDOR_DIR is redirected to the primary checkout root
+             when running inside a linked git worktree (see issue #116).
         Why: Scripts must write into .claude/vendor; an incorrect constant
-             would scatter files elsewhere in the repo.
+             would scatter files elsewhere in the repo, or make a worktree's
+             cache invisible to the primary checkout and vice versa.
         """
         # Arrange / Act / Assert
-        assert VENDOR_DIR == PROJECT_ROOT / ".claude" / "vendor"
+        assert _shared_checkout_root(PROJECT_ROOT) / ".claude" / "vendor" == VENDOR_DIR
 
     def test_sources_dir_is_under_vendor_dir(self) -> None:
         """SOURCES_DIR is VENDOR_DIR / 'sources'.
@@ -719,3 +726,250 @@ class TestDirectoryConstants:
         """
         # Arrange / Act / Assert
         assert SOURCES_DIR == VENDOR_DIR / "sources"
+
+
+# ---------------------------------------------------------------------------
+# Worktree detection
+# ---------------------------------------------------------------------------
+
+
+def _run_git(args: list[str], *, cwd: Path) -> None:
+    """Run a git command, raising with captured output on failure.
+
+    Args:
+        args: Arguments to pass to ``git`` (excluding the ``git`` executable itself).
+        cwd: Working directory to run the command in.
+
+    Raises:
+        subprocess.CalledProcessError: If the git command exits non-zero.
+    """
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _init_repo_with_commit(repo_dir: Path) -> None:
+    """Create a git repository at *repo_dir* with a single commit.
+
+    Args:
+        repo_dir: Directory to initialise as a git repository. Must already exist.
+    """
+    _run_git(["init", "--initial-branch=main"], cwd=repo_dir)
+    _run_git(["config", "user.email", "test@example.com"], cwd=repo_dir)
+    _run_git(["config", "user.name", "Test"], cwd=repo_dir)
+    (repo_dir / "file.txt").write_text("content\n", encoding="utf-8")
+    _run_git(["add", "."], cwd=repo_dir)
+    _run_git(["commit", "-m", "initial commit"], cwd=repo_dir)
+
+
+class TestSharedCheckoutRoot:
+    """Tests for _shared_checkout_root — linked-worktree primary-checkout detection.
+
+    Uses real ``git init`` / ``git worktree add`` subprocess calls rather than
+    mocks, per the issue #116 fix requirement that detection be validated
+    against actual git-managed filesystem shapes, not simulated behaviour.
+    """
+
+    def test_non_git_directory_returns_start_unchanged(self, tmp_path: Path) -> None:
+        """A directory with no .git entry at all returns start unchanged.
+
+        Tests: _shared_checkout_root with no repository present
+        How: Pass a plain empty directory with no .git file or directory.
+        Why: An installed wheel with no .git anywhere above it must resolve
+             VENDOR_DIR under itself, not raise or require git.
+        """
+        # Arrange
+        plain_dir = tmp_path / "no_repo"
+        plain_dir.mkdir()
+
+        # Act
+        result = _shared_checkout_root(plain_dir)
+
+        # Assert
+        assert result == plain_dir
+
+    def test_plain_checkout_returns_start_unchanged(self, tmp_path: Path) -> None:
+        """A plain checkout (.git is a directory) returns start unchanged.
+
+        Tests: _shared_checkout_root with a plain (non-worktree) checkout
+        How: git init a real repository, assert the function returns its own root.
+        Why: The overwhelming majority of clones are plain checkouts; this must
+             be a complete no-op for them, preserving today's behaviour exactly.
+        """
+        # Arrange
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_repo_with_commit(repo)
+
+        # Act
+        result = _shared_checkout_root(repo)
+
+        # Assert
+        assert result == repo
+
+    def test_linked_worktree_returns_primary_checkout_root(self, tmp_path: Path) -> None:
+        """A linked worktree (git worktree add) resolves to the primary checkout root.
+
+        Tests: _shared_checkout_root with a real linked worktree
+        How: git init a repo with a commit, `git worktree add` a second working
+             tree, assert _shared_checkout_root(worktree) == primary repo root.
+        Why: This is the exact issue #116 scenario — a linked worktree's
+             gitignored .claude/vendor/ must resolve to the primary checkout's
+             cache, not its own empty directory.
+        """
+        # Arrange
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_repo_with_commit(repo)
+        worktree = tmp_path / "linked-worktree"
+        _run_git(["worktree", "add", str(worktree)], cwd=repo)
+
+        # Act
+        result = _shared_checkout_root(worktree)
+
+        # Assert
+        assert result == repo.resolve()
+
+    def test_submodule_shape_returns_start_unchanged(self, tmp_path: Path) -> None:
+        """A submodule's .git file (gitdir with no commondir) returns start unchanged.
+
+        Tests: _shared_checkout_root defensive fallback for the submodule shape
+        How: Construct the filesystem shape directly (a .git file pointing at a
+             gitdir that lacks a commondir file) — the same shape `git submodule
+             add` produces — rather than invoking `git submodule add`, whose
+             exact internal layout depends on git version and requires enabling
+             the file:// transport (CVE-2022-39253 mitigation) in CI.
+        Why: A submodule's .git file has no commondir, so it must be treated as
+             "not a linked worktree" and never redirected — confirmed as a
+             distinct case during design.
+        """
+        # Arrange
+        submodule_dir = tmp_path / "submodule"
+        submodule_gitdir = tmp_path / "parent" / ".git" / "modules" / "submodule"
+        submodule_gitdir.mkdir(parents=True)
+        submodule_dir.mkdir()
+        (submodule_dir / ".git").write_text(f"gitdir: {submodule_gitdir}\n", encoding="utf-8")
+        # No commondir file under submodule_gitdir — this is what distinguishes
+        # a submodule's gitdir from a linked worktree's gitdir.
+
+        # Act
+        result = _shared_checkout_root(submodule_dir)
+
+        # Assert
+        assert result == submodule_dir
+
+    def test_bare_repo_worktree_resolves_via_commondir(self, tmp_path: Path) -> None:
+        """A worktree attached to a bare repository resolves via its commondir.
+
+        Tests: _shared_checkout_root with a bare-repo-backed worktree
+        How: Create a bare repo, seed it with a commit via a throwaway clone,
+             then `git --git-dir=<bare> worktree add` a real working tree.
+        Why: Bare-repo worktree setups are a distinct topology from a linked
+             worktree off a normal checkout; the commondir-resolution algorithm
+             must handle both without special-casing.
+        """
+        # Arrange
+        bare = tmp_path / "repo.git"
+        _run_git(["init", "--bare", "--initial-branch=main", str(bare)], cwd=tmp_path)
+        seed = tmp_path / "seed"
+        seed.mkdir()
+        _run_git(["clone", str(bare), str(seed)], cwd=tmp_path)
+        _run_git(["config", "user.email", "test@example.com"], cwd=seed)
+        _run_git(["config", "user.name", "Test"], cwd=seed)
+        (seed / "file.txt").write_text("content\n", encoding="utf-8")
+        _run_git(["add", "."], cwd=seed)
+        _run_git(["commit", "-m", "initial commit"], cwd=seed)
+        _run_git(["push", "origin", "main"], cwd=seed)
+        bare_worktree = tmp_path / "bare-worktree"
+        _run_git(["--git-dir", str(bare), "worktree", "add", str(bare_worktree), "main"], cwd=tmp_path)
+
+        # Act
+        result = _shared_checkout_root(bare_worktree)
+
+        # Assert — the bare repo's directory has no working-tree parent of its
+        # own, so the resolved commondir's parent is the bare repo's *parent*
+        # directory. This is the algorithm's defined, deterministic behaviour
+        # for this topology, not a meaningful "primary checkout" in the
+        # linked-worktree sense.
+        assert result == bare.resolve().parent
+
+    def test_malformed_gitdir_content_returns_start_unchanged(self, tmp_path: Path) -> None:
+        """A .git file with unreadable/garbage gitdir content returns start unchanged.
+
+        Tests: _shared_checkout_root defensive fallback for malformed .git file
+        How: Write a .git file with content that doesn't match the "gitdir: "
+             prefix contract at all.
+        Why: Must never raise on a corrupt or foreign .git file; always falls
+             back to treating the directory as its own root.
+        """
+        # Arrange
+        weird_dir = tmp_path / "weird"
+        weird_dir.mkdir()
+        (weird_dir / ".git").write_text("not a gitdir pointer\n", encoding="utf-8")
+
+        # Act
+        result = _shared_checkout_root(weird_dir)
+
+        # Assert
+        assert result == weird_dir
+
+    def test_gitdir_pointing_nowhere_returns_start_unchanged(self, tmp_path: Path) -> None:
+        """A .git file pointing at a nonexistent gitdir returns start unchanged.
+
+        Tests: _shared_checkout_root defensive fallback for a dangling gitdir pointer
+        How: Write a .git file whose gitdir target directory doesn't exist,
+             so reading its commondir file fails.
+        Why: A dangling or stale worktree registration must never raise;
+             falls back to start.
+        """
+        # Arrange
+        dangling_dir = tmp_path / "dangling"
+        dangling_dir.mkdir()
+        (dangling_dir / ".git").write_text(f"gitdir: {tmp_path / 'nonexistent-gitdir'}\n", encoding="utf-8")
+
+        # Act
+        result = _shared_checkout_root(dangling_dir)
+
+        # Assert
+        assert result == dangling_dir
+
+
+# ---------------------------------------------------------------------------
+# Regression guard: PROJECT_ROOT must stay worktree-local
+# ---------------------------------------------------------------------------
+
+
+class TestProjectRootStaysWorktreeLocal:
+    """Regression guard for issue #116 point 1 — PROJECT_ROOT is never redirected.
+
+    Only VENDOR_DIR (and therefore SOURCES_DIR) is redirected to the primary
+    checkout root inside a linked worktree. PROJECT_ROOT itself must remain
+    worktree-local because scripts/fetch_spec_schema.py uses it to write
+    tracked source files (packages/skilllint/schemas/agentskills_io/ and
+    packages/skilllint/_spec_constants.py); redirecting it would make a
+    worktree run of that script silently overwrite generated source in a
+    different working tree than the one being edited.
+    """
+
+    def test_schema_dir_resolves_under_this_checkout_not_a_shared_one(self) -> None:
+        """fetch_spec_schema.SCHEMA_DIR resolves under this test's own repo root.
+
+        Tests: PROJECT_ROOT (and everything derived from it) is not passed
+               through _shared_checkout_root.
+        How: Compute this test file's own repo root independently of vendor_io
+             (by walking up from __file__), then assert SCHEMA_DIR and
+             PROJECT_ROOT both match it exactly. This test runs for real
+             inside a linked worktree in CI/dev — if PROJECT_ROOT were ever
+             redirected to a primary checkout, this assertion would fail
+             whenever a primary checkout with an existing cache exists
+             alongside the worktree running the tests.
+        Why: Guards against the exact wrong-implementation described in the
+             issue #116 design — redirecting PROJECT_ROOT instead of only
+             VENDOR_DIR.
+        """
+        # Arrange
+        from scripts.fetch_spec_schema import SCHEMA_DIR
+
+        this_checkout_root = Path(__file__).resolve().parents[3]
+
+        # Act / Assert
+        assert this_checkout_root == PROJECT_ROOT
+        assert this_checkout_root / "packages" / "skilllint" / "schemas" / "agentskills_io" == SCHEMA_DIR

--- a/packages/skilllint/vendor_io.py
+++ b/packages/skilllint/vendor_io.py
@@ -9,8 +9,8 @@ It is imported by scripts that fetch, cache, and compare external documentation:
 
 Public API:
   Constants:
-    PROJECT_ROOT -- absolute path to the repository root
-    VENDOR_DIR   -- PROJECT_ROOT / ".claude" / "vendor"
+    PROJECT_ROOT -- absolute path to the repository root (worktree-local)
+    VENDOR_DIR   -- _shared_checkout_root(PROJECT_ROOT) / ".claude" / "vendor"
     SOURCES_DIR  -- VENDOR_DIR / "sources"
 
   Functions:
@@ -47,10 +47,89 @@ import httpx
 #:   .parent                → packages/skilllint/
 #:   .parent.parent         → packages/
 #:   .parent.parent.parent  → repo root (contains pyproject.toml)
+#: This stays worktree-local by design: scripts/fetch_spec_schema.py uses it
+#: to write tracked source files, and those must land in the worktree the
+#: agent is actually operating in, not a sibling checkout.
 PROJECT_ROOT: Path = Path(__file__).resolve().parent.parent.parent
 
+
+def _read_git_internal_file_or_none(path: Path) -> str | None:
+    """Read a git-internal metadata file (``.git``, ``commondir``), stripped.
+
+    Args:
+        path: Path to the git-internal file to read.
+
+    Returns:
+        Stripped file content, or None if the file is missing, unreadable,
+        or otherwise inaccessible (permission error, is a directory, etc.).
+    """
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+
+
+def _shared_checkout_root(start: Path) -> Path:
+    """Return the primary checkout root when *start* sits inside a linked git worktree.
+
+    A plain checkout has ``.git`` as a directory; a linked worktree (created by
+    ``git worktree add``) has ``.git`` as a *file* containing a ``gitdir:``
+    pointer into the primary checkout's ``.git/worktrees/<name>/`` directory,
+    which in turn holds a ``commondir`` file pointing back at the shared
+    ``.git`` directory. Resolving that chain yields the primary checkout root,
+    which is where a gitignored cache directory (e.g. ``.claude/vendor/``)
+    actually lives and is shared across all worktrees.
+
+    Detection here is pure filesystem inspection — no ``git`` subprocess call.
+    This function runs at ``skilllint`` package import time, so a subprocess
+    round-trip would tax every CLI invocation, and it would also require
+    ``git`` on PATH, which an installed wheel's consumer may not have.
+
+    Args:
+        start: Directory to inspect (typically ``PROJECT_ROOT``).
+
+    Returns:
+        The primary checkout root if *start* is a linked worktree with a
+        resolvable ``commondir``; otherwise *start* unchanged. Never raises —
+        any missing, unreadable, or malformed git-internal file (including
+        the submodule case, where ``.git`` is a file but its gitdir has no
+        ``commondir``) is treated as "not a linked worktree" and falls back
+        to *start*.
+    """
+    git_entry = start / ".git"
+    if not git_entry.is_file():
+        return start
+
+    gitdir_line = _read_git_internal_file_or_none(git_entry)
+    prefix = "gitdir: "
+    if gitdir_line is None or not gitdir_line.startswith(prefix):
+        return start
+
+    gitdir_path = Path(gitdir_line[len(prefix) :].strip())
+    if not gitdir_path.is_absolute():
+        gitdir_path = start / gitdir_path
+
+    commondir_line = _read_git_internal_file_or_none(gitdir_path / "commondir")
+    if not commondir_line:
+        return start
+
+    commondir_path = Path(commondir_line)
+    if not commondir_path.is_absolute():
+        commondir_path = gitdir_path / commondir_path
+
+    try:
+        resolved_git_dir = commondir_path.resolve(strict=True)
+    except OSError:
+        return start
+
+    return resolved_git_dir.parent
+
+
 #: Vendor documentation directory inside .claude/.
-VENDOR_DIR: Path = PROJECT_ROOT / ".claude" / "vendor"
+#: Redirected to the primary checkout when running inside a linked git
+#: worktree, so the gitignored cache is shared instead of duplicated
+#: (and silently invisible) per worktree. See _shared_checkout_root.
+VENDOR_DIR: Path = _shared_checkout_root(PROJECT_ROOT) / ".claude" / "vendor"
 
 #: Per-source cached documents directory.
 SOURCES_DIR: Path = VENDOR_DIR / "sources"


### PR DESCRIPTION
## Summary

- `.claude/vendor/` is gitignored, so `VENDOR_DIR` (derived from `PROJECT_ROOT`, which resolves worktree-local via `__file__`) pointed at an empty directory inside every linked git worktree — the documented "fetch to disk, then read from disk" agent workflow (`AGENTS.md` § Vendor documentation cache) silently found nothing, and a fresh fetch would land worktree-local and never be found on the next lookup either.
- Adds `_shared_checkout_root()` in `packages/skilllint/vendor_io.py`: pure filesystem inspection (no `git` subprocess — this module is imported at package-import time) that resolves a linked worktree's `.git` file → `gitdir:` pointer → `commondir` file, back to the primary checkout root. Falls back to the input path unchanged for plain checkouts, submodules (gitdir with no `commondir`), and any missing/unreadable/malformed git-internal file.
- `VENDOR_DIR` (and therefore `SOURCES_DIR`) is redirected through this helper for both reads and writes, since every consumer (`vendor_cache.py`, `scripts/fetch_platform_docs.py`, the `skilllint docs` CLI) derives its paths from that one constant.
- `PROJECT_ROOT` is deliberately left untouched — `scripts/fetch_spec_schema.py` uses it to write tracked source files (`packages/skilllint/schemas/agentskills_io/`, `packages/skilllint/_spec_constants.py`) that must land in the worktree actually being edited, not a sibling checkout.

Closes #116

## Test plan

- [x] TDD: added tests to `packages/skilllint/tests/test_vendor_io.py` — RED confirmed against the pre-fix module (`ImportError: cannot import name '_shared_checkout_root'`), GREEN after the fix (42/42 passed).
- [x] New `TestSharedCheckoutRoot` class uses real `git init` / `git worktree add` subprocess calls (no mocks) covering: non-git directory, plain checkout, linked worktree, submodule shape (constructed filesystem layout — `git submodule add` needs `protocol.file.allow` and version-dependent internals), bare-repo-backed worktree, malformed `.git` content, and a dangling `gitdir:` pointer.
- [x] Regression guard `TestProjectRootStaysWorktreeLocal` proves `fetch_spec_schema.SCHEMA_DIR` still resolves under the running worktree, guarding against the dangerous alternative (redirecting `PROJECT_ROOT` instead of only `VENDOR_DIR`).
- [x] `uv run prek run --all-files` — clean.
- [x] `uv run pytest` — 1556 passed, 10 skipped (pre-existing).
- [x] Real end-to-end behavioral validation via a second `git worktree add` into a scratch tmp location:
  - Scratch worktree's `.claude/vendor/sources/` confirmed absent before any fetch.
  - `skilllint docs latest claude-code--skills` from inside the scratch worktree found the primary checkout's existing cached file (exit 0, correct path printed) — read redirect confirmed.
  - `skilllint docs fetch https://docs.claude.com/en/docs/claude-code/settings.md` from inside the scratch worktree landed the new file in the **primary checkout's** `.claude/vendor/sources/`, not the scratch worktree's own — write redirect confirmed.
  - Scratch worktree's own `.claude/vendor/` confirmed to contain only the tracked `CLAUDE.md`, no new writes.
  - From the **primary checkout itself**, `skilllint docs latest claude-code--skills` produced byte-identical output to the scratch-worktree run — the non-worktree (plain checkout) case is unaffected.
  - Scratch worktree removed (`git worktree remove --force`).

## Documented gap

Per the issue's TDD requirement, the submodule and bare-repo-worktree shapes are covered, but the submodule test constructs the filesystem shape directly (`.git` file + gitdir with no `commondir`) rather than invoking `git submodule add`, since that command's exact internal layout is git-version-dependent and requires enabling the `file://` transport (CVE-2022-39253 mitigation) in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4