### PR TITLE
fix(tc): count_tokens raises ValueError on literal tiktoken special-token text

### DIFF
--- a/packages/skilllint/tests/test_token_counting.py
+++ b/packages/skilllint/tests/test_token_counting.py
@@ -28,7 +28,7 @@ import pytest
 from hypothesis import given, settings, strategies as st
 
 from skilllint.plugin_validator import TOKEN_ERROR_THRESHOLD, TOKEN_WARNING_THRESHOLD, ComplexityValidator
-from skilllint.token_counter import count_tokens
+from skilllint.token_counter import _SPECIAL_TOKENS, count_tokens
 
 
 def generate_exact_token_content(target_tokens: int) -> str:
@@ -190,6 +190,45 @@ hooks: session-start
             assert result1.passed == result2.passed, "Frontmatter differences affected validation result"
             assert len(result1.errors) == len(result2.errors), "Frontmatter differences affected error count"
             assert len(result1.warnings) == len(result2.warnings), "Frontmatter differences affected warning count"
+
+
+class TestDisallowedSpecialTokens:
+    """Test literal tiktoken special-token strings in body text don't raise.
+
+    Tests: count_tokens must treat a SKILL.md body as free-form prose, never
+        as a prompt being validated against tiktoken's own special-token
+        allowlist.
+    How: Call count_tokens on text containing each literal special-token
+        string from cl100k_base's _SPECIAL_TOKENS and assert it returns a
+        plain int rather than raising ValueError.
+    Why: Regression test for issue #226 — tiktoken's encode() raises
+        ValueError("Encountered text corresponding to disallowed special
+        token ...") by default when input text contains one of these literal
+        substrings. A SKILL.md body can legitimately contain such text (e.g.
+        documentation describing tiktoken itself), so count_tokens must pass
+        disallowed_special=() through to encode().
+    """
+
+    @pytest.mark.parametrize("special_token", sorted(_SPECIAL_TOKENS))
+    def test_literal_special_token_string_does_not_raise(self, special_token: str) -> None:
+        """Test count_tokens returns an int for text containing a literal special token.
+
+        Args:
+            special_token: A literal tiktoken special-token string, e.g. "<|endoftext|>".
+        """
+        result = count_tokens(f"some text with {special_token} embedded in it")
+
+        assert isinstance(result, int)
+        assert result > 0
+
+    def test_multiple_special_tokens_in_one_body_does_not_raise(self) -> None:
+        """Test count_tokens handles several literal special-token strings in the same text."""
+        body = " ".join(f"{token} appears here." for token in sorted(_SPECIAL_TOKENS))
+
+        result = count_tokens(body)
+
+        assert isinstance(result, int)
+        assert result > 0
 
 
 class TestThresholdBoundaries:

--- a/packages/skilllint/token_counter.py
+++ b/packages/skilllint/token_counter.py
@@ -132,13 +132,21 @@ TOKEN_ERROR_THRESHOLD: int = BODY_TOKEN_ERROR
 def count_tokens(text: str) -> int:
     """Count tokens in *text* using the cl100k_base encoding.
 
+    A SKILL.md body is free-form prose/markdown, not a prompt being replayed
+    through a model, so it must never be validated against tiktoken's own
+    special-token allowlist: literal text like ``<|endoftext|>`` appearing in
+    a skill body (e.g. documentation describing tiktoken itself) is ordinary
+    content to count, not a special token to reject. ``disallowed_special=()``
+    is tiktoken's own documented way to disable that check (see the
+    suggestion in ``tiktoken.core.Encoding.encode``'s ``ValueError`` message).
+
     Args:
         text: Text content to count tokens in.
 
     Returns:
         Number of tokens in *text*.
     """
-    return len(_get_encoding().encode(text))
+    return len(_get_encoding().encode(text, disallowed_special=()))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `count_tokens()` (`packages/skilllint/token_counter.py`) called tiktoken's `Encoding.encode()` without `disallowed_special=()`, so a SKILL.md body containing a literal special-token substring — e.g. `<|endoftext|>`, `<|fim_prefix|>`, `<|fim_middle|>`, `<|fim_suffix|>`, `<|endofprompt|>` — raised `ValueError: Encountered text corresponding to disallowed special token ...` instead of returning a count.
- `count_tokens` measures untrusted skill-file body text for the SK006/SK007 thresholds; a SKILL.md body is free-form prose/markdown, not a prompt being replayed through a model, so it must never be checked against tiktoken's own special-token allowlist.
- Fix: pass `disallowed_special=()` to `encode()`, per tiktoken's own suggested fix in the error message. One call site was affected; grepped for other `.encode(` calls on the same `Encoding` object (`tc_series.py`, `ComplexityValidator`) and confirmed both route through `count_tokens`, so no other call sites needed the same fix.

Closes #226

## Test plan

- [x] Added `TestDisallowedSpecialTokens` to `packages/skilllint/tests/test_token_counting.py`, parametrized over all 5 literal special-token strings from `token_counter._SPECIAL_TOKENS`, plus a combined-body case
- [x] Confirmed the new tests fail with the pre-fix `ValueError` (RED), then pass after the one-line fix (GREEN)
- [x] Ran `TestTokenCountDeterminism`'s Hypothesis property test 3x with random seeds, and again with `max_examples=2000` — all pass
- [x] `uv run prek run --all-files` — all hooks pass
- [x] `uv run pytest` — 1606 passed, 10 skipped (pre-existing, unrelated)
- [x] `uv run python -c "from skilllint.token_counter import count_tokens; print(count_tokens('has <|endoftext|> in it'))"` → `9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4