### PR TITLE
fix(PL006): discover and validate marketplace-only repositories

### DIFF
--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -148,6 +148,27 @@ def _safe_load_yaml(text: str) -> YamlValue:
     return _yaml_safe.load(text)
 
 
+def _find_anchor_dir(path: Path, marker_relpath: str) -> Path | None:
+    """Walk up from *path* looking for a marker file relative to a root.
+
+    Shared upward walk behind :func:`find_plugin_dir` and
+    :func:`find_marketplace_dir` (skilllint#118).
+
+    Args:
+        path: Path to start searching from (file or directory).
+        marker_relpath: Marker path relative to a candidate root, e.g.
+            ``".claude-plugin/plugin.json"``.
+
+    Returns:
+        The directory containing the marker, or None if not found.
+    """
+    search_path = path.parent if path.is_file() else path
+    for parent in [search_path, *search_path.parents]:
+        if (parent / marker_relpath).exists():
+            return parent
+    return None
+
+
 def find_plugin_dir(path: Path) -> Path | None:
     """Find the plugin directory containing .claude-plugin/plugin.json.
 
@@ -160,11 +181,25 @@ def find_plugin_dir(path: Path) -> Path | None:
     Returns:
         Plugin directory path, or None if not found.
     """
-    search_path = path.parent if path.is_file() else path
-    for parent in [search_path, *search_path.parents]:
-        if (parent / ".claude-plugin" / "plugin.json").exists():
-            return parent
-    return None
+    return _find_anchor_dir(path, ".claude-plugin/plugin.json")
+
+
+def find_marketplace_dir(path: Path) -> Path | None:
+    """Find the directory containing .claude-plugin/marketplace.json.
+
+    Walks up the directory tree from *path* (or its parent, if *path* is a
+    file) looking for a ``.claude-plugin/marketplace.json`` marker. Used as a
+    fallback root anchor when no ``plugin.json`` exists anywhere in the
+    ancestry (skilllint#118): a repository whose only Claude-plugin artifact
+    is a marketplace manifest still needs a root for PL006 to validate.
+
+    Args:
+        path: Path to start searching from.
+
+    Returns:
+        Marketplace root directory path, or None if not found.
+    """
+    return _find_anchor_dir(path, ".claude-plugin/marketplace.json")
 
 
 def _dump_yaml(data: dict[str, YamlValue]) -> str:
@@ -1081,7 +1116,14 @@ class FileType(StrEnum):
 
         if path.name == "SKILL.md":
             result = FileType.SKILL
-        elif path.name == "plugin.json" or (path / ".claude-plugin/plugin.json").exists():
+        elif (
+            path.name in {"plugin.json", "marketplace.json"}
+            or (path / ".claude-plugin/plugin.json").exists()
+            or (path / ".claude-plugin/marketplace.json").exists()
+        ):
+            # marketplace.json is a Claude-plugin artifact in its own right
+            # (skilllint#118): a marketplace-only repository must be
+            # classified as PLUGIN so PluginStructureValidator (PL006) runs.
             result = FileType.PLUGIN
         elif "agents" in path.parts:
             result = FileType.AGENT
@@ -3134,10 +3176,15 @@ class PluginStructureValidator:
         warnings: list[ValidationIssue] = []
         info: list[ValidationIssue] = []
 
-        # Find plugin directory (contains .claude-plugin/plugin.json)
-        plugin_dir = find_plugin_dir(path)
+        # Find plugin directory (contains .claude-plugin/plugin.json), falling
+        # back to a marketplace-only root (contains .claude-plugin/
+        # marketplace.json but no plugin.json anywhere in its ancestry) so
+        # PL006 is reachable there too (skilllint#118). Plugin anchor is
+        # tried first: a nested plugin root must resolve to itself, not to
+        # an ancestor's marketplace.json.
+        plugin_dir = find_plugin_dir(path) or find_marketplace_dir(path)
         if plugin_dir is None:
-            # Not a plugin directory - skip validation
+            # Neither a plugin nor a marketplace directory - skip validation
             return ValidationResult(passed=True, errors=errors, warnings=warnings, info=info)
 
         # Validate plugin.json JSON syntax locally before delegating to claude CLI.

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -42,6 +42,7 @@ DEFAULT_SCAN_PATTERNS: tuple[str, ...] = (
     "**/agents/*.md",
     "**/commands/*.md",
     "**/.claude-plugin/plugin.json",
+    "**/.claude-plugin/marketplace.json",
     "**/hooks/hooks.json",
     "**/CLAUDE.md",
 )
