### PR TITLE
test(provenance): enforce schema JSON locators

### DIFF
--- a/packages/skilllint/schemas/provenance-registry.json
+++ b/packages/skilllint/schemas/provenance-registry.json
@@ -201,17 +201,6 @@
       "assertion_location": {"file": "packages/skilllint/schemas/agentskills_io/v1.json", "symbol": "$.properties.name.maxLength", "source_type": "schema_json_field"},
       "expected_value": 64,
       "x-audited": {"date": "2026-09-12", "source": "packages/skilllint/schemas/agentskills_io/v1.json"}
-    },
-    "AgentSkills.required_fields": {
-      "rule_code": "FM001",
-      "claim_name": "required_fields",
-      "description": "AgentSkills schema required frontmatter fields",
-      "claim_type": "enum_set",
-      "authority": {"vendor_file": "packages/skilllint/schemas/agentskills_io/v1.json", "anchor_selector": null, "authority_url": "https://agentskills.io/specification"},
-      "extraction": {"prompt_template": "Read required fields.", "output_schema": {"type": "array", "items": {"type": "string"}}, "post_processing": "sort"},
-      "assertion_location": {"file": "packages/skilllint/schemas/agentskills_io/v1.json", "symbol": "$.required", "source_type": "schema_json_enum"},
-      "expected_value": ["description", "name"],
-      "x-audited": {"date": "2026-09-12", "source": "packages/skilllint/schemas/agentskills_io/v1.json"}
     }
   }
 }

--- a/packages/skilllint/schemas/provenance-registry.json
+++ b/packages/skilllint/schemas/provenance-registry.json
@@ -190,17 +190,6 @@
         "date": "2026-09-04",
         "source": ".claude/vendor/sources/hooks-2026-08-28-0408.md"
       }
-    },
-    "AgentSkills.name_max_length": {
-      "rule_code": "FM010",
-      "claim_name": "name_max_length",
-      "description": "AgentSkills schema maximum name length",
-      "claim_type": "scalar",
-      "authority": {"vendor_file": "packages/skilllint/schemas/agentskills_io/v1.json", "anchor_selector": null, "authority_url": "https://agentskills.io/specification"},
-      "extraction": {"prompt_template": "Read maxLength for name.", "output_schema": {"type": "integer"}, "post_processing": "none"},
-      "assertion_location": {"file": "packages/skilllint/schemas/agentskills_io/v1.json", "symbol": "$.properties.name.maxLength", "source_type": "schema_json_field"},
-      "expected_value": 64,
-      "x-audited": {"date": "2026-09-12", "source": "packages/skilllint/schemas/agentskills_io/v1.json"}
     }
   }
 }

--- a/packages/skilllint/schemas/provenance-registry.json
+++ b/packages/skilllint/schemas/provenance-registry.json
@@ -31,40 +31,6 @@
         "source": "packages/skilllint/schemas/agentskills_io/v1.json"
       }
     },
-    "FM001.required_fields": {
-      "rule_code": "FM001",
-      "claim_name": "required_fields",
-      "description": "Required Agent Skills frontmatter fields",
-      "claim_type": "enum_set",
-      "authority": {
-        "vendor_file": "packages/skilllint/schemas/agentskills_io/v1.json",
-        "anchor_selector": null,
-        "authority_url": "https://agentskills.io/specification"
-      },
-      "extraction": {
-        "prompt_template": "Extract the required skill frontmatter field names from the JSON schema. Return a JSON array of strings. {{section}}",
-        "output_schema": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "post_processing": "sort"
-      },
-      "assertion_location": {
-        "file": "packages/skilllint/schemas/agentskills_io/v1.json",
-        "symbol": "$.required",
-        "source_type": "schema_json_enum"
-      },
-      "expected_value": [
-        "name",
-        "description"
-      ],
-      "x-audited": {
-        "date": "2026-03-14",
-        "source": "packages/skilllint/schemas/agentskills_io/v1.json"
-      }
-    },
     "FM007.tool_field_names": {
       "rule_code": "FM007",
       "claim_name": "tool_field_names",

--- a/packages/skilllint/schemas/provenance-registry.json
+++ b/packages/skilllint/schemas/provenance-registry.json
@@ -21,9 +21,9 @@
         "post_processing": null
       },
       "assertion_location": {
-        "file": "packages/skilllint/schemas/agentskills_io/v1.json",
-        "symbol": "$.properties.name.maxLength",
-        "source_type": "schema_json_field"
+        "file": "packages/skilllint/_spec_constants.py",
+        "symbol": "MAX_NAME_LENGTH",
+        "source_type": "python_constant"
       },
       "expected_value": 64,
       "x-audited": {

--- a/packages/skilllint/schemas/provenance-registry.json
+++ b/packages/skilllint/schemas/provenance-registry.json
@@ -190,6 +190,28 @@
         "date": "2026-09-04",
         "source": ".claude/vendor/sources/hooks-2026-08-28-0408.md"
       }
