### PR TITLE
fix: gate --fix invocation on a path's own findings, report applied fixes

### DIFF
--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -549,6 +549,42 @@ def get_validator_constraint_scopes(class_name: str) -> set[str]:
     return VALIDATOR_CONSTRAINT_SCOPES.get(class_name, {"shared", "provider_specific"})
 
 
+# Rule codes that authorise a fixer to run against a path under --fix.
+# Keyed by validator class name, the same convention as VALIDATOR_OWNERSHIP
+# and VALIDATOR_CONSTRAINT_SCOPES above. A fixer whose class is not a key
+# here gets an empty set from get_fixer_trigger_codes() and therefore never
+# runs (fail closed) -- see test_every_can_fix_validator_has_trigger_codes.
+#
+# The trigger set for a validator is not always the codes it *reports* in
+# the normal validate() pipeline:
+# - NameFormatValidator is a fix-only participant appended by
+#   _get_fixers_for_path; FM010 is reported by FrontmatterValidator, but
+#   only NameFormatValidator implements the repair.
+# - FrontmatterValidator.fix() also repairs a missing `name` field (AS001),
+#   a code owned by AsSeriesValidator in the reporting pipeline, via
+#   fix_skill_name_field() -- see skilllint#144/#117 design brief.
+FIXER_TRIGGER_CODES: dict[str, frozenset[str]] = {
+    "SymlinkTargetValidator": frozenset({"SL001"}),
+    "FrontmatterValidator": frozenset({"FM004", "FM007", "FM009", "FM010", "AS001"}),
+    "NameFormatValidator": frozenset({"FM010"}),
+    "HookValidator": frozenset({"HK005"}),
+}
+
+
+def get_fixer_trigger_codes(validator: Validator) -> frozenset[str]:
+    """Get the rule codes that authorise a validator's fixer to run.
+
+    Args:
+        validator: A validator instance being considered for --fix.
+
+    Returns:
+        Frozenset of rule codes declared in FIXER_TRIGGER_CODES for this
+        validator's class. Empty for any class not declared there, so an
+        undeclared or third-party fixer never runs (fail closed).
+    """
+    return FIXER_TRIGGER_CODES.get(type(validator).__name__, frozenset())
+
+
 def filter_validators_by_constraint_scopes(
     validators: Sequence[Validator], constraint_scopes: set[str]
 ) -> list[Validator]:
@@ -1180,6 +1216,24 @@ class ComplexityMetrics:
         if self.status == "warning":
             return f"WARNING: {self.body_tokens} tokens (>{TOKEN_WARNING_THRESHOLD})"
         return f"OK: {self.body_tokens} tokens"
+
+
+@dataclass(frozen=True)
+class AppliedFix:
+    """Record of one fix a validator applied to a file under --fix.
+
+    Attribution is per fixer invocation, not per description: when a single
+    fixer's ``fix()`` call is authorised by more than one rule code and
+    returns multiple description strings, every description from that call
+    carries the full triggering code set. Precise per-description
+    attribution would require passing findings into ``fix()`` (tracked as a
+    follow-up -- see the skilllint#144/#117 design brief, Approach C).
+    """
+
+    path: Path
+    validator: str
+    codes: tuple[str, ...]
+    description: str
 
 
 # ============================================================================
@@ -3799,6 +3853,7 @@ def _collect_validator_results(
     config_root: Path | None,
     ignore_config: IgnoreConfig,
     policy: ValidationPolicy | None = None,
+    raw_codes_out: set[str] | None = None,
 ) -> list[tuple[str, ValidationResult]]:
     """Run each validator and collect results, applying ignore filtering.
 
@@ -3810,6 +3865,11 @@ def _collect_validator_results(
             prefix matching. Pass ``None`` to skip filtering.
         ignore_config: Resolved ignore configuration.
         policy: Optional resolved token/severity policy.
+        raw_codes_out: Optional mutable out-param collecting every issue code
+            found *before* ignore filtering. ``--fix`` gating reads this set:
+            issue #144's fix policy is "ignore = suppress reporting, not
+            fixing", so the fixer gate must see codes ignore filtering would
+            otherwise remove.
 
     Returns:
         List of (validator_class_name, result) tuples.
@@ -3847,6 +3907,8 @@ def _collect_validator_results(
                 warnings=[i for i in issues if i.severity == "warning"],
                 info=[i for i in issues if i.severity == "info"],
             )
+        if raw_codes_out is not None:
+            raw_codes_out.update(str(i.code) for i in (*result.errors, *result.warnings, *result.info))
         if config_root is not None:
             result = _filter_result_by_ignore(result, path, config_root, ignore_config)
         results.append((name, result))
@@ -3871,6 +3933,7 @@ def validate_single_path(
     verbose: bool,
     per_run_cache: dict[str, tuple[IgnoreConfig, Path | None]] | None = None,
     per_run_policy_cache: dict[str, tuple[ValidationPolicy, Path | None]] | None = None,
+    fixes_out: list[AppliedFix] | None = None,
 ) -> FileResults:
     """Validate a single path and return results grouped by file.
 
