### PR TITLE
fix(PL006): downgrade unrecognized root keys to warning, make severity tunable

### DIFF
--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -672,9 +672,10 @@ class ValidationPolicy:
 DEFAULT_THRESHOLDS: dict[str, int] = {"SK006": TOKEN_WARNING_THRESHOLD, "SK007": TOKEN_ERROR_THRESHOLD}
 # Threshold keys must map to an implemented warning/error band.
 _THRESHOLD_POLICY_RULES = frozenset({"SK006", "SK007"})
-# Severity may be reconfigured for the token-band rules. AS005 shared this band
-# and was listed here until it was retired into SK006/SK007.
-_SEVERITY_POLICY_RULES = frozenset({"SK006", "SK007"})
+# Severity may be reconfigured for the token-band rules (SK006/SK007) and for
+# PL006's marketplace.json root-key check (see issue #145). AS005 shared this
+# band and was listed here until it was retired into SK006/SK007.
+_SEVERITY_POLICY_RULES = frozenset({"PL006", "SK006", "SK007"})
 _VALID_SEVERITIES = frozenset({"warning", "info"})
 
 _SKILLLINT_CONFIG_FILENAME = ".skilllint.json"
@@ -831,7 +832,9 @@ def _resolve_ignore_config(
     """Resolve the ignore config for *path*, walking up the directory tree.
 
     Checks the cache first (keyed by resolved directory path string). If not
-    cached, walks up from ``path.parent`` looking for:
+    cached, walks up from ``path`` itself when *path* is already a directory
+    (e.g. a plugin root passed directly by ``FileType.PLUGIN`` validation) or
+    from ``path.parent`` when *path* is a file, looking for:
 
     - ``.claude-plugin/plugin.json`` → loads from ``.claude-plugin/validator.json``
       via :func:`_load_ignore_config`.
@@ -851,7 +854,7 @@ def _resolve_ignore_config(
         that contained the config file, used as the base for relative-path
         prefix matching. Both values are empty / ``None`` when nothing is found.
     """
-    start_dir = path.parent.resolve()
+    start_dir = (path if path.is_dir() else path.parent).resolve()
     cache_key = str(start_dir)
     if cache_key in cache:
         return cache[cache_key]
@@ -896,12 +899,15 @@ def _resolve_policy(
 
     Diagnostics for invalid config are emitted once per config file: they fire
     only on a cache miss (the first file that resolves a given config), so a
-    1000-file scan warns once, not once per file.
+    1000-file scan warns once, not once per file. Walks up from ``path``
+    itself when *path* is already a directory (a plugin root passed directly
+    by ``FileType.PLUGIN`` validation), or from ``path.parent`` when *path*
+    is a file -- see ``_resolve_ignore_config`` for the identical rationale.
 
     Returns:
         The policy and its config root, or defaults and ``None``.
     """
-    start_dir = path.parent.resolve()
+    start_dir = (path if path.is_dir() else path.parent).resolve()
     key = str(start_dir)
     if key in cache:
         return cache[key]
@@ -3145,8 +3151,9 @@ class PluginStructureValidator:
 
         mp_layout = check_pl006(plugin_dir)
         if mp_layout:
-            errors.extend(mp_layout)
-            return ValidationResult(passed=False, errors=errors, warnings=warnings, info=info)
+            for issue in mp_layout:
+                (errors if issue.severity == "error" else warnings).append(issue)
+            return ValidationResult(passed=not errors, errors=errors, warnings=warnings, info=info)
 
         # Skip claude plugin validate when running inside a Claude Code session
         # (nested CLI invocations are blocked by Anthropic safety measure).
@@ -3329,7 +3336,8 @@ class PluginStructureValidator:
         # If no specific error pattern matched but validation failed, add generic error
         # Include actual CLI output for diagnosis (truncate to avoid huge messages)
         if not errors:
-            errors.append(claude_validation_failure_issue(stdout, stderr))
+            issue = claude_validation_failure_issue(stdout, stderr)
+            (errors if issue.severity == "error" else warnings).append(issue)
 
 
 # ============================================================================

--- a/packages/skilllint/rules/pl_series.py
+++ b/packages/skilllint/rules/pl_series.py
@@ -33,8 +33,14 @@ Rule IDs and default severities:
     | PL003 | Missing required field 'name' in plugin.json              | error     |
     | PL004 | Component path does not start with './'                   | error     |
     | PL005 | Referenced component file does not exist                  | error     |
-    | PL006 | marketplace.json has invalid top-level keys               | error     |
+    | PL006 | marketplace.json has invalid top-level keys               | split*    |
     +-------+-----------------------------------------------------------+-----------+
+
+    * PL006 severity is not uniform: unrecognized top-level keys are a
+      **warning** (verified against ``claude plugin validate`` v2.1.263, see
+      issue #145), while a non-object ``marketplace.json`` root is a genuine
+      structural defect and stays an **error**. ``@skilllint_rule`` still
+      registers PL006's nominal default as ``error`` (see ``check_pl006``).
 
 Import note: ValidationIssue is deferred inside ``_make_issue`` to break the
 circular import: plugin_validator imports rules/, so rules/ cannot import
@@ -235,8 +241,9 @@ def claude_validation_failure_issue(stdout: str, stderr: str) -> ValidationIssue
     """Build the catch-all issue for a failed ``claude plugin validate`` run.
 
     Used when the subprocess reported failure but no PL001-PL005 pattern
-    matched.  Emits PL006 when the output names unrecognized marketplace keys,
-    otherwise a generic PL002.
+    matched.  Emits PL006 as a **warning** when the output names unrecognized
+    marketplace keys (verified against ``claude plugin validate`` v2.1.263,
+    see issue #145), otherwise a generic PL002.
 
     Args:
         stdout: Standard output from claude CLI.
@@ -250,7 +257,7 @@ def claude_validation_failure_issue(stdout: str, stderr: str) -> ValidationIssue
     if "marketplace" in low and "unrecognized keys" in low:
         return _make_issue(
             field="marketplace.json",
-            severity="error",
+            severity="warning",
             message=(
                 "marketplace.json: top-level keys rejected by `claude plugin validate` "
                 "(see the Claude Code marketplace schema for the documented root keys)"
@@ -538,6 +545,11 @@ def check_pl005(claude_output: str) -> list[ValidationIssue]:
 # PL006 — marketplace.json has invalid top-level keys
 # ---------------------------------------------------------------------------
 
+# Severity split verified against `claude plugin validate` v2.1.263 (issue
+# #145): unrecognized top-level keys are a warning; a non-object root stays
+# an error. The decorator below keeps "error" as PL006's nominal default,
+# matching the check_pa001 precedent for dual-severity rules.
+
 
 @skilllint_rule(
     "PL006",
@@ -554,6 +566,15 @@ def check_pl006(plugin_dir: Path) -> list[ValidationIssue]:
     ``plugins``, ``metadata``, ``$schema``, ``description``, ``version``,
     ``allowCrossMarketplaceDependenciesOn``, or ``renames`` (see
     ``MARKETPLACE_JSON_ROOT_KEYS``).
+
+    **Severity is split by branch**, verified against ``claude plugin
+    validate`` v2.1.263 (issue #145):
+
+    - Unrecognized/misplaced top-level keys -> **warning**: the vendor CLI
+      reports these under ``warnings`` with ``errors: []`` and exits 0.
+    - A non-object ``marketplace.json`` root -> **error**: a genuine
+      structural defect: the vendor CLI still reports a real error and a
+      non-zero exit for this case.
 
     Detection is **direct**: ``.claude-plugin/marketplace.json`` is read and
     decoded, then its root keys are classified by
@@ -653,7 +674,7 @@ def check_pl006(plugin_dir: Path) -> list[ValidationIssue]:
     return [
         _make_issue(
             field="marketplace.json",
-            severity="error",
+            severity="warning",
             message=f"marketplace.json violates the Claude Code marketplace schema: {detail}.",
             code="PL006",
             suggestion=suggestion,

--- a/packages/skilllint/tests/test_plugin_structure_validator.py
+++ b/packages/skilllint/tests/test_plugin_structure_validator.py
@@ -491,8 +491,10 @@ class TestMarketplaceJsonLayout:
         validator = PluginStructureValidator()
         result = validator.validate(plugin_dir)
 
-        assert result.passed is False
-        assert any(e.code == PL006 for e in result.errors)
+        # PL006 unrecognized/misplaced root keys are a warning, not an error
+        # (verified against `claude plugin validate` v2.1.263, see issue #145).
+        assert result.passed is True
+        assert any(e.code == PL006 for e in result.warnings)
         mock_run.assert_not_called()
 
     def test_pl006_recognized_field_suggests_move_to_metadata(self, tmp_path: Path) -> None:
@@ -511,7 +513,7 @@ class TestMarketplaceJsonLayout:
         validator = PluginStructureValidator()
         result = validator.validate(plugin_dir)
 
-        pl006 = [e for e in result.errors if e.code == PL006]
+        pl006 = [e for e in result.warnings if e.code == PL006]
         assert len(pl006) == 1
         assert pl006[0].suggestion is not None
         assert "metadata" in pl006[0].suggestion
@@ -531,7 +533,7 @@ class TestMarketplaceJsonLayout:
         validator = PluginStructureValidator()
         result = validator.validate(plugin_dir)
 
-        pl006 = [e for e in result.errors if e.code == PL006]
+        pl006 = [e for e in result.warnings if e.code == PL006]
         assert len(pl006) == 1
         assert pl006[0].suggestion is not None
         assert "remove or rename" in pl006[0].suggestion.lower()
@@ -560,6 +562,31 @@ class TestMarketplaceJsonLayout:
         result = validator.validate(plugin_dir)
 
         assert not any(e.code == PL006 for e in result.errors)
+        assert not any(e.code == PL006 for e in result.warnings)
+
+    def test_pl006_non_object_root_stays_error(self, tmp_path: Path) -> None:
+        """A non-object marketplace.json root is a structural defect, not an
+        unrecognized-key finding, and must stay an **error** (exit 1).
+
+        Regression guard: a naive blanket ``severity="error"`` -> ``"warning"``
+        find-and-replace across `check_pl006` would wrongly downgrade this
+        case too. Verified against `claude plugin validate` v2.1.263 (issue
+        #145): a non-object root still reports a real error, non-zero exit.
+        """
+        plugin_dir = tmp_path / "test-plugin"
+        plugin_dir.mkdir()
+        claude_plugin = plugin_dir / ".claude-plugin"
+        claude_plugin.mkdir()
+        (claude_plugin / "plugin.json").write_text('{"name": "test"}')
+        (claude_plugin / "marketplace.json").write_text(json.dumps([1, 2, 3]))
+
+        validator = PluginStructureValidator()
+        result = validator.validate(plugin_dir)
+
+        assert result.passed is False
+        pl006 = [e for e in result.errors if e.code == PL006]
+        assert len(pl006) == 1
+        assert not any(e.code == PL006 for e in result.warnings)
 
     def test_fix_leaves_documented_marketplace_json_byte_identical(self, tmp_path: Path) -> None:
         """`--fix` must not rewrite a marketplace.json with documented root fields.
@@ -617,5 +644,7 @@ class TestMarketplaceJsonLayout:
         validator = PluginStructureValidator()
         result = validator.validate(plugin_dir)
 
-        assert result.passed is False
-        assert any(e.code == PL006 for e in result.errors)
+        # Subprocess-derived PL006 (fallback parser) is also a warning
+        # (verified against `claude plugin validate` v2.1.263, see issue #145).
+        assert result.passed is True
+        assert any(e.code == PL006 for e in result.warnings)

--- a/packages/skilllint/tests/test_policy_config.py
+++ b/packages/skilllint/tests/test_policy_config.py
@@ -115,6 +115,31 @@ def test_token_band_severity_is_configurable(tmp_path: Path) -> None:
     assert diagnostics == []
 
 
+def test_pl006_severity_is_configurable(tmp_path: Path) -> None:
+    # PL006's unrecognized-root-key finding is a warning by default (issue
+    # #145/#152); a config override must still be honored, same as SK006/SK007.
+    cfg = tmp_path / ".skilllint.json"
+    cfg.write_text(json.dumps({"severity": {"PL006": "info"}}))
+    policy, diagnostics = _load_policy(cfg)
+    assert policy.severity == {"PL006": "info"}
+    assert diagnostics == []
+
+
+def test_resolve_policy_finds_plugin_config_from_plugin_root_directory(tmp_path: Path) -> None:
+    # `_get_validators_for_path` passes the plugin ROOT DIRECTORY itself (not
+    # a file within it) to `_resolve_policy` for FileType.PLUGIN. Regression
+    # guard: `start_dir` must search from that directory, not its parent, or
+    # PL006's (and any other plugin-root-scoped rule's) own
+    # `.claude-plugin/validator.json` is silently skipped.
+    root = tmp_path / "plugin"
+    (root / ".claude-plugin").mkdir(parents=True)
+    (root / ".claude-plugin" / "plugin.json").write_text("{}")
+    (root / ".claude-plugin" / "validator.json").write_text(json.dumps({"severity": {"PL006": "info"}}))
+    policy, config_root = _resolve_policy(root, {})
+    assert policy.severity == {"PL006": "info"}
+    assert config_root == root
+
+
 def test_inverted_thresholds_reset_to_defaults(tmp_path: Path) -> None:
     # SK006 >= SK007 makes the warning band unreachable; reset both (finding #2).
     cfg = tmp_path / ".skilllint.json"


### PR DESCRIPTION
## Summary

- `claude plugin validate` v2.1.263 reports an unrecognized `marketplace.json` root key as a **warning** (`errors: []`, exit 0). PL006 instead emitted `error`, exit 1 — the captured-stderr fixture that severity rested on predates the current CLI and matches neither its severity nor its exact wording (reproduced live this session and in the prior #114 session).
- PL006 actually spans two distinct upstream behaviors, not one severity:
  - Unrecognized/misplaced top-level keys → **warning** (now matches the CLI).
  - A non-object `marketplace.json` root → **error**, unchanged — a genuine structural defect; the live CLI still returns a real error and non-zero exit for this case.
- The `@skilllint_rule` decorator keeps its nominal `error` default, matching the existing `check_pa001` dual-severity precedent (PA001 is also registered `error` despite having dual-severity runtime behavior).
- Adds `"PL006"` to `_SEVERITY_POLICY_RULES` so a user who disagrees with the default can override it via `.claude-plugin/validator.json` — same mechanism already used for SK006/SK007.
- Fixes `_resolve_ignore_config`/`_resolve_policy` to search from a directory path *itself* (not its parent) when `FileType.PLUGIN` passes the plugin root directly. Without this, a plugin-root config was silently skipped for any plugin-root-scoped rule (including PL006's new override) — found via behavioral testing, not part of the original ask, but required for the override to actually take effect.
- Does **not** touch PL006's authority metadata (already fixed by #193), `_THRESHOLD_POLICY_RULES` (separate numeric-band mechanism), `_VALID_SEVERITIES` (downgrade-only contract preserved), or add a `--strict` flag.

Closes #145, closes #152.

## Test plan

- [x] `uv run prek run --all-files` — all hooks pass
- [x] `uv run pytest` — 1559 passed, 10 skipped, coverage 86.49%
- [x] New regression guard `test_pl006_non_object_root_stays_error`-equivalent coverage (non-object root asserted still in `result.errors`)
- [x] New `test_pl006_severity_is_configurable` + `test_resolve_policy_finds_plugin_config_from_plugin_root_directory` in `test_policy_config.py`

### Behavioral validation (real CLI, real temp dirs)

```
$ skilllint check <dir with marketplace.json root key "repository">
⚠ [PL006] marketplace.json: ... move these under `metadata` by hand ...
PASSED, Warnings: 1, exit 0

$ # same dir + .claude-plugin/validator.json: {"severity": {"PL006": "info"}}
$ skilllint check <dir>
ℹ [PL006] marketplace.json: ... (same message, now info)
PASSED, exit 0

$ skilllint check <dir with marketplace.json root == [1,2,3]>
❌ [PL006] marketplace.json: marketplace.json must be a JSON object at the root
FAILED, exit 1
```

All three confirm: default severity now matches the live CLI, the config override actually takes effect end-to-end, and the non-object-root regression guard holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4