+    },
+    "AgentSkills.name_max_length": {
+      "rule_code": "FM010",
+      "claim_name": "name_max_length",
+      "description": "AgentSkills schema maximum name length",
+      "claim_type": "scalar",
+      "authority": {"vendor_file": "packages/skilllint/schemas/agentskills_io/v1.json", "anchor_selector": null, "authority_url": "https://agentskills.io/specification"},
+      "extraction": {"prompt_template": "Read maxLength for name.", "output_schema": {"type": "integer"}, "post_processing": "none"},
+      "assertion_location": {"file": "packages/skilllint/schemas/agentskills_io/v1.json", "symbol": "$.properties.name.maxLength", "source_type": "schema_json_field"},
+      "expected_value": 64,
+      "x-audited": {"date": "2026-09-12", "source": "packages/skilllint/schemas/agentskills_io/v1.json"}
+    },
+    "AgentSkills.required_fields": {
+      "rule_code": "FM001",
+      "claim_name": "required_fields",
+      "description": "AgentSkills schema required frontmatter fields",
+      "claim_type": "enum_set",
+      "authority": {"vendor_file": "packages/skilllint/schemas/agentskills_io/v1.json", "anchor_selector": null, "authority_url": "https://agentskills.io/specification"},
+      "extraction": {"prompt_template": "Read required fields.", "output_schema": {"type": "array", "items": {"type": "string"}}, "post_processing": "sort"},
+      "assertion_location": {"file": "packages/skilllint/schemas/agentskills_io/v1.json", "symbol": "$.required", "source_type": "schema_json_enum"},
+      "expected_value": ["description", "name"],
+      "x-audited": {"date": "2026-09-12", "source": "packages/skilllint/schemas/agentskills_io/v1.json"}
     }
   }
 }

--- a/packages/skilllint/schemas/provenance-registry.json
+++ b/packages/skilllint/schemas/provenance-registry.json
@@ -21,11 +21,45 @@
         "post_processing": null
       },
       "assertion_location": {
-        "file": "packages/skilllint/_spec_constants.py",
-        "symbol": "MAX_NAME_LENGTH",
-        "source_type": "python_constant"
+        "file": "packages/skilllint/schemas/agentskills_io/v1.json",
+        "symbol": "$.properties.name.maxLength",
+        "source_type": "schema_json_field"
       },
       "expected_value": 64,
