### PR TITLE
fix(scripts): mark skilllint path source editable in standalone PEP 723 scripts

### DIFF
--- a/scripts/assert_rules_completeness.py
+++ b/scripts/assert_rules_completeness.py
@@ -6,7 +6,7 @@
 # ]
 #
 # [tool.uv.sources]
-# skilllint = { path = ".." }
+# skilllint = { path = "..", editable = true }
 # ///
 """CI assertion script: verify that skilllint rules output meets MIN_REGISTERED_SERIES.
 

--- a/scripts/fetch_doc_source.py
+++ b/scripts/fetch_doc_source.py
@@ -8,7 +8,7 @@
 # ]
 #
 # [tool.uv.sources]
-# skilllint = { path = ".." }
+# skilllint = { path = "..", editable = true }
 # ///
 """CLI wrapper for skilllint.vendor_cache — fetch, query, and verify cached documentation."""
 

--- a/scripts/fetch_platform_docs.py
+++ b/scripts/fetch_platform_docs.py
@@ -8,7 +8,7 @@
 # ]
 #
 # [tool.uv.sources]
-# skilllint = { path = ".." }
+# skilllint = { path = "..", editable = true }
 # ///
 """Fetch platform documentation for schema auditing.
 

--- a/scripts/fetch_spec_schema.py
+++ b/scripts/fetch_spec_schema.py
@@ -8,7 +8,7 @@
 # ]
 #
 # [tool.uv.sources]
-# skilllint = { path = ".." }
+# skilllint = { path = "..", editable = true }
 # ///
 
 """Fetch agentskills.io specification and generate JSON Schema.

--- a/scripts/refresh_claim_values.py
+++ b/scripts/refresh_claim_values.py
@@ -6,7 +6,7 @@
 # ]
 #
 # [tool.uv.sources]
-# skilllint = { path = ".." }
+# skilllint = { path = "..", editable = true }
 # ///
 """L3 drift check: re-extract vendor-backed provenance claims and diff them.
 


### PR DESCRIPTION
## Summary

Five standalone PEP 723 scripts (`fetch_doc_source.py`, `fetch_platform_docs.py`,
`fetch_spec_schema.py`, `assert_rules_completeness.py`, `refresh_claim_values.py`)
declared `skilllint = { path = ".." }` in `[tool.uv.sources]` without
`editable = true`. `uv run --script` builds a frozen copy of the package into a
per-script-hash cache environment instead of linking back to the repo.

`packages/skilllint/vendor_io.py`'s `VENDOR_DIR`/`PROJECT_ROOT` are computed from
`Path(__file__)`, so every standalone invocation of these scripts resolved vendor
paths against the frozen cache copy, not the real checkout — silently. Confirmed
this in a live session: `.claude/vendor/` was stuck at a 2026-03-23 snapshot
despite `fetch_platform_docs.py` being re-run since, because it was writing to a
phantom `.claude/vendor` under `~/.cache/uv/environments-v2/...` the whole time.
`uv run skilllint docs fetch` (the installed CLI via the project's own editable
`.venv`) was unaffected — only the documented standalone `--script` fallback form
(the one AGENTS.md tells agents to use "outside the skilllint CLI") hit this.

## Fix

One-line change × 5 files: `skilllint = { path = "..", editable = true }`.

Verified after the fix: `uv run scripts/fetch_platform_docs.py --dry-run` reports
`Vendor dir: /Users/jamienelson/repos/skilllint/.claude/vendor` (the real,
shared-across-worktrees location), and a real sync run successfully refreshed
`codex`, `kimi`, `kilocode`, and `opencode` to their current upstream HEADs.

## Test plan

- [x] `uv run prek run --all-files` — passed on the changed files
- [x] Ran `uv run scripts/fetch_platform_docs.py --dry-run` before and after the
      fix — vendor dir path changed from a `~/.cache/uv/environments-v2/...`
      cache path to the real repo path
- [x] Ran the real sync; confirmed via `git -C .claude/vendor/<provider> log -1`
      that codex/kimi/kilocode/opencode now show current HEAD commits
      (previously frozen at 2026-03-23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ke4pBmhpiEuWoFTV2ax4