### PR TITLE
fix(rule-registry): break circular import with rules package

### DIFF
--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -4813,8 +4813,7 @@ from rich.panel import Panel as _Panel
 from rich.table import Table as _Table
 
 from skilllint.fixture_loader import FIXTURES_ROOT as _FIXTURES_ROOT, discover_fixtures as _discover_fixtures
-from skilllint.rule_registry import get_rule as _get_rule, list_rules as _list_rules
-from skilllint.rules._constants import RuleCategory, RulePlatform
+from skilllint.rule_registry import RuleCategory, RulePlatform, get_rule as _get_rule, list_rules as _list_rules
 from skilllint.rules.pa_series import PluginAgentFrontmatterValidator
 
 

--- a/packages/skilllint/rule_registry.py
+++ b/packages/skilllint/rule_registry.py
@@ -31,8 +31,6 @@ from urllib.parse import urljoin
 
 from pydantic import BaseModel, Field
 
-from skilllint.rules._constants import ClientLoadBehavior, RuleCategory, RulePlatform
-
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -83,6 +81,41 @@ def _make_issue(
     return ValidationIssue(
         field=field, severity=severity, message=message, code=code, docs_url=rule_reference(code), suggestion=suggestion
     )
+
+
+# Live value space of RuleEntry.category, grepped from every @skilllint_rule(...)
+# call site in packages/skilllint/rules/*_series.py (issue #41 item 3). Adding a
+# new category requires adding it here first, or Pydantic rejects the
+# registration at import time.
+RuleCategory = Literal[
+    "agent",
+    "codex",
+    "cursor",
+    "frontmatter",
+    "hook",
+    "link",
+    "namespace-reference",
+    "plugin",
+    "plugin-registration",
+    "progressive-disclosure",
+    "skill",
+    "symlink",
+    "token-count",
+]
+
+# Live value space of RuleEntry.platforms elements, including sites that omit
+# platforms= and take the @skilllint_rule decorator's ["agentskills"] default.
+RulePlatform = Literal["agentskills", "claude-code", "codex", "cursor"]
+
+# Live value space of RuleEntry.client_load_behavior. Populated only when the
+# client-implementation guide is explicit about what a real client does for a
+# rule's finding — "warn-and-load" (validation is lenient; the client logs a
+# warning and loads the skill anyway) or "skip-skill" (the client refuses to
+# load the skill and logs an error). None (the RuleEntry default) means the
+# guide does not say, mirroring RuleEntry.authority's None-means-unstated
+# semantics rather than adding a separate "unknown" member.
+# Source: https://agentskills.io/client-implementation/adding-skills-support#lenient-validation
+ClientLoadBehavior = Literal["warn-and-load", "skip-skill"]
 
 
 class RuleAuthority(BaseModel):

--- a/packages/skilllint/rules/_constants.py
+++ b/packages/skilllint/rules/_constants.py
@@ -2,42 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Literal
-
-# Live value space of RuleEntry.category, grepped from every @skilllint_rule(...)
-# call site in packages/skilllint/rules/*_series.py (issue #41 item 3). Adding a
-# new category requires adding it here first, or Pydantic rejects the
-# registration at import time.
-RuleCategory = Literal[
-    "agent",
-    "codex",
-    "cursor",
-    "frontmatter",
-    "hook",
-    "link",
-    "namespace-reference",
-    "plugin",
-    "plugin-registration",
-    "progressive-disclosure",
-    "skill",
-    "symlink",
-    "token-count",
-]
-
-# Live value space of RuleEntry.platforms elements, including sites that omit
-# platforms= and take the @skilllint_rule decorator's ["agentskills"] default.
-RulePlatform = Literal["agentskills", "claude-code", "codex", "cursor"]
-
-# Live value space of RuleEntry.client_load_behavior. Populated only when the
-# client-implementation guide is explicit about what a real client does for a
-# rule's finding — "warn-and-load" (validation is lenient; the client logs a
-# warning and loads the skill anyway) or "skip-skill" (the client refuses to
-# load the skill and logs an error). None (the RuleEntry default) means the
-# guide does not say, mirroring RuleEntry.authority's None-means-unstated
-# semantics rather than adding a separate "unknown" member.
-# Source: https://agentskills.io/client-implementation/adding-skills-support#lenient-validation
-ClientLoadBehavior = Literal["warn-and-load", "skip-skill"]
-
 # Full set of expected series prefixes: the 14 series from P038 plus the AG
 # agent-frontmatter series added for issue #132.
 # CM001 is scoped out — reserved, no validator logic (P038 architect spec §9).

--- a/packages/skilllint/tests/test_rule_registry.py
+++ b/packages/skilllint/tests/test_rule_registry.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+import subprocess
+import sys
 
 import pytest
 
@@ -218,3 +220,37 @@ def test_iter_authority_urls_silently_skips_none_reference(caplog: pytest.LogCap
     assert urls == []
     # Assert — no warning was logged for this rule
     assert not any("FM009" in record.message for record in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Regression test: standalone import must not trip the rule_registry <->
+# rules circular import (issue #221).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("module_name", ["skilllint.rule_registry", "skilllint.cli_docs"])
+def test_module_imports_standalone_without_prior_rules_import(module_name: str) -> None:
+    """Importing the module alone, with no prior import of skilllint.rules, succeeds.
+
+    Tests: standalone `import {module_name}` in a fresh interpreter
+    How: Runs `python -c "import {module_name}"` in a subprocess so no other
+         test or fixture (notably the autouse conftest fixture that imports
+         skilllint.rules before every test body) has already loaded
+         skilllint.rules into sys.modules. A subprocess is required: purging
+         sys.modules in-process to force a bare re-import creates a second
+         RULE_REGISTRY dict object, breaking the autouse fixture's isolation
+         for every later test in the session.
+    Why: rule_registry.py previously imported
+         `skilllint.rules._constants`, which triggers `rules/__init__.py`,
+         which imports the series modules, which import back from
+         rule_registry — a circular import that only manifests when
+         rule_registry (or a module that imports it, like cli_docs) is
+         imported before skilllint.rules. Every existing in-process test
+         passes even on the broken code because the autouse fixture always
+         imports skilllint.rules first.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", f"import {module_name}"], capture_output=True, text=True, check=False
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

- `rule_registry.py` imported `RuleCategory`/`RulePlatform`/`ClientLoadBehavior` from `skilllint.rules._constants`, which triggers `rules/__init__.py` to import all 15 series modules — each of which imports back from `rule_registry`, which is still mid-initialization. Standalone `import skilllint.rule_registry` raised `ImportError`; `skilllint.cli_docs` (which imports from `rule_registry`) hit the same cycle.
- `_constants.py` has no dependency on `rule_registry`, so relocating the three `Literal` aliases into `rule_registry.py` itself (next to `RuleEntry`, which already uses them as field types) fully breaks the cycle — no new module, no compat shim. `EXPECTED_SERIES`/`MIN_REGISTERED_SERIES` stay in `_constants.py` since they have no coupling back to `rule_registry`.
- `plugin_validator.py`'s two separate imports (`rule_registry` and `rules._constants`) merge into one `from skilllint.rule_registry import ...` line.

Closes #221

## Test plan

- [x] New subprocess-based regression test (`test_module_imports_standalone_without_prior_rules_import`, parametrized over `skilllint.rule_registry` and `skilllint.cli_docs`) — confirmed RED on pre-fix code (fails at test *collection* since the import cycle trips even at module load), GREEN after the fix. In-process assertions were rejected: `conftest.py`'s autouse fixture imports `skilllint.rules` before every test body, which would mask the bug.
- [x] `uv run python -c "import skilllint.rule_registry"` — succeeds standalone
- [x] `uv run python -c "import skilllint.cli_docs"` — succeeds standalone
- [x] `uv run skilllint rules` / `uv run skilllint rule FM004` — still list/render rules correctly
- [x] Registration parity: `import skilllint.rules` still yields 51 rules across 15 series
- [x] `uv run pytest` — 1588 passed, 10 skipped
- [x] `uv run prek run --all-files` — all hooks pass, including `ty check` (resolves `RuleCategory`/`RulePlatform` at their new location)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4