### PR TITLE
fix(validation): classify literal errors as FM006

### DIFF
--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -1387,7 +1387,7 @@ def _pydantic_error_to_validation_issue(error: ErrorDetails) -> ValidationIssue:
             # over-length name (#139); _check_name_field_format's duplicate
             # guard then suppresses the second FM010 source.
             code = FM010
-    elif "Input should be" in msg and "literal" in msg.lower():
+    elif error.get("type") == "literal_error":
         code = FM006
         valid_values = _get_pydantic_ctx_val(error, "expected")
         msg = f"Invalid value. Must be one of: {valid_values}"

--- a/packages/skilllint/tests/fixtures/providers/agentskills/failing-examples/FM006/fixture.toml
+++ b/packages/skilllint/tests/fixtures/providers/agentskills/failing-examples/FM006/fixture.toml
@@ -3,19 +3,7 @@ rule_id = "FM006"
 tier = 1
 description = "Invalid field value — enum constraint violated (e.g. context not in allowed set)"
 
-# FM006 cannot be exercised via the fixture harness with the current validator.
-#
-# Root cause: _pydantic_error_to_validation_issue() routes Pydantic Literal
-# constraint failures to FM006 only when "literal" appears in the error
-# message (line 987: `"literal" in msg.lower()`). Pydantic v2 generates
-# "Input should be 'fork'" for Literal["fork"] violations — this message
-# does not contain "literal", so the FM006 branch is never taken and the
-# violation is filed as FM005 instead.
-#
-# check_fm006() in fm_series.py always returns [] (metadata-registration only).
-#
-# A failing variant directory exists at invalid-context-value/ for reference,
-# but no [[variants]] entry is declared here so the loader does not create
-# a test case for it. When the validator code is fixed to correctly detect
-# FM006 from Pydantic v2 messages, add a [[variants]] entry and set the
-# expected_count to the number of FM006 violations produced.
+[[variants]]
+name = "invalid-context-value"
+kind = "failing"
+expected_count = 1

--- a/packages/skilllint/tests/test_cli.py
+++ b/packages/skilllint/tests/test_cli.py
@@ -83,6 +83,17 @@ class TestCLICommandParsing:
 class TestExitCodes:
     """Test CLI exit codes for different scenarios."""
 
+    def test_literal_error_fixture_exits_one_with_fm006(self, cli_runner: CliRunner, no_color_env: None) -> None:
+        fixture_dir = (
+            Path(__file__).parent / "fixtures/providers/agentskills/failing-examples/FM006/invalid-context-value"
+        )
+
+        result = cli_runner.invoke(plugin_validator.app, ["check", str(fixture_dir)])
+
+        assert result.exit_code == 1, result.stdout
+        assert "[FM006] context:" in result.stdout
+        assert "[FM005] context:" not in result.stdout
+
     def test_exit_0_on_valid_file(self, cli_runner: CliRunner, sample_skill_dir: Path, no_color_env: None) -> None:
         """Verify exit code 0 when validation passes.
 


### PR DESCRIPTION
Part of #124

## Evidence

- Focused fixture, public CLI, and nonliteral FM005 regression tests passed.
- Manual `uv run skilllint check` on the committed FM006 fixture emitted `[FM006] context` and exited 1.
- Evidence: `/Users/jamienelson/repos/skilllint/.omo/teams/team-ada89d5b/evidence/product-remediation-before-docs/tasks/task-6/c51e5cfa3a38d2fd0ceafacbf81f22b058a9b583/`.

## Non-goals

- Does not reclassify nonliteral Pydantic failures.
- Does not complete or close #124.