@@ -298,7 +299,9 @@ def _discover_bare_paths(directory: Path) -> list[Path]:
     covered_roots = plugin_roots | provider_roots
     for pattern in DEFAULT_SCAN_PATTERNS:
         for match in _glob_excluding(directory, pattern):
-            if pattern.endswith("plugin.json"):
+            if ".claude-plugin/" in pattern:
+                # Both plugin.json and marketplace.json anchor a root two
+                # levels up from the match (skilllint#118).
                 candidate = match.parent.parent
             elif pattern.endswith("skills/*/SKILL.md"):
                 candidate = match.parent

--- a/packages/skilllint/tests/test_plugin_structure_validator.py
+++ b/packages/skilllint/tests/test_plugin_structure_validator.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
     from pytest_mock import MockerFixture
 
-from skilllint.plugin_validator import PL006, PluginStructureValidator, validate_single_path
+from skilllint.plugin_validator import PL006, PluginStructureValidator, find_marketplace_dir, validate_single_path
 
 
 class TestPluginStructureValidatorBasic:
@@ -648,3 +648,146 @@ class TestMarketplaceJsonLayout:
         # (verified against `claude plugin validate` v2.1.263, see issue #145).
         assert result.passed is True
         assert any(e.code == PL006 for e in result.warnings)