@@ -3886,6 +3949,10 @@ def validate_single_path(
         per_run_policy_cache: Optional mutable cache for policy resolution,
             with the same per-run lifetime as ``per_run_cache``.  Sharing it
             avoids re-walking and re-reading config for every sibling file.
+        fixes_out: Optional mutable append-only out-param collecting one
+            AppliedFix per fix description a fixer returned. Only appended
+            to when ``fix`` is True and a fixer's declared trigger codes
+            (FIXER_TRIGGER_CODES) intersect this path's findings.
 
     Returns:
         Mapping of file path to list of (validator_class_name, result) tuples.
@@ -3921,8 +3988,17 @@ def validate_single_path(
     policy, _policy_root = _resolve_policy(path, policy_cache)
     policy = ValidationPolicy(policy.thresholds, policy.severity, ignore_config)
 
+    # raw_codes carries every issue code found before ignore filtering, so the
+    # --fix gate below sees suppressed findings too (ignore = suppress
+    # reporting, not fixing -- see the note in the fix loop).
+    raw_codes: set[str] = set()
     validator_results = _collect_validator_results(
-        validators, path, config_root=config_root, ignore_config=ignore_config, policy=policy
+        validators,
+        path,
+        config_root=config_root,
+        ignore_config=ignore_config,
+        policy=policy,
+        raw_codes_out=raw_codes if fix else None,
     )
 
     # Note: --fix still runs even for suppressed issues (ignore = suppress reporting, not fixing)
@@ -3933,12 +4009,27 @@ def validate_single_path(
         else:
             fixes_applied: list[str] = []
             for validator in _get_fixers_for_path(validators, path):
-                if validator.can_fix():
-                    try:
-                        validator_fixes = validator.fix(path)
-                        fixes_applied.extend(validator_fixes)
-                    except NotImplementedError:
-                        pass  # Validator doesn't support fixing
+                if not validator.can_fix():
+                    continue
+                # A fixer may only run when this path's findings include at
+                # least one rule code it is declared to repair (issue #144).
+                # Unmapped fixers get an empty set from get_fixer_trigger_codes
+                # and are skipped -- fail closed rather than fixing on an
+                # undeclared trigger.
+                triggered_codes = get_fixer_trigger_codes(validator) & raw_codes
+                if not triggered_codes:
+                    continue
+                try:
+                    validator_fixes = validator.fix(path)
+                except NotImplementedError:
+                    continue  # Validator doesn't support fixing
+                fixes_applied.extend(validator_fixes)
+                if fixes_out is not None and validator_fixes:
+                    codes = tuple(sorted(triggered_codes))
+                    fixes_out.extend(
+                        AppliedFix(path=path, validator=type(validator).__name__, codes=codes, description=description)
+                        for description in validator_fixes
+                    )
 
             # Re-validate after fixes
             if fixes_applied:
@@ -4448,7 +4539,9 @@ def main(
         per_run_cache: dict[str, tuple[IgnoreConfig, Path | None]] = {}
         per_run_policy_cache: dict[str, tuple[ValidationPolicy, Path | None]] = {}
 
-        def _validate_with_cache(p: Path, *, check: bool, fix: bool, verbose: bool) -> FileResults:
+        def _validate_with_cache(
+            p: Path, *, check: bool, fix: bool, verbose: bool, fixes_out: list[AppliedFix] | None = None
+        ) -> FileResults:
             return validate_single_path(
                 p,
                 check=check,
@@ -4456,6 +4549,7 @@ def main(
                 verbose=verbose,
                 per_run_cache=per_run_cache,
                 per_run_policy_cache=per_run_policy_cache,
+                fixes_out=fixes_out,
             )
 
         run_validation_loop(

--- a/packages/skilllint/reporting.py
+++ b/packages/skilllint/reporting.py
@@ -14,7 +14,7 @@ from rich.measure import Measurement
 from rich.panel import Panel
 
 if TYPE_CHECKING:
-    from skilllint.plugin_validator import ValidationIssue, ValidationResult
+    from skilllint.plugin_validator import AppliedFix, ValidationIssue, ValidationResult
 
 FileResults: TypeAlias = dict[Path, list[tuple[str, "ValidationResult"]]]
 
@@ -33,6 +33,10 @@ class Reporter(Protocol):
 
     def summarize(self, total_files: int, passed: int, failed: int, warnings: int) -> None:
         """Display summary statistics."""
+        ...
+
+    def report_fixes(self, fixes: list[AppliedFix]) -> None:
+        """Display fixes applied by --fix, grouped by file."""
         ...
 
 
@@ -118,6 +122,29 @@ class ConsoleReporter:
                 for issue in issues_to_show:
                     self._print_issue(issue)
 
+    def report_fixes(self, fixes: list[AppliedFix]) -> None:
+        """Display a summary of files and rules that --fix modified.
+
+        Args:
+            fixes: Fixes applied during this run, in the order they were
+                recorded. Grouped by file for display, preserving the order
+                each file's fixes were recorded in.
+        """
+        self.console.print("\n[bold]Fixes applied[/bold]", crop=False, overflow="ignore")
+        fixes_by_path: dict[Path, list[AppliedFix]] = {}
+        for applied_fix in fixes:
+            fixes_by_path.setdefault(applied_fix.path, []).append(applied_fix)
+        for file_path, path_fixes in fixes_by_path.items():
+            self.console.print(f"[bold]{file_path}[/bold]", crop=False, overflow="ignore")
+            for applied_fix in path_fixes:
+                codes = ", ".join(applied_fix.codes)
+                self.console.print(
+                    f"  :wrench: [magenta][{codes}][/magenta] "
+                    f"[dim]{applied_fix.validator}:[/dim] {applied_fix.description}",
+                    crop=False,
+                    overflow="ignore",
+                )
+
     def summarize(self, total_files: int, passed: int, failed: int, warnings: int) -> None:
         """Display summary statistics with Rich formatting."""
         if failed == 0:
@@ -201,6 +228,16 @@ class CIReporter:
                 for issue in issues_to_show:
                     self._print_issue(issue)
 
+    def report_fixes(self, fixes: list[AppliedFix]) -> None:
+        """Display a summary of files and rules that --fix modified, plain text.
+
+        Args:
+            fixes: Fixes applied during this run, one line per fix.
+        """
+        for applied_fix in fixes:
+            codes = ", ".join(applied_fix.codes)
+            print(f"FIXED [{codes}] {applied_fix.path}: {applied_fix.description}")
+
     def summarize(self, total_files: int, passed: int, failed: int, warnings: int) -> None:
         """Display summary statistics in plain text."""
         status = "✓ PASSED" if failed == 0 else "✗ FAILED"
@@ -219,6 +256,9 @@ class SummaryReporter:
     """Single-line summary reporter for quick status checks."""
 
     def report(self, file_results: FileResults, verbose: bool = False, *, show_progress: bool = False) -> None:
+        """Display nothing (summary-only reporter)."""
+
+    def report_fixes(self, fixes: list[AppliedFix]) -> None:
         """Display nothing (summary-only reporter)."""
 
     def summarize(self, total_files: int, passed: int, failed: int, warnings: int) -> None:

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -26,6 +26,8 @@ from .reporting import CIReporter, ConsoleReporter, FileResults, Reporter
 if TYPE_CHECKING:
     from rich.console import Console
 
+    from .plugin_validator import AppliedFix
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -547,6 +549,24 @@ def _ignore_path(path: Path) -> Path:
     return skill_file if path.is_dir() and skill_file.is_file() else path
 
 
+def _select_reporter(*, no_color: bool, record_console: Console | None) -> Reporter:
+    """Choose the reporter implementation for this run.
+
+    Args:
+        no_color: Disable color output (selects the plain-text CI reporter).
+        record_console: When provided, takes precedence so recorded output
+            (e.g. SVG/HTML export) always uses Rich formatting.
+
+    Returns:
+        A ConsoleReporter (recording or colored) or a CIReporter.
+    """
+    if record_console is not None:
+        return ConsoleReporter(console=record_console)
+    if no_color:
+        return CIReporter()
+    return ConsoleReporter(no_color=no_color)
+
+
 def run_validation_loop(
     *,
     expanded_paths: list[Path],
@@ -606,6 +626,7 @@ def run_validation_loop(
         return str(p.resolve()) in ignored_set
 
     all_results: FileResults = {}
+    all_fixes: list[AppliedFix] = []
     for path in expanded_paths:
         if _should_skip(_ignore_path(path)):
             continue
@@ -613,21 +634,20 @@ def run_validation_loop(
             violations = validate_file(_ignore_path(path), adapters, platform_override)
             all_results[path] = [("platform", violations_to_result(violations))]
         else:
-            file_results = validate_single_path(path, check=check, fix=fix, verbose=verbose)
+            file_results = validate_single_path(path, check=check, fix=fix, verbose=verbose, fixes_out=all_fixes)
             for file_path, validator_results in file_results.items():
                 if file_path in all_results:
                     all_results[file_path].extend(validator_results)
                 else:
                     all_results[file_path] = list(validator_results)
 
-    reporter: Reporter
-    if record_console is not None:
-        reporter = ConsoleReporter(console=record_console)
-    elif no_color:
-        reporter = CIReporter()
-    else:
-        reporter = ConsoleReporter(no_color=no_color)
+    reporter = _select_reporter(no_color=no_color, record_console=record_console)
     reporter.report(all_results, verbose=verbose, show_progress=show_progress)
+    if all_fixes:
+        # Printed before summarize(): ConsoleReporter.summarize() mutates
+        # self.console.width to fit its summary panel, so anything printed
+        # afterwards on the same console would inherit that narrowed width.
+        reporter.report_fixes(all_fixes)
 
     total_files, passed, failed, warnings = _compute_summary(all_results)
     if show_summary:

--- a/packages/skilllint/tests/test_cli.py
+++ b/packages/skilllint/tests/test_cli.py
@@ -224,9 +224,10 @@ tools: Read, Write
     def test_fix_reports_applied_fixes(self, cli_runner: CliRunner, tmp_path: Path, no_color_env: None) -> None:
         """Verify --fix mode reports which fixes were applied.
 
-        Tests: --fix mode outputs list of applied fixes
-        How: Create file with fixable issues, run --fix, check output
-        Why: Users should know what changes were made
+        Tests: --fix mode outputs list of applied fixes (skilllint#117)
+        How: Create file with a fixable multiline description, run --fix, check output
+        Why: Users should know what changes were made -- exit 0 alone does not
+            distinguish "nothing to fix" from "fixed silently".
         """
         # Create skill with fixable multiline description
         skill_dir = tmp_path / "fix-report-skill"
@@ -242,11 +243,72 @@ tools: Read, Write
 # Test Skill
 """)
 
-        result = cli_runner.invoke(plugin_validator.app, ["check", "--fix", str(skill_file)])
+        result = cli_runner.invoke(plugin_validator.app, ["check", "--fix", "--no-color", str(skill_file)])
 
-        # Command should complete successfully (fixes may or may not be needed)
-        # The key is that --fix flag is accepted and runs without error
         assert result.exit_code == 0
+        assert "FIXED" in result.stdout
+        assert "FM004" in result.stdout
+        assert "multiline" in result.stdout
+        assert str(skill_file) in result.stdout
+
+    def test_fix_summary_absent_when_nothing_fixed(
+        self, cli_runner: CliRunner, tmp_path: Path, no_color_env: None
+    ) -> None:
+        """Verify --fix prints no fix summary when the file has nothing fixable.
+
+        Tests: --fix summary reporting is silent on a clean file (skilllint#117)
+        How: Create a skill with only a non-fixable finding, run --fix, check output
+        Why: A fix summary on an untouched file would be a false positive
+        """
+        skill_dir = tmp_path / "clean-cli-skill"
+        skill_dir.mkdir()
+        skill_file = skill_dir / "SKILL.md"
+        skill_file.write_text("""---
+name: clean-cli-skill
+description: A short description without any keywords for automatic loading here.
+tools: Read, Write
+---
+
+# Test Skill
+""")
+
+        result = cli_runner.invoke(plugin_validator.app, ["check", "--fix", "--no-color", str(skill_file)])
+
+        assert result.exit_code == 0
+        assert "FIXED" not in result.stdout
+        assert "Fixes applied" not in result.stdout
+
+    def test_fix_summary_printed_before_summary_panel(
+        self, cli_runner: CliRunner, tmp_path: Path, no_color_env: None
+    ) -> None:
+        """Verify the fix summary appears before the validation summary block.
+
+        Tests: Fix summary ordering relative to reporter.summarize() (skilllint#117)
+        How: Run --fix on a fixable file, locate both markers in stdout
+        Why: ConsoleReporter.summarize() mutates console width for its panel;
+            printing the fix summary afterwards would inherit that width.
+        """
+        skill_dir = tmp_path / "fix-order-skill"
+        skill_dir.mkdir()
+        skill_file = skill_dir / "SKILL.md"
+        skill_file.write_text("""---
+name: fix-order-skill
+description: >-
+  Test skill with multiline description using fold marker
+tools: Read, Write
+---
+
+# Test Skill
+""")
+
+        result = cli_runner.invoke(
+            plugin_validator.app, ["check", "--fix", "--no-color", "--show-summary", str(skill_file)]
+        )
+
+        assert result.exit_code == 0
+        fixed_index = result.stdout.index("FIXED")
+        summary_index = result.stdout.index("=" * 60)
+        assert fixed_index < summary_index
 
     def test_fix_revalidates_after_fixing(self, cli_runner: CliRunner, tmp_path: Path, no_color_env: None) -> None:
         """Verify --fix mode re-validates after applying fixes.

--- a/packages/skilllint/tests/test_fixer_gating.py
+++ b/packages/skilllint/tests/test_fixer_gating.py
@@ -1,0 +1,235 @@
+"""Tests for the --fix rule-code gate (skilllint#144) and its fail-closed contract.
+
+Covers:
+- A fixer must not run against a path whose findings include none of its
+  declared trigger codes (FIXER_TRIGGER_CODES), even though every shipping
+  fixer happens to self-gate internally today -- see the assertions on
+  ``fix()`` call counts, not on file bytes, which is the whole point.
+- The fix-only NameFormatValidator (never a reporter) still runs when FM010
+  fires, proving the gate is rule-code scoped rather than
+  validator-identity scoped.
+- FrontmatterValidator's AS001-only "add missing name" repair still fires.
+- --fix still runs for findings a .skilllint.json ignore config suppresses
+  from the report (ignore = suppress reporting, not fixing).
+- NameFormatValidator stays last in fixer invocation order.
+- Contract: every can_fix()=True validator has a non-empty trigger set,
+  every trigger code is a real registered rule, and every fixable=True
+  registry rule is covered by at least one trigger set.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from skilllint import plugin_validator as pv
+from skilllint.rule_registry import get_rule, list_rules
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
+
+def _write_skill(directory: Path, frontmatter: str, body: str = "\n# Skill\n\nBody.\n") -> Path:
+    """Write a SKILL.md with the given frontmatter block and return its path."""
+    directory.mkdir(parents=True, exist_ok=True)
+    skill_file = directory / "SKILL.md"
+    skill_file.write_text(f"---\n{frontmatter}\n---\n{body}", encoding="utf-8")
+    return skill_file
+
+
+class TestFixGating:
+    """--fix must gate each fixer on that path's own findings (#144)."""
+
+    def test_fix_does_not_invoke_fixer_when_its_rules_did_not_fire(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        """A file whose only finding is SK005 (non-fixable) must invoke no fixer.
+
+        Red before the gate exists: every shipping fixer happens to self-gate
+        on its own read of the file today, so an "unchanged bytes" assertion
+        would already pass. Spying on fix() and asserting zero calls is the
+        only assertion that distinguishes "gated" from "ran and no-opped".
+        """
+        skill_file = _write_skill(
+            tmp_path / "clean-skill",
+            "name: clean-skill\n"
+            "description: A short description without any keywords for automatic loading here.\n"
+            "tools: Read, Write",
+        )
+        frontmatter_fix = mocker.spy(pv.FrontmatterValidator, "fix")
+        name_format_fix = mocker.spy(pv.NameFormatValidator, "fix")
+        symlink_fix = mocker.spy(pv.SymlinkTargetValidator, "fix")
+
+        results = pv.validate_single_path(skill_file, check=False, fix=True, verbose=False)
+
+        all_codes = {
+            str(issue.code)
+            for validator_results in results.values()
+            for _, vr in validator_results
+            for issue in (*vr.errors, *vr.warnings, *vr.info)
+        }
+        assert "SK005" in all_codes
+        assert frontmatter_fix.call_count == 0
+        assert name_format_fix.call_count == 0
+        assert symlink_fix.call_count == 0
+
+    def test_fix_invokes_frontmatter_fixer_when_fm007_fires(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        """FrontmatterValidator.fix() runs when FM007 fires; NameFormatValidator does not."""
+        skill_file = _write_skill(
+            tmp_path / "fm007-skill",
+            "name: fm007-skill\n"
+            "description: Use when testing the FM007 auto-fix gate for this skill.\n"
+            "tools:\n  - Read\n  - Write",
+        )
+        frontmatter_fix = mocker.spy(pv.FrontmatterValidator, "fix")
+        name_format_fix = mocker.spy(pv.NameFormatValidator, "fix")
+
+        pv.validate_single_path(skill_file, check=False, fix=True, verbose=False)
+
+        assert frontmatter_fix.call_count == 1
+        assert name_format_fix.call_count == 0
+        assert "tools: Read, Write" in skill_file.read_text(encoding="utf-8")
+
+    def test_fix_invokes_name_format_fixer_when_fm010_fires(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        """NameFormatValidator.fix() runs on FM010 even though it never reports.
+
+        NameFormatValidator is appended by _get_fixers_for_path as a fix-only
+        participant (FrontmatterValidator is the sole reporter of FM010). A
+        validator-identity-scoped gate ("did this instance report?") would
+        disable this fix entirely -- this test kills that design.
+        """
+        command_file = tmp_path / "commands" / "My_Command.md"
+        command_file.parent.mkdir(parents=True)
+        command_file.write_text(
+            "---\nname: My_Command\ndescription: A short description of what this command does.\n---\n\nBody.\n",
+            encoding="utf-8",
+        )
+        name_format_fix = mocker.spy(pv.NameFormatValidator, "fix")
+
+        pv.validate_single_path(command_file, check=False, fix=True, verbose=False)
+
+        assert name_format_fix.call_count == 1
+        assert "name: my-command" in command_file.read_text(encoding="utf-8")
+
+    def test_fix_adds_missing_name_when_only_as001_fires(self, tmp_path: Path) -> None:
+        """FrontmatterValidator adds a missing `name` field triggered by AS001 alone."""
+        skill_dir = tmp_path / "no-name-skill"
+        skill_file = _write_skill(
+            skill_dir, "description: Use when testing the AS001 add-missing-name auto-fix gate.\ntools: Read"
+        )
+
+        pv.validate_single_path(skill_file, check=False, fix=True, verbose=False)
+
+        assert "name: no-name-skill" in skill_file.read_text(encoding="utf-8")
+
+    def test_fixer_ordering_name_format_last(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        """NameFormatValidator must run after FrontmatterValidator, never before.
+
+        Their fixes converge only in this order: FrontmatterValidator's
+        fix_skill_name_field() sets `name` from the directory first, so
+        NameFormatValidator's normalize-and-compare no-ops on an already
+        correct name instead of racing it from a different source of truth.
+        """
+        call_order: list[str] = []
+        original_frontmatter_fix = pv.FrontmatterValidator.fix
+        original_name_format_fix = pv.NameFormatValidator.fix
+
+        def frontmatter_fix(self: pv.FrontmatterValidator, path: Path) -> list[str]:
+            call_order.append("FrontmatterValidator")
+            return original_frontmatter_fix(self, path)
+
+        def name_format_fix(self: pv.NameFormatValidator, path: Path) -> list[str]:
+            call_order.append("NameFormatValidator")
+            return original_name_format_fix(self, path)
+
+        mocker.patch.object(pv.FrontmatterValidator, "fix", frontmatter_fix)
+        mocker.patch.object(pv.NameFormatValidator, "fix", name_format_fix)
+
+        skill_file = _write_skill(
+            tmp_path / "my-bad-skill",
+            "name: My_Bad_Skill\ndescription: Use when testing fixer ordering convergence here.\ntools: Read",
+        )
+
+        pv.validate_single_path(skill_file, check=False, fix=True, verbose=False)
+
+        assert call_order == ["FrontmatterValidator", "NameFormatValidator"]
+
+
+class TestFixGatingIgnoreSemantics:
+    """--fix must still apply to findings a .skilllint.json ignore suppresses."""
+
+    def test_fix_runs_for_ignore_suppressed_findings(self, tmp_path: Path) -> None:
+        """FM007 is fixed even when .skilllint.json suppresses it from the report.
+
+        Pins the documented invariant at the --fix call site: "ignore =
+        suppress reporting, not fixing". Gating on the post-ignore-filter
+        codes would silently disable this fix and regress that invariant.
+        """
+        skill_dir = tmp_path / "suppressed-skill"
+        skill_file = _write_skill(
+            skill_dir,
+            "name: suppressed-skill\n"
+            "description: Use when testing ignore-suppressed fix behavior here.\n"
+            "tools:\n  - Read\n  - Write",
+        )
+        (tmp_path / ".skilllint.json").write_text(json.dumps({"ignore": {"": ["FM007"]}}), encoding="utf-8")
+
+        results = pv.validate_single_path(skill_file, check=False, fix=True, verbose=False)
+
+        all_codes = {
+            str(issue.code)
+            for validator_results in results.values()
+            for _, vr in validator_results
+            for issue in (*vr.errors, *vr.warnings, *vr.info)
+        }
+        assert "FM007" not in all_codes, "FM007 should still be suppressed from the report"
+        assert "tools: Read, Write" in skill_file.read_text(encoding="utf-8"), "but the fixer should still have run"
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed contract tests
+# ---------------------------------------------------------------------------
+
+# Every validator class reachable from _get_validators_for_path's universe,
+# plus NameFormatValidator (fix-only, appended by _get_fixers_for_path).
+_ALL_VALIDATOR_CLASSES: list[type] = [
+    pv.SymlinkTargetValidator,
+    pv.FrontmatterValidator,
+    pv.NameFormatValidator,
+    pv.HookValidator,
+    pv.PluginStructureValidator,
+    pv.PluginRegistrationValidator,
+    pv.ProgressiveDisclosureValidator,
+    pv.InternalLinkValidator,
+    pv.NamespaceReferenceValidator,
+    pv.DescriptionValidator,
+    pv.ComplexityValidator,
+    pv.MarkdownTokenCounter,
+    pv.AsSeriesValidator,
+]
+
+
+class TestFixerTriggerCodesContract:
+    """FIXER_TRIGGER_CODES must fail closed and stay consistent with the rule registry."""
+
+    def test_every_can_fix_validator_has_trigger_codes(self) -> None:
+        """Every validator whose can_fix() is True has a non-empty trigger set."""
+        for validator_class in _ALL_VALIDATOR_CLASSES:
+            validator = validator_class()
+            if not validator.can_fix():
+                continue
+            trigger_codes = pv.get_fixer_trigger_codes(validator)
+            assert trigger_codes, f"{validator_class.__name__}.can_fix() is True but has no FIXER_TRIGGER_CODES entry"
+
+    def test_trigger_codes_exist_in_rule_registry(self) -> None:
+        """Every code in every trigger set resolves to a registered rule."""
+        for validator_name, codes in pv.FIXER_TRIGGER_CODES.items():
+            for code in codes:
+                assert get_rule(code) is not None, f"{validator_name} declares unknown rule code {code!r}"
+
+    def test_every_fixable_rule_has_a_fixer(self) -> None:
+        """Every fixable=True registry rule is covered by at least one trigger set."""
+        declared_codes = {code for codes in pv.FIXER_TRIGGER_CODES.values() for code in codes}
+        fixable_codes = {rule.id for rule in list_rules() if rule.fixable}
+        missing = fixable_codes - declared_codes
+        assert not missing, f"fixable=True rules with no fixer trigger entry: {missing}"

--- a/packages/skilllint/tests/test_reporters.py
+++ b/packages/skilllint/tests/test_reporters.py
@@ -17,7 +17,7 @@ import contextlib
 from io import StringIO
 from pathlib import Path
 
-from skilllint.plugin_validator import ErrorCode, ValidationIssue, ValidationResult
+from skilllint.plugin_validator import AppliedFix, ErrorCode, ValidationIssue, ValidationResult
 from skilllint.reporting import CIReporter, ConsoleReporter, SummaryReporter
 
 
@@ -176,6 +176,36 @@ class TestConsoleReporter:
         assert "Warnings: 1" in output
         assert "FAILED" in output
 
+    def test_report_fixes(self) -> None:
+        """Test report_fixes output groups fixes by file with code and description.
+
+        Tests: --fix summary reporting (skilllint#117)
+        How: Inject Console writing to StringIO, call report_fixes with one AppliedFix
+        Why: Verify the file path, rule code and fix description all appear in output
+        """
+        from rich.console import Console
+
+        buf = StringIO()
+        console = Console(file=buf, color_system=None, width=200)
+        reporter = ConsoleReporter(console=console)
+
+        fixes = [
+            AppliedFix(
+                path=Path("/tmp/test/SKILL.md"),
+                validator="FrontmatterValidator",
+                codes=("FM007",),
+                description="Converted tools from YAML array to comma-separated string",
+            )
+        ]
+        reporter.report_fixes(fixes)
+
+        output = buf.getvalue()
+        assert "Fixes applied" in output
+        assert "/tmp/test/SKILL.md" in output
+        assert "FM007" in output
+        assert "Converted tools from YAML array to comma-separated string" in output
+        assert "FrontmatterValidator" in output
+
 
 class TestCIReporter:
     """Test CIReporter plain text output.
@@ -219,6 +249,34 @@ class TestCIReporter:
         output = buf.getvalue()
         assert "\u2717 ERROR" in output
         assert "FM001" in output
+
+    def test_report_fixes(self) -> None:
+        """Test CIReporter emits a plain-text FIXED line per applied fix.
+
+        Tests: --fix summary reporting in plain text (skilllint#117)
+        How: Call report_fixes with one AppliedFix, capture stdout
+        Why: Verify greppable "FIXED [CODE] path: description" format
+        """
+        reporter = CIReporter()
+        fixes = [
+            AppliedFix(
+                path=Path("/tmp/test/My_Command.md"),
+                validator="NameFormatValidator",
+                codes=("FM010",),
+                description="Normalized name from 'My_Command' to 'my-command'",
+            )
+        ]
+
+        buf = StringIO()
+        with contextlib.redirect_stdout(buf):
+            reporter.report_fixes(fixes)
+
+        output = buf.getvalue()
+        assert "FIXED" in output
+        assert "[FM010]" in output
+        assert "/tmp/test/My_Command.md" in output
+        assert "Normalized name from 'My_Command' to 'my-command'" in output
+        assert "\x1b" not in output
 
     def test_report_warnings(self) -> None:
         """Test CIReporter shows warning format.


### PR DESCRIPTION
## Summary

- `--fix` ran every fixer's `fix()` against every eligible file regardless of what was actually flagged for that file, and silently discarded the list of fixes applied. Add `FIXER_TRIGGER_CODES`, a rule-code-scoped map (keyed by validator class name, not validator instance identity) that gates each fixer at the `--fix` call site in `validate_single_path` on the pre-ignore-filter findings for that path.
- Rule-code scoping is required, not validator-identity scoping: `NameFormatValidator` is a fix-only participant that never reports FM010 itself (`FrontmatterValidator` is the sole reporter), and `FrontmatterValidator.fix()` also repairs AS001 (owned by `AsSeriesValidator`) via its missing-name repair. An identity-scoped gate would silently disable both.
- Gating reads findings from *before* ignore filtering, preserving the documented invariant "ignore = suppress reporting, not fixing".
- `PluginStructureValidator` (PL006) is untouched — its `can_fix() -> False` from #114 stays exactly as-is.
- Adds `AppliedFix`, threaded through a new `fixes_out` out-param on `validate_single_path`, collected by `run_validation_loop`, and rendered via a new `Reporter.report_fixes()` (added to the Protocol and all three implementations) printed **before** `summarize()` (which mutates console width for its panel). No `rich.Table` — matches this reporter's existing line-oriented style.

Fixes #144, fixes #117.

## Follow-ups intentionally out of scope

Per the design brief's evidence-gathering (`.claude/design-brief-144-117.md`, not included in this PR):

- `FrontmatterValidator.fix()` destroys authored YAML comments, reorders keys, and drops trailing blank lines whenever any single transform fires (same data-loss family as #114).
- AS001 is auto-fixed in part (missing `name` field) but marked `fixable=False` in the rule registry — a labeling inconsistency, not fixed here.
- Approach C (pass findings directly into `fix()`) for precise per-description code attribution instead of today's per-invocation attribution.
- FM010 has two fixers (`FrontmatterValidator` and `NameFormatValidator`) writing the `name` field from different sources of truth; they only converge because of fixer ordering today.
- Re-implementing a correct PL006 marketplace.json relocation fix (the auto-fix removed in #114).

## Test plan

- [x] New `packages/skilllint/tests/test_fixer_gating.py`: gating tests (spy-based `fix()` call-count assertions, not file-byte assertions — confirmed red before the fix, green after), ignore-suppression-still-fixes regression, fixer-ordering pin, and fail-closed registry contract tests.
- [x] Tightened `test_cli.py::test_fix_reports_applied_fixes` (previously asserted only `exit_code == 0`); added fix-summary-absent-when-clean and fix-summary-before-summary-panel tests.
- [x] Added `report_fixes()` unit tests to `test_reporters.py` for both `ConsoleReporter` and `CIReporter`.
- [x] `uv run pytest` — full suite green (1572 passed, 10 skipped).
- [x] `uv run prek run --all-files` — all hooks green (ruff, ruff-format, ty, actionlint, markdownlint, shellcheck, ...).
- [x] Manual behavioral validation against real fixture files (skill/command/hook mix): exit 0, `clean-skill/SKILL.md` byte-identical, `FIXED [FM007]`/`FIXED [FM010]`/`FIXED [HK005]` lines print for the files actually fixed, and a monkeypatch-based invocation-count check confirms zero `fix()` calls on the untouched file (previously 1 call each on `FrontmatterValidator`/`NameFormatValidator`).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4