+      "x-audited": {
+        "date": "2026-03-14",
+        "source": "packages/skilllint/schemas/agentskills_io/v1.json"
+      }
+    },
+    "FM001.required_fields": {
+      "rule_code": "FM001",
+      "claim_name": "required_fields",
+      "description": "Required Agent Skills frontmatter fields",
+      "claim_type": "enum_set",
+      "authority": {
+        "vendor_file": "packages/skilllint/schemas/agentskills_io/v1.json",
+        "anchor_selector": null,
+        "authority_url": "https://agentskills.io/specification"
+      },
+      "extraction": {
+        "prompt_template": "Extract the required skill frontmatter field names from the JSON schema. Return a JSON array of strings. {{section}}",
+        "output_schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "post_processing": "sort"
+      },
+      "assertion_location": {
+        "file": "packages/skilllint/schemas/agentskills_io/v1.json",
+        "symbol": "$.required",
+        "source_type": "schema_json_enum"
+      },
+      "expected_value": [
+        "name",
+        "description"
+      ],
       "x-audited": {
         "date": "2026-03-14",
         "source": "packages/skilllint/schemas/agentskills_io/v1.json"

--- a/packages/skilllint/tests/test_provenance_registry_locators.py
+++ b/packages/skilllint/tests/test_provenance_registry_locators.py
@@ -66,14 +66,14 @@ def _iter_claims() -> list[tuple[str, dict[str, Any]]]:
     return [*registry["claims"].items(), *opinions["opinions"].items()]
 
 
-def _resolve_schema_json_location(claim_id: str, location: dict[str, str]) -> object:
+def _resolve_schema_json_location(claim_id: str, location: dict[str, str]) -> JsonValue:
     recorded_file = location["file"]
     schema_path = REPO_ROOT / recorded_file
     assert schema_path.is_file(), f"{claim_id}: assertion_location.file '{recorded_file}' does not exist"
 
     symbol = location["symbol"]
     assert symbol.startswith("$."), f"{claim_id}: schema locator '{symbol}' must start with '$.'"
-    target: object = JSON_OBJECT.validate_json(schema_path.read_text(encoding="utf-8"))
+    target: JsonValue = JSON_OBJECT.validate_json(schema_path.read_text(encoding="utf-8"))
     for part in symbol.removeprefix("$.").split("."):
         assert isinstance(target, dict), f"{claim_id}: '{symbol}' cannot traverse '{part}'"
         assert part in target, f"{claim_id}: '{symbol}' has no segment '{part}'"

--- a/packages/skilllint/tests/test_provenance_registry_locators.py
+++ b/packages/skilllint/tests/test_provenance_registry_locators.py
@@ -106,6 +106,17 @@ def test_registry_does_not_attribute_agentskills_required_fields_to_fm001() -> N
     assert "FM001.required_fields" not in registry["claims"]
 
 
+def test_fm010_claim_tracks_the_enforced_name_length_constant() -> None:
+    registry = json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
+    location = registry["claims"]["FM010.max_name_length"]["assertion_location"]
+
+    assert location == {
+        "file": "packages/skilllint/_spec_constants.py",
+        "symbol": "MAX_NAME_LENGTH",
+        "source_type": "python_constant",
+    }
+
+
 @pytest.mark.parametrize(
     ("location", "expected_value"),
     [

--- a/packages/skilllint/tests/test_provenance_registry_locators.py
+++ b/packages/skilllint/tests/test_provenance_registry_locators.py
@@ -86,7 +86,7 @@ def _resolve_schema_json_location(claim_id: str, location: dict[str, str]) -> ob
     ("source_type", "symbol", "expected_value"),
     [
         ("schema_json_field", "$.properties.name.maxLength", 64),
-        ("schema_json_enum", "$.required", ["name", "description"]),
+        ("schema_json_enum", "$.required", ["description", "name"]),
     ],
 )
 def test_schema_json_locators_resolve_values(source_type: str, symbol: str, expected_value: object) -> None:
@@ -96,7 +96,14 @@ def test_schema_json_locators_resolve_values(source_type: str, symbol: str, expe
         "source_type": source_type,
     }
 
-    assert _resolve_schema_json_location("schema locator", location) == expected_value
+    actual = _resolve_schema_json_location("schema locator", location)
+    assert _normalize(actual) == _normalize(expected_value)
+
+
+def test_registry_does_not_attribute_agentskills_required_fields_to_fm001() -> None:
+    registry = json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
+
+    assert "FM001.required_fields" not in registry["claims"]
 
 
 @pytest.mark.parametrize(

--- a/packages/skilllint/tests/test_provenance_registry_locators.py
+++ b/packages/skilllint/tests/test_provenance_registry_locators.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import importlib
 import json
 import re
+import sys
 from pathlib import Path
 from re import Pattern
 from typing import Any
@@ -132,15 +133,35 @@ def test_schema_json_locators_reject_corrupted_values(location: dict[str, str], 
         assert _resolve_schema_json_location("corrupted schema locator", location) == expected_value
 
 
+def test_claim_locator_mismatch_reports_schema_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    claims = [
+        (
+            "FM010.max_name_length",
+            {
+                "assertion_location": {
+                    "file": "packages/skilllint/schemas/agentskills_io/v1.json",
+                    "symbol": "$.properties.name.maxLength",
+                    "source_type": "schema_json_field",
+                },
+                "expected_value": 65,
+            },
+        )
+    ]
+    monkeypatch.setattr(sys.modules[__name__], "_iter_claims", lambda: claims)
+
+    with pytest.raises(AssertionError, match=r"agentskills_io/v1\.json"):
+        test_claim_locators_resolve_and_values_match()
+
+
 def test_claim_locators_resolve_and_values_match() -> None:
     for claim_id, claim in _iter_claims():
         location = claim["assertion_location"]
         source_type = location["source_type"]
+        recorded_file = location["file"]
         assert source_type in _KNOWN_SOURCE_TYPES, f"{claim_id}: unrecognized source_type '{source_type}'"
 
         match source_type:
             case "python_constant":
-                recorded_file = location["file"]
                 assert (REPO_ROOT / recorded_file).is_file(), (
                     f"{claim_id}: assertion_location.file '{recorded_file}' does not exist"
                 )

--- a/packages/skilllint/tests/test_provenance_registry_locators.py
+++ b/packages/skilllint/tests/test_provenance_registry_locators.py
@@ -94,7 +94,7 @@ def _resolve_schema_json_location(claim_id: str, location: dict[str, str]) -> Js
         ("schema_json_enum", "$.required", ["description", "name"]),
     ],
 )
-def test_schema_json_locators_resolve_values(source_type: str, symbol: str, expected_value: object) -> None:
+def test_schema_json_locators_resolve_values(source_type: str, symbol: str, expected_value: JsonValue) -> None:
     location = {
         "file": "packages/skilllint/schemas/agentskills_io/v1.json",
         "symbol": symbol,
@@ -151,7 +151,7 @@ def test_fm010_claim_tracks_the_enforced_name_length_constant() -> None:
         ),
     ],
 )
-def test_schema_json_locators_reject_corrupted_values(location: dict[str, str], expected_value: object) -> None:
+def test_schema_json_locators_reject_corrupted_values(location: dict[str, str], expected_value: JsonValue) -> None:
     with pytest.raises(AssertionError):
         assert _resolve_schema_json_location("corrupted schema locator", location) == expected_value
 

--- a/packages/skilllint/tests/test_provenance_registry_locators.py
+++ b/packages/skilllint/tests/test_provenance_registry_locators.py
@@ -205,6 +205,27 @@ def test_claim_locators_reject_scalar_type_changes(monkeypatch: pytest.MonkeyPat
         test_claim_locators_resolve_and_values_match()
 
 
+def test_claim_locators_reject_non_string_expected_enum_members(monkeypatch: pytest.MonkeyPatch) -> None:
+    claims = [
+        (
+            "schema.numeric_enum_member",
+            {
+                "assertion_location": {
+                    "file": "packages/skilllint/schemas/agentskills_io/v1.json",
+                    "symbol": "$.required",
+                    "source_type": "schema_json_enum",
+                },
+                "expected_value": [1],
+            },
+        )
+    ]
+    monkeypatch.setattr(sys.modules[__name__], "_iter_claims", lambda: claims)
+    monkeypatch.setattr(sys.modules[__name__], "_resolve_schema_json_location", lambda _claim, _location: ["1"])
+
+    with pytest.raises(AssertionError, match="only strings"):
+        test_claim_locators_resolve_and_values_match()
+
+
 def test_claim_locators_resolve_and_values_match() -> None:
     for claim_id, claim in _iter_claims():
         location = claim["assertion_location"]
@@ -231,6 +252,12 @@ def test_claim_locators_resolve_and_values_match() -> None:
                 raise AssertionError(f"{claim_id}: unrecognized source_type '{source_type}'")
 
         assert "expected_value" in claim, f"{claim_id}: missing expected_value"
+        if source_type == "schema_json_enum":
+            expected_members = claim["expected_value"]
+            assert isinstance(expected_members, list), f"{claim_id}: schema_json_enum expected_value must be an array"
+            assert all(isinstance(member, str) for member in expected_members), (
+                f"{claim_id}: schema_json_enum expected_value must contain only strings"
+            )
         actual = _normalize(target)
         expected = _normalize(claim["expected_value"])
         assert type(actual) is type(expected), (

--- a/packages/skilllint/tests/test_provenance_registry_locators.py
+++ b/packages/skilllint/tests/test_provenance_registry_locators.py
@@ -23,6 +23,8 @@ from pathlib import Path
 from re import Pattern
 from typing import Any
 
+import pytest
+
 REPO_ROOT = Path(__file__).parent.parent.parent.parent
 SCHEMAS_DIR = REPO_ROOT / "packages" / "skilllint" / "schemas"
 REGISTRY_PATH = SCHEMAS_DIR / "provenance-registry.json"
@@ -61,27 +63,99 @@ def _iter_claims() -> list[tuple[str, dict[str, Any]]]:
     return [*registry["claims"].items(), *opinions["opinions"].items()]
 
 
+def _resolve_schema_json_location(claim_id: str, location: dict[str, str]) -> object:
+    recorded_file = location["file"]
+    schema_path = REPO_ROOT / recorded_file
+    assert schema_path.is_file(), f"{claim_id}: assertion_location.file '{recorded_file}' does not exist"
+
+    symbol = location["symbol"]
+    assert symbol.startswith("$."), f"{claim_id}: schema locator '{symbol}' must start with '$.'"
+    target: object = json.loads(schema_path.read_text(encoding="utf-8"))
+    for part in symbol.removeprefix("$.").split("."):
+        assert isinstance(target, dict), f"{claim_id}: '{symbol}' cannot traverse '{part}'"
+        assert part in target, f"{claim_id}: '{symbol}' has no segment '{part}'"
+        target = target[part]
+
+    if location["source_type"] == "schema_json_enum":
+        assert isinstance(target, list), f"{claim_id}: schema_json_enum '{symbol}' must resolve to a JSON array"
+    return target
+
+
+@pytest.mark.parametrize(
+    ("source_type", "symbol", "expected_value"),
+    [
+        ("schema_json_field", "$.properties.name.maxLength", 64),
+        ("schema_json_enum", "$.required", ["name", "description"]),
+    ],
+)
+def test_schema_json_locators_resolve_values(source_type: str, symbol: str, expected_value: object) -> None:
+    location = {
+        "file": "packages/skilllint/schemas/agentskills_io/v1.json",
+        "symbol": symbol,
+        "source_type": source_type,
+    }
+
+    assert _resolve_schema_json_location("schema locator", location) == expected_value
+
+
+@pytest.mark.parametrize(
+    ("location", "expected_value"),
+    [
+        (
+            {
+                "file": "packages/skilllint/schemas/does-not-exist.json",
+                "symbol": "$.properties.name.maxLength",
+                "source_type": "schema_json_field",
+            },
+            64,
+        ),
+        (
+            {
+                "file": "packages/skilllint/schemas/agentskills_io/v1.json",
+                "symbol": "$.properties.name.doesNotExist",
+                "source_type": "schema_json_field",
+            },
+            64,
+        ),
+        (
+            {
+                "file": "packages/skilllint/schemas/agentskills_io/v1.json",
+                "symbol": "$.required",
+                "source_type": "schema_json_enum",
+            },
+            ["name"],
+        ),
+    ],
+)
+def test_schema_json_locators_reject_corrupted_values(location: dict[str, str], expected_value: object) -> None:
+    with pytest.raises(AssertionError):
+        assert _resolve_schema_json_location("corrupted schema locator", location) == expected_value
+
+
 def test_claim_locators_resolve_and_values_match() -> None:
-    """Every python_constant assertion_location must import, resolve, and match."""
     for claim_id, claim in _iter_claims():
         location = claim["assertion_location"]
         source_type = location["source_type"]
         assert source_type in _KNOWN_SOURCE_TYPES, f"{claim_id}: unrecognized source_type '{source_type}'"
-        if source_type != "python_constant":
-            continue
 
-        recorded_file = location["file"]
-        assert (REPO_ROOT / recorded_file).is_file(), (
-            f"{claim_id}: assertion_location.file '{recorded_file}' does not exist"
-        )
+        match source_type:
+            case "python_constant":
+                recorded_file = location["file"]
+                assert (REPO_ROOT / recorded_file).is_file(), (
+                    f"{claim_id}: assertion_location.file '{recorded_file}' does not exist"
+                )
 
-        module_name = recorded_file.removeprefix("packages/").removesuffix(".py").replace("/", ".")
-        target: object = importlib.import_module(module_name)
-        for part in location["symbol"].split("."):
-            assert hasattr(target, part), (
-                f"{claim_id}: {recorded_file} has no symbol '{location['symbol']}' (missing '{part}')"
-            )
-            target = getattr(target, part)
+                module_name = recorded_file.removeprefix("packages/").removesuffix(".py").replace("/", ".")
+                target: object = importlib.import_module(module_name)
+                for part in location["symbol"].split("."):
+                    assert hasattr(target, part), (
+                        f"{claim_id}: {recorded_file} has no symbol '{location['symbol']}' (missing '{part}')"
+                    )
+                    target = getattr(target, part)
+            case "schema_json_field" | "schema_json_enum":
+                target = _resolve_schema_json_location(claim_id, location)
+            case _:
+                raise AssertionError(f"{claim_id}: unrecognized source_type '{source_type}'")
 
         assert "expected_value" in claim, f"{claim_id}: missing expected_value"
         actual = _normalize(target)

--- a/packages/skilllint/tests/test_provenance_registry_locators.py
+++ b/packages/skilllint/tests/test_provenance_registry_locators.py
@@ -25,9 +25,11 @@ from re import Pattern
 from typing import Any
 
 import pytest
+from pydantic import JsonValue, TypeAdapter
 
 REPO_ROOT = Path(__file__).parent.parent.parent.parent
 SCHEMAS_DIR = REPO_ROOT / "packages" / "skilllint" / "schemas"
+JSON_OBJECT = TypeAdapter(dict[str, JsonValue])
 REGISTRY_PATH = SCHEMAS_DIR / "provenance-registry.json"
 OPINION_CATALOG_PATH = SCHEMAS_DIR / "opinion-catalog.json"
 
@@ -71,7 +73,7 @@ def _resolve_schema_json_location(claim_id: str, location: dict[str, str]) -> ob
 
     symbol = location["symbol"]
     assert symbol.startswith("$."), f"{claim_id}: schema locator '{symbol}' must start with '$.'"
-    target: object = json.loads(schema_path.read_text(encoding="utf-8"))
+    target: object = JSON_OBJECT.validate_json(schema_path.read_text(encoding="utf-8"))
     for part in symbol.removeprefix("$.").split("."):
         assert isinstance(target, dict), f"{claim_id}: '{symbol}' cannot traverse '{part}'"
         assert part in target, f"{claim_id}: '{symbol}' has no segment '{part}'"

--- a/packages/skilllint/tests/test_provenance_registry_locators.py
+++ b/packages/skilllint/tests/test_provenance_registry_locators.py
@@ -184,6 +184,27 @@ def test_claim_locator_mismatch_reports_schema_file(monkeypatch: pytest.MonkeyPa
         test_claim_locators_resolve_and_values_match()
 
 
+def test_claim_locators_reject_scalar_type_changes(monkeypatch: pytest.MonkeyPatch) -> None:
+    claims = [
+        (
+            "schema.boolean_drift",
+            {
+                "assertion_location": {
+                    "file": "packages/skilllint/schemas/agentskills_io/v1.json",
+                    "symbol": "$.properties.enabled.default",
+                    "source_type": "schema_json_field",
+                },
+                "expected_value": 1,
+            },
+        )
+    ]
+    monkeypatch.setattr(sys.modules[__name__], "_iter_claims", lambda: claims)
+    monkeypatch.setattr(sys.modules[__name__], "_resolve_schema_json_location", lambda _claim, _location: True)
+
+    with pytest.raises(AssertionError, match="type"):
+        test_claim_locators_resolve_and_values_match()
+
+
 def test_claim_locators_resolve_and_values_match() -> None:
     for claim_id, claim in _iter_claims():
         location = claim["assertion_location"]
@@ -212,6 +233,10 @@ def test_claim_locators_resolve_and_values_match() -> None:
         assert "expected_value" in claim, f"{claim_id}: missing expected_value"
         actual = _normalize(target)
         expected = _normalize(claim["expected_value"])
+        assert type(actual) is type(expected), (
+            f"{claim_id}: {recorded_file}.{location['symbol']} has type {type(actual).__name__}, "
+            f"but expected_value has type {type(expected).__name__}"
+        )
         assert actual == expected, (
             f"{claim_id}: {recorded_file}.{location['symbol']} is {actual!r}, but expected_value says {expected!r}"
         )

--- a/packages/skilllint/tests/test_provenance_registry_locators.py
+++ b/packages/skilllint/tests/test_provenance_registry_locators.py
@@ -222,7 +222,27 @@ def test_claim_locators_reject_non_string_expected_enum_members(monkeypatch: pyt
     monkeypatch.setattr(sys.modules[__name__], "_iter_claims", lambda: claims)
     monkeypatch.setattr(sys.modules[__name__], "_resolve_schema_json_location", lambda _claim, _location: ["1"])
 
-    with pytest.raises(AssertionError, match="only strings"):
+    with pytest.raises(AssertionError, match="types"):
+        test_claim_locators_resolve_and_values_match()
+
+
+def test_claim_locators_reject_array_member_type_changes(monkeypatch: pytest.MonkeyPatch) -> None:
+    claims = [
+        (
+            "schema.array_drift",
+            {
+                "assertion_location": {
+                    "file": "packages/skilllint/schemas/agentskills_io/v1.json",
+                    "symbol": "$.properties.name.examples",
+                    "source_type": "schema_json_field",
+                },
+                "expected_value": ["1"],
+            },
+        )
+    ]
+    monkeypatch.setattr(sys.modules[__name__], "_iter_claims", lambda: claims)
+    monkeypatch.setattr(sys.modules[__name__], "_resolve_schema_json_location", lambda _claim, _location: [1])
+    with pytest.raises(AssertionError, match="type"):
         test_claim_locators_resolve_and_values_match()
 
 
@@ -252,6 +272,10 @@ def test_claim_locators_resolve_and_values_match() -> None:
                 raise AssertionError(f"{claim_id}: unrecognized source_type '{source_type}'")
 
         assert "expected_value" in claim, f"{claim_id}: missing expected_value"
+        if isinstance(target, list) and isinstance(claim["expected_value"], list):
+            assert [type(member) for member in target] == [type(member) for member in claim["expected_value"]], (
+                f"{claim_id}: {recorded_file}.{location['symbol']} array members have different types"
+            )
         if source_type == "schema_json_enum":
             expected_members = claim["expected_value"]
             assert isinstance(expected_members, list), f"{claim_id}: schema_json_enum expected_value must be an array"

--- a/packages/skilllint/tests/test_provenance_registry_locators.py
+++ b/packages/skilllint/tests/test_provenance_registry_locators.py
@@ -246,6 +246,27 @@ def test_claim_locators_reject_array_member_type_changes(monkeypatch: pytest.Mon
         test_claim_locators_resolve_and_values_match()
 
 
+def test_claim_locators_reject_non_string_field_set_members(monkeypatch: pytest.MonkeyPatch) -> None:
+    claims = [
+        (
+            "schema.field_set",
+            {
+                "claim_type": "field_set",
+                "assertion_location": {
+                    "file": "packages/skilllint/schemas/agentskills_io/v1.json",
+                    "symbol": "$.properties.name.examples",
+                    "source_type": "schema_json_field",
+                },
+                "expected_value": [1],
+            },
+        )
+    ]
+    monkeypatch.setattr(sys.modules[__name__], "_iter_claims", lambda: claims)
+    monkeypatch.setattr(sys.modules[__name__], "_resolve_schema_json_location", lambda _claim, _location: [1])
+    with pytest.raises(AssertionError, match="only strings"):
+        test_claim_locators_resolve_and_values_match()
+
+
 def test_claim_locators_resolve_and_values_match() -> None:
     for claim_id, claim in _iter_claims():
         location = claim["assertion_location"]
@@ -272,6 +293,17 @@ def test_claim_locators_resolve_and_values_match() -> None:
                 raise AssertionError(f"{claim_id}: unrecognized source_type '{source_type}'")
 
         assert "expected_value" in claim, f"{claim_id}: missing expected_value"
+        if claim.get("claim_type") in {"enum_set", "field_set"}:
+            assert isinstance(target, (list, tuple, set, frozenset)), (
+                f"{claim_id}: set claim resolved value must be a collection"
+            )
+            assert all(isinstance(member, str) for member in target), (
+                f"{claim_id}: set claim resolved value must contain only strings"
+            )
+            assert isinstance(claim["expected_value"], list), f"{claim_id}: set claim expected_value must be an array"
+            assert all(isinstance(member, str) for member in claim["expected_value"]), (
+                f"{claim_id}: set claim expected_value must contain only strings"
+            )
         if isinstance(target, list) and isinstance(claim["expected_value"], list):
             assert [type(member) for member in target] == [type(member) for member in claim["expected_value"]], (
                 f"{claim_id}: {recorded_file}.{location['symbol']} array members have different types"

--- a/packages/skilllint/tests/test_provenance_registry_locators.py
+++ b/packages/skilllint/tests/test_provenance_registry_locators.py
@@ -79,6 +79,9 @@ def _resolve_schema_json_location(claim_id: str, location: dict[str, str]) -> ob
 
     if location["source_type"] == "schema_json_enum":
         assert isinstance(target, list), f"{claim_id}: schema_json_enum '{symbol}' must resolve to a JSON array"
+        assert all(isinstance(member, str) for member in target), (
+            f"{claim_id}: schema_json_enum '{symbol}' must contain only strings"
+        )
     return target
 
 
@@ -149,6 +152,16 @@ def test_fm010_claim_tracks_the_enforced_name_length_constant() -> None:
 def test_schema_json_locators_reject_corrupted_values(location: dict[str, str], expected_value: object) -> None:
     with pytest.raises(AssertionError):
         assert _resolve_schema_json_location("corrupted schema locator", location) == expected_value
+
+
+def test_schema_json_enum_locators_reject_non_string_members(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    schema_path = tmp_path / "schema.json"
+    schema_path.write_text('{"required": [1]}', encoding="utf-8")
+    monkeypatch.setattr(sys.modules[__name__], "REPO_ROOT", tmp_path)
+    location = {"file": "schema.json", "symbol": "$.required", "source_type": "schema_json_enum"}
+
+    with pytest.raises(AssertionError, match="only strings"):
+        _resolve_schema_json_location("schema enum locator", location)
 
 
 def test_claim_locator_mismatch_reports_schema_file(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/scripts/assert_installed_artifact.py
+++ b/scripts/assert_installed_artifact.py
@@ -66,16 +66,19 @@ def _executable(venv_path: Path, name: str) -> Path:
 
 
 def _environment(cache_directory: Path) -> dict[str, str]:
+    # IANA assigns TCP port 1 to tcpmux; loopback keeps dependency checks offline.
+    # https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml
+    offline_proxy = "http://127.0.0.1:1"
     return {
         **{
             key: value
             for key, value in os.environ.items()
             if key.upper() not in {"NO_PROXY", "PYTHONPATH", "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY"}
         },
-        "ALL_PROXY": "http://127.0.0.1:1",
+        "ALL_PROXY": offline_proxy,
         "DATA_GYM_CACHE_DIR": str(cache_directory),
-        "HTTP_PROXY": "http://127.0.0.1:1",
-        "HTTPS_PROXY": "http://127.0.0.1:1",
+        "HTTP_PROXY": offline_proxy,
+        "HTTPS_PROXY": offline_proxy,
         "TIKTOKEN_CACHE_DIR": str(cache_directory),
     }
 

--- a/tests/test_refresh_claim_values.py
+++ b/tests/test_refresh_claim_values.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
+from pydantic import JsonValue
 from scripts import refresh_claim_values as refresh
 
 from skilllint.vendor_cache import CacheResult, CacheStatus, NoCacheError
@@ -19,7 +20,7 @@ REPO_ROOT = Path(__file__).parent.parent
 AUTHORITY_URL = "https://example.test/hooks.md"
 
 
-def _registry() -> dict[str, object]:
+def _registry() -> dict[str, JsonValue]:
     return {
         "description": "Registry — exact bytes",
         "claims": {


### PR DESCRIPTION
Part of #146

## Summary
- Resolve schema_json_field and schema_json_enum assertion locators from tracked JSON schemas.
- Enroll a field locator and an enum locator in the provenance registry.
- Reject missing files, missing JSON-path segments, and corrupted expected values.

## Evidence
- Red: locator tests failed before the resolver existed.
- Green: `uv run pytest -o addopts= -q packages/skilllint/tests/test_provenance_registry_locators.py` (7 passed).
- `uv run prek run --all-files` passed.
- Manual: `uv run skilllint rule FM001` exited 0.
- `uv run pytest` completed with 1606 passed, 10 skipped, and 5 unrelated failures caused by Claude plugin validation timing out after 3 seconds in existing CLI/AS008 tests.

## Non-goals
- No fourth locator type or generic schema engine.
- #146 remains open; enrollment discovery is deferred.