+
+
+class TestMarketplaceOnlyDiscovery:
+    """PL006 must be reachable when the only Claude-plugin artifact in a
+    repository is `.claude-plugin/marketplace.json` (skilllint#118).
+
+    `PluginStructureValidator.validate` anchored only on `find_plugin_dir`,
+    which recognizes `.claude-plugin/plugin.json` and nothing else. A
+    marketplace-only root has no `plugin.json` anywhere in its ancestry, so
+    `find_plugin_dir` always returned None and PL006 was silently skipped.
+    These tests cover the `find_plugin_dir(path) or find_marketplace_dir(path)`
+    fallback at the validator's root-resolution gate.
+    """
+
+    def test_pl006_fires_on_marketplace_only_root_non_object(self, tmp_path: Path) -> None:
+        """A marketplace-only root with a non-object marketplace.json still
+        reports PL006 as an error, with no plugin.json anywhere in the tree.
+        """
+        claude_plugin = tmp_path / ".claude-plugin"
+        claude_plugin.mkdir()
+        (claude_plugin / "marketplace.json").write_text(json.dumps([1, 2, 3]))
+
+        result = PluginStructureValidator().validate(tmp_path)
+
+        assert result.passed is False
+        pl006 = [e for e in result.errors if e.code == PL006]
+        assert len(pl006) == 1
+
+    def test_pl006_fires_on_marketplace_only_root_unknown_keys(self, tmp_path: Path) -> None:
+        """A marketplace-only root with an unrecognized top-level key reports
+        PL006 as a warning, matching the plugin-root behavior in
+        TestMarketplaceJsonLayout.
+        """
+        claude_plugin = tmp_path / ".claude-plugin"
+        claude_plugin.mkdir()
+        marketplace = {"name": "cat", "owner": {"name": "x"}, "plugins": [], "pluginz": "typo"}
+        (claude_plugin / "marketplace.json").write_text(json.dumps(marketplace))
+
+        result = PluginStructureValidator().validate(tmp_path)
+
+        assert result.passed is True
+        pl006 = [e for e in result.warnings if e.code == PL006]
+        assert len(pl006) == 1
+
+    def test_pl006_attributed_to_marketplace_root_not_nested_plugin(self, tmp_path: Path) -> None:
+        """A repo-root marketplace.json is validated at the root, independent
+        of a nested plugin directory living underneath it.
+        """
+        claude_plugin = tmp_path / ".claude-plugin"
+        claude_plugin.mkdir()
+        marketplace = {"name": "cat", "owner": {"name": "x"}, "plugins": [], "pluginz": "typo"}
+        (claude_plugin / "marketplace.json").write_text(json.dumps(marketplace))
+
+        nested_plugin = tmp_path / "plugins" / "foo"
+        (nested_plugin / ".claude-plugin").mkdir(parents=True)
+        (nested_plugin / ".claude-plugin" / "plugin.json").write_text('{"name": "foo"}')
+
+        result = PluginStructureValidator().validate(tmp_path)
+
+        assert any(e.code == PL006 for e in result.warnings)
+
+    def test_nested_plugin_not_shadowed_by_ancestor_marketplace(self, tmp_path: Path) -> None:
+        """`find_plugin_dir` must be tried before `find_marketplace_dir`:
+        a nested plugin root resolves to itself, never to an ancestor's
+        marketplace.json — even when that ancestor's marketplace.json has
+        PL006 findings of its own.
+
+        Regression guard for the fallback ordering call in `validate`
+        (`find_plugin_dir(path) or find_marketplace_dir(path)`). Reversing
+        the operands would let `find_marketplace_dir` walk past `foo` up to
+        the ancestor's marketplace.json before `find_plugin_dir` ever runs.
+        """
+        claude_plugin = tmp_path / ".claude-plugin"
+        claude_plugin.mkdir()
+        marketplace = {"name": "cat", "owner": {"name": "x"}, "plugins": [], "pluginz": "typo"}
+        (claude_plugin / "marketplace.json").write_text(json.dumps(marketplace))
+
+        nested_plugin = tmp_path / "plugins" / "foo"
+        (nested_plugin / ".claude-plugin").mkdir(parents=True)
+        (nested_plugin / ".claude-plugin" / "plugin.json").write_text('{"name": "foo"}')
+
+        result = PluginStructureValidator().validate(nested_plugin)
+
+        # foo has no marketplace.json of its own — the ancestor's PL006
+        # finding must not leak onto foo's result.
+        assert not any(e.code == PL006 for e in result.warnings)
+        assert not any(e.code == PL006 for e in result.errors)
+
+    def test_marketplace_root_with_plugin_json_unchanged(self, tmp_path: Path) -> None:
+        """Regression guard: a plugin root that also carries marketplace.json
+        keeps resolving via find_plugin_dir, unaffected by the new fallback.
+        """
+        plugin_dir = tmp_path / "test-plugin"
+        claude_plugin = plugin_dir / ".claude-plugin"
+        claude_plugin.mkdir(parents=True)
+        (claude_plugin / "plugin.json").write_text('{"name": "test"}')
+        marketplace = {"name": "cat", "owner": {"name": "x"}, "plugins": [], "pluginz": "typo"}
+        (claude_plugin / "marketplace.json").write_text(json.dumps(marketplace))
+
+        result = PluginStructureValidator().validate(plugin_dir)
+
+        assert any(e.code == PL006 for e in result.warnings)
+
+    def test_plugin_only_root_unaffected(self, tmp_path: Path) -> None:
+        """Regression guard: a plugin-only root (no marketplace.json anywhere)
+        behaves exactly as before — no PL006, passed True.
+        """
+        plugin_dir = tmp_path / "test-plugin"
+        claude_plugin = plugin_dir / ".claude-plugin"
+        claude_plugin.mkdir(parents=True)
+        (claude_plugin / "plugin.json").write_text('{"name": "test"}')
+
+        result = PluginStructureValidator().validate(plugin_dir)
+
+        assert not any(e.code == PL006 for e in result.warnings)
+        assert not any(e.code == PL006 for e in result.errors)
+
+
+class TestFindMarketplaceDir:
+    """Unit tests for `find_marketplace_dir` (skilllint#118)."""
+
+    def test_returns_own_dir_when_marketplace_json_present(self, tmp_path: Path) -> None:
+        """A directory whose own .claude-plugin/marketplace.json exists resolves to itself."""
+        claude_plugin = tmp_path / ".claude-plugin"
+        claude_plugin.mkdir()
+        (claude_plugin / "marketplace.json").write_text("{}")
+
+        assert find_marketplace_dir(tmp_path) == tmp_path
+
+    def test_walks_up_from_nested_file(self, tmp_path: Path) -> None:
+        """A file several directories below the marketplace root still resolves to the root."""
+        claude_plugin = tmp_path / ".claude-plugin"
+        claude_plugin.mkdir()
+        (claude_plugin / "marketplace.json").write_text("{}")
+        nested_file = tmp_path / "plugins" / "foo" / "SKILL.md"
+        nested_file.parent.mkdir(parents=True)
+        nested_file.write_text("# skill")
+
+        assert find_marketplace_dir(nested_file) == tmp_path
+
+    def test_returns_none_when_absent(self, tmp_path: Path) -> None:
+        """No marketplace.json anywhere up-tree returns None, matching find_plugin_dir's contract."""
+        assert find_marketplace_dir(tmp_path) is None

--- a/packages/skilllint/tests/test_scan_context.py
+++ b/packages/skilllint/tests/test_scan_context.py
@@ -1216,6 +1216,28 @@ class TestBareDirectoryRegressionCompatibility:
         # Assert — plugin root itself must be present (added by _discover_plugin_paths)
         assert tmp_path in result
 
