### PR TITLE
fix(record): strip trailing whitespace from exported SVG/HTML

### DIFF
--- a/packages/skilllint/record_export.py
+++ b/packages/skilllint/record_export.py
@@ -34,6 +34,31 @@ def make_recording_console(*, no_color: bool = False) -> Console:
     return Console(record=True, force_terminal=True, no_color=no_color)
 
 
+def _strip_trailing_whitespace(content: str) -> str:
+    """Strip trailing whitespace from every line of *content*.
+
+    Rich's SVG export template embeds structurally-indented lines that carry
+    trailing whitespace independent of the recorded terminal content. The
+    ``trailing-whitespace`` pre-commit/prek hook rewrites such lines whenever
+    a checked-in recording is regenerated, which turns routine screenshot
+    updates into a guaranteed CI failure on first push. Stripping here keeps
+    the file the hook would already consider clean.
+
+    Only trailing whitespace is removed; leading whitespace (indentation) is
+    left untouched so the exported markup is not otherwise reformatted. A
+    trailing newline at the end of *content*, if present, is preserved.
+
+    Args:
+        content: Raw SVG or HTML markup, as returned by
+            :meth:`rich.console.Console.export_svg` or
+            :meth:`rich.console.Console.export_html`.
+
+    Returns:
+        *content* with trailing whitespace removed from each line.
+    """
+    return "\n".join(line.rstrip() for line in content.split("\n"))
+
+
 def export_recording(console: Console, path: Path, *, title: str) -> None:
     """Export a recorded Rich console session to *path*.
 
@@ -41,6 +66,10 @@ def export_recording(console: Console, path: Path, *, title: str) -> None:
 
     - ``.html`` — :meth:`rich.console.Console.export_html`
     - anything else (including ``.svg``) — :meth:`rich.console.Console.export_svg`
+
+    Trailing whitespace is stripped from every line before writing (see
+    :func:`_strip_trailing_whitespace`) so the recorded file never trips the
+    repository's ``trailing-whitespace`` hook.
 
     The write is atomic: content is first written to a :class:`tempfile.NamedTemporaryFile`
     in the same directory as *path*, then renamed into place with :func:`os.replace`.
@@ -62,6 +91,7 @@ def export_recording(console: Console, path: Path, *, title: str) -> None:
     if suffix not in {".svg", ".html"}:
         raise ValueError(f"Unsupported file extension {path.suffix!r}. Use .svg or .html.")
     content = console.export_html(clear=False) if suffix == ".html" else console.export_svg(title=title, clear=False)
+    content = _strip_trailing_whitespace(content)
 
     # Atomic write: write to a sibling temp file, then rename.
     dir_ = path.parent

--- a/packages/skilllint/tests/test_record_export.py
+++ b/packages/skilllint/tests/test_record_export.py
@@ -148,6 +148,22 @@ class TestExportRecording:
         normalised = html.unescape(content).replace("\xa0", " ")
         assert "My Custom Title" in normalised
 
+    def test_svg_output_has_no_trailing_whitespace(self, tmp_path: Path) -> None:
+        """export_recording strips trailing whitespace from every line of SVG output.
+
+        Rich's SVG export template contains structurally indented lines with
+        trailing whitespace (independent of the recorded terminal content).
+        The `trailing-whitespace` pre-commit/prek hook rewrites any such line
+        when a screenshot is regenerated, so the file skilllint writes must
+        already be clean or every regeneration trips the hook on first push.
+        """
+        console = self._make_console_with_output()
+        dest = tmp_path / "output.svg"
+        export_recording(console, dest, title="test title")
+        content = dest.read_text(encoding="utf-8")
+        offending = [line for line in content.splitlines() if line != line.rstrip()]
+        assert not offending, f"lines with trailing whitespace: {offending!r}"
+
     def test_unsupported_extension_raises_value_error(self, tmp_path: Path) -> None:
         """export_recording raises ValueError for unsupported file extensions."""
         console = make_recording_console()


### PR DESCRIPTION
## Summary

`skilllint --record` writes SVG/HTML with trailing whitespace on several
lines. Rich's `export_svg()` template emits structurally-indented lines
with trailing whitespace regardless of the recorded content, so the
`trailing-whitespace` prek hook rewrites the file on the next commit.
Anyone regenerating a checked-in recording (e.g. `docs/screenshots/rules.svg`
per #105) hits a guaranteed CI failure on first push.

- Reproduced the bug against the real `--record` path first: ran
  `skilllint check <target> --record repro.svg` and found 5 lines with
  trailing whitespace via `grep -nP ' +$'`. Confirmed the same template
  artifact reproduces even for trivial single-line console output.
- Fixed in `export_recording()`: strip trailing whitespace per line
  (`content.split("\n")` + `rstrip()` per line, rejoined) before the
  atomic write. Leading indentation and the file's final trailing
  newline are preserved — no other reformatting.
- Added a TDD regression test (`test_svg_output_has_no_trailing_whitespace`)
  that failed against pre-fix behavior and passes after the fix.

## Test plan

- [x] `uv run pytest packages/skilllint/tests/test_record_export.py -v` — new test fails pre-fix, passes post-fix
- [x] `uv run pytest` — 1557 passed, 10 skipped
- [x] `uv run prek run --all-files` — all hooks pass
- [x] Ran `skilllint check plugins/agentskills-skilllint --record <file>.svg` and `.html` against the real CLI; `grep -rnP ' +$'` finds zero trailing-whitespace lines in either output

Fixes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4