+    def test_bare_directory_marketplace_only_root_included(self, tmp_path: Path) -> None:
+        """Directory with only .claude-plugin/marketplace.json is discovered as itself.
+
+        Tests: _discover_validatable_paths — BARE context marketplace.json
+               fallback in DEFAULT_SCAN_PATTERNS (skilllint#118)
+        How: Create .claude-plugin/marketplace.json at tmp_path root (no
+             plugin.json anywhere), call _discover_validatable_paths, assert
+             tmp_path itself is in the result.
+        Why: Without a marketplace anchor in DEFAULT_SCAN_PATTERNS, a
+             marketplace-only repository is never discovered and PL006 can
+             never fire (skilllint#118).
+        """
+        # Arrange
+        (tmp_path / ".claude-plugin").mkdir()
+        (tmp_path / ".claude-plugin" / "marketplace.json").write_text("{}")
+
+        # Act
+        result = _discover_validatable_paths(tmp_path)
+
+        # Assert — marketplace root itself must be present
+        assert tmp_path in result
+
     def test_bare_directory_nested_plugin_root_in_results(self, tmp_path: Path) -> None:
         """For BARE dir with nested plugin, the plugin root appears in results.
 

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -261,6 +261,66 @@ class TestDiscoverValidatablePaths:
 
         assert _discover_validatable_paths(skill_dir) == [skill_dir]
 
+    def test_discovers_marketplace_only_root(self, tmp_path: Path) -> None:
+        """_discover_validatable_paths returns the marketplace root itself.
+
+        Tests: .claude-plugin/marketplace.json discovery returns the owning
+               root directory, mirroring plugin.json discovery (skilllint#118).
+        How: Create a marketplace-only directory (no plugin.json anywhere)
+             and verify the root directory is discovered.
+        Why: Without this, PL006 has no reachable path to validate on a
+             marketplace-only repository -- the scan silently discovers
+             nothing (skilllint#118).
+        """
+        claude_plugin = tmp_path / ".claude-plugin"
+        claude_plugin.mkdir()
+        (claude_plugin / "marketplace.json").write_text('{"name": "cat"}')
+
+        discovered = _discover_validatable_paths(tmp_path)
+
+        assert tmp_path in discovered, f"Expected {tmp_path} in discovered paths: {discovered}"
+
+    def test_discovers_marketplace_root_and_nested_plugin_separately(self, tmp_path: Path) -> None:
+        """A repo-root marketplace.json and a nested plugin root are both
+        discovered, as distinct paths (skilllint#118).
+
+        Tests: the marketplace root is not swallowed by the nested plugin's
+               covered_roots exclusion, and vice versa.
+        How: Create tmp_path/.claude-plugin/marketplace.json plus
+             tmp_path/plugins/foo/.claude-plugin/plugin.json.
+        Why: PL006 must be attributed to the repository root, not
+             re-attributed to (or hidden by) a nested plugin.
+        """
+        claude_plugin = tmp_path / ".claude-plugin"
+        claude_plugin.mkdir()
+        (claude_plugin / "marketplace.json").write_text('{"name": "cat"}')
+
+        nested_plugin = tmp_path / "plugins" / "foo"
+        (nested_plugin / ".claude-plugin").mkdir(parents=True)
+        (nested_plugin / ".claude-plugin" / "plugin.json").write_text('{"name": "foo"}')
+
+        discovered = _discover_validatable_paths(tmp_path)
+
+        assert tmp_path in discovered, f"Expected marketplace root in {discovered}"
+        assert nested_plugin in discovered, f"Expected nested plugin root in {discovered}"
+
+    def test_marketplace_and_plugin_json_same_nested_root_not_duplicated(self, tmp_path: Path) -> None:
+        """A nested directory carrying both plugin.json and marketplace.json
+        in the same .claude-plugin/ is discovered exactly once (skilllint#118).
+
+        Tests: _discover_bare_paths's covered_roots guard also dedupes the
+               new marketplace.json pattern against the plugin.json pattern.
+        """
+        nested = tmp_path / "my-plugin"
+        claude_plugin = nested / ".claude-plugin"
+        claude_plugin.mkdir(parents=True)
+        (claude_plugin / "plugin.json").write_text('{"name": "test"}')
+        (claude_plugin / "marketplace.json").write_text('{"name": "cat"}')
+
+        discovered = _discover_validatable_paths(tmp_path)
+
+        assert discovered.count(nested) == 1, f"Expected exactly one occurrence: {discovered}"
+
 
 class TestResolveFilterAndExpandPaths:
     """Tests for _resolve_filter_and_expand_paths seam."""
@@ -715,6 +775,8 @@ class TestConstantsExport:
         assert any("commands" in p for p in patterns), f"Missing commands pattern in {patterns}"
         # Should include plugin.json
         assert any("plugin.json" in p for p in patterns), f"Missing plugin.json pattern in {patterns}"
+        # Should include marketplace.json (skilllint#118)
+        assert any("marketplace.json" in p for p in patterns), f"Missing marketplace.json pattern in {patterns}"
         # Should include hooks.json
         assert any("hooks.json" in p for p in patterns), f"Missing hooks.json pattern in {patterns}"
         # Should include CLAUDE.md


### PR DESCRIPTION
## Summary

PL006 (marketplace.json layout) never fired on a repository whose only
Claude-plugin artifact is `.claude-plugin/marketplace.json`. Three
independent gates all anchored exclusively on `plugin.json`:

1. `DEFAULT_SCAN_PATTERNS` had no `marketplace.json` entry, so
   `_discover_bare_paths` found nothing to validate on a marketplace-only
   repo — the scan was silent rather than wrong.
2. `FileType.detect_file_type` classified a marketplace-only root (or a
   direct `marketplace.json` path) as `UNKNOWN`, so the CLI reported
   `Error: Cannot determine file type` (exit 2) for a direct file
   invocation.
3. `PluginStructureValidator.validate` resolved its root via
   `find_plugin_dir` only, returning `passed=True` *before* reaching
   `check_pl006` whenever no `plugin.json` existed anywhere in the
   ancestry.

Fixes #118 by:

- Adding `**/.claude-plugin/marketplace.json` to `DEFAULT_SCAN_PATTERNS`
  and widening the bare-discovery candidate-mapping condition so the match
  maps to its owning root (mirrors `plugin.json`'s existing behavior).
- Extending `FileType.detect_file_type`'s `PLUGIN` branch to also recognize
  `marketplace.json` (by name or by presence in `.claude-plugin/`).
- Factoring `find_plugin_dir`'s upward-walk into a shared `_find_anchor_dir`
  helper and adding `find_marketplace_dir` beside it.
- Changing the root-resolution call in `PluginStructureValidator.validate`
  to `find_plugin_dir(path) or find_marketplace_dir(path)` — plugin anchor
  is tried first, so a nested plugin root inside a marketplace repo still
  resolves to itself, never to the ancestor's marketplace manifest.

No changes to `check_pl006`, `detect_scan_context`, `--filter-type`
resolution, or any other `find_plugin_dir` call site (LK/PA/MCP rules,
`PluginRegistrationValidator`) — those all correctly mean "plugin root"
specifically and are out of scope for this issue.

## Test plan

- [x] TDD: added failing tests first in `test_scan_runtime.py`,
      `test_scan_context.py`, and `test_plugin_structure_validator.py`
      (confirmed RED against pre-fix code via `ImportError` /
      assertion failures), then implemented to GREEN.
- [x] `uv run pytest` — full suite, 1572 passed, 10 skipped.
- [x] `uv run prek run --all-files` — all hooks green (ruff, ruff-format,
      ty, actionlint, markdownlint, shellcheck, ...).
- [x] Behavioral validation with real `tmp`-built fixtures run through
      `uv run skilllint check`, covering all shapes from the issue:
  - Marketplace-only root, non-object root → PL006 fires, **exit 1**
    (previously: silent, exit 0).
  - Marketplace-only root, unknown keys → PL006 warning, exit 0.
  - Direct `marketplace.json` file path → PL006 reported (previously:
    `Error: Cannot determine file type`, exit 2).
  - Marketplace root + nested plugin → PL006 reported exactly once,
    attributed to the repo root, not the nested plugin.
  - Plugin root that also carries `marketplace.json` → unchanged
    (regression guard).
  - Plugin-only root, clean → unchanged, exit 0 (regression guard).
  - This repo's own plugin (`plugins/agentskills-skilllint`) → unchanged,
    exit 0.
  - `--fix` on a marketplace-only PL006 finding → no crash, file
    byte-identical (SHA-256 verified) — matches `can_fix() == False`.
  - `--filter-type skills` on a marketplace+nested-plugin fixture →
    unaffected, exit 0.

## Notes

- Built on top of #217 (merged as `48dfeea`), which already fixed the
  `path.is_dir()` gap in `_resolve_ignore_config`/`_resolve_policy` and
  split PL006 severity (unrecognized keys → warning, non-object root →
  error). This PR does not touch severity or config-resolution logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4