### PR TITLE
fix(fixer): persist declared tool-list normalization

### DIFF
--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -255,6 +255,16 @@ def _replace_list_valued_tool_fields(frontmatter_text: str, data: dict[str, Yaml
     return frontmatter_text
 
 
+def _is_losslessly_scalar_tool_list(values: YamlValue) -> bool:
+    if not isinstance(values, list):
+        return False
+    return all(
+        str(value) and "," not in str(value) and not re.search(r"\s", str(value))
+        for value in values
+        if value is not None
+    )
+
+
 def _comment_lines(comment_data: object) -> list[str]:
     if isinstance(comment_data, CommentToken):
         return [line.removeprefix("#").removeprefix(" ") for line in comment_data.value.splitlines()]
@@ -2413,11 +2423,7 @@ class FrontmatterValidator:
         tool_fields = {"tools", "disallowedTools", "allowed-tools"}
         for field_name in tool_fields:
             original_value = original_data.get(field_name)
-            if isinstance(original_value, list) and all(
-                str(value) and "," not in str(value) and not re.search(r"\s", str(value))
-                for value in original_value
-                if value is not None
-            ):
+            if isinstance(original_value, list) and _is_losslessly_scalar_tool_list(original_value):
                 normalized_dict[field_name] = ", ".join(str(x) for x in original_value if x is not None)
                 fixes.append(f"Converted {field_name} from YAML array to comma-separated string")
         for key, value in normalized_dict.items():
@@ -2472,12 +2478,14 @@ class FrontmatterValidator:
             f"Converted {field_name} from YAML array to comma-separated string"
             for field_name in ("tools", "disallowedTools", "allowed-tools")
             if isinstance(original_data.get(field_name), list)
+            and _is_losslessly_scalar_tool_list(original_data[field_name])
         }
         tool_values = {
             field_name: value
             for field_name, value in normalized_dict.items()
             if field_name in {"tools", "disallowedTools", "allowed-tools"}
             and isinstance(original_data.get(field_name), list)
+            and _is_losslessly_scalar_tool_list(original_data[field_name])
             and isinstance(value, str)
         }
         if set(fixes) == tool_list_fixes:

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -54,6 +54,7 @@ from ruamel.yaml import YAML, YAMLError
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from ruamel.yaml.nodes import MappingNode, SequenceNode
 from ruamel.yaml.scalarstring import DoubleQuotedScalarString
+from ruamel.yaml.tokens import CommentToken
 
 import skilllint.rules  # ruff: ignore[unused-import] — ensures all 15 series modules register into RULE_REGISTRY
 from skilllint.adapters import PlatformAdapter, load_adapters, matches_file
@@ -238,6 +239,7 @@ def _replace_list_valued_tool_fields(frontmatter_text: str, data: dict[str, Yaml
             if (
                 value_node.start_mark.index < key_node.end_mark.index
                 or "&" in frontmatter_text[key_node.end_mark.index : value_node.end_mark.index]
+                or "#" in frontmatter_text[key_node.end_mark.index : value_node.end_mark.index]
                 or not separator.startswith(":")
             ):
                 return None
@@ -253,14 +255,31 @@ def _replace_list_valued_tool_fields(frontmatter_text: str, data: dict[str, Yaml
     return frontmatter_text
 
 
+def _comment_lines(comment_data: object) -> list[str]:
+    if isinstance(comment_data, CommentToken):
+        return [line.lstrip("# ") for line in comment_data.value.splitlines()]
+    if isinstance(comment_data, list):
+        return [line for item in comment_data for line in _comment_lines(item)]
+    if isinstance(comment_data, tuple):
+        return [line for item in comment_data for line in _comment_lines(item)]
+    if isinstance(comment_data, dict):
+        return [line for item in comment_data.values() for line in _comment_lines(item)]
+    return []
+
+
 def _dump_tool_list_fixes(frontmatter_text: str, tool_values: dict[str, str]) -> str | None:
     data = _rt_yaml.load(frontmatter_text)
     if not isinstance(data, CommentedMap):
         return None
     for field_name, value in tool_values.items():
         original_value = data.get(field_name)
+        comment_lines = _comment_lines(data.ca.items.get(field_name))
         if isinstance(original_value, CommentedSeq) and original_value.anchor.value is not None:
             original_value.yaml_set_anchor(original_value.anchor.value, always_dump=True)
+        if isinstance(original_value, CommentedSeq):
+            comment_lines.extend(_comment_lines(original_value.ca.items))
+        if comment_lines:
+            data.yaml_set_comment_before_after_key(field_name, before="\n".join(comment_lines))
         data[field_name] = value
     buffer = StringIO()
     _rt_yaml.dump(data, buffer)

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -234,14 +234,20 @@ def _replace_list_valued_tool_fields(frontmatter_text: str, data: dict[str, Yaml
             and isinstance(value, list)
             and isinstance(value_node, SequenceNode)
         ):
+            separator = frontmatter_text[key_node.end_mark.index : value_node.start_mark.index]
             if (
                 value_node.start_mark.index < key_node.end_mark.index
                 or "&" in frontmatter_text[key_node.end_mark.index : value_node.end_mark.index]
+                or not separator.startswith(":")
             ):
                 return None
-            replacement_value = ", ".join(str(item) for item in value) or "''"
+            scalar_buffer = StringIO()
+            _rt_yaml.dump({"value": ", ".join(str(item) for item in value)}, scalar_buffer)
+            replacement_value = scalar_buffer.getvalue().removeprefix("value: ").rstrip()
             replacements.append((key_node.end_mark.index, value_node.end_mark.index, f": {replacement_value}"))
 
+    if not replacements:
+        return None
     for start, end, replacement in reversed(replacements):
         frontmatter_text = f"{frontmatter_text[:start]}{replacement}{frontmatter_text[end:]}"
     return frontmatter_text

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -244,7 +244,7 @@ def _replace_list_valued_tool_fields(frontmatter_text: str, data: dict[str, Yaml
             ):
                 return None
             scalar_buffer = StringIO()
-            _rt_yaml.dump({"value": ", ".join(str(item) for item in value)}, scalar_buffer)
+            _rt_yaml.dump({"value": ", ".join(str(item) for item in value if item is not None)}, scalar_buffer)
             replacement_value = scalar_buffer.getvalue().removeprefix("value: ").rstrip()
             replacements.append((key_node.end_mark.index, value_node.end_mark.index, f": {replacement_value}"))
 
@@ -2414,7 +2414,7 @@ class FrontmatterValidator:
         for field_name in tool_fields:
             original_value = original_data.get(field_name)
             if isinstance(original_value, list):
-                normalized_dict[field_name] = ", ".join(str(x) for x in original_value)
+                normalized_dict[field_name] = ", ".join(str(x) for x in original_value if x is not None)
                 fixes.append(f"Converted {field_name} from YAML array to comma-separated string")
         for key, value in normalized_dict.items():
             if key in tool_fields:

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -51,6 +51,7 @@ from git.exc import InvalidGitRepositoryError, NoSuchPathError
 from git.index.fun import entry_key
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from ruamel.yaml import YAML, YAMLError
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from ruamel.yaml.nodes import MappingNode, SequenceNode
 from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 
@@ -219,10 +220,10 @@ def _dump_yaml(data: dict[str, YamlValue]) -> str:
     return buf.getvalue()
 
 
-def _replace_list_valued_tool_fields(frontmatter_text: str, data: dict[str, YamlValue]) -> str:
+def _replace_list_valued_tool_fields(frontmatter_text: str, data: dict[str, YamlValue]) -> str | None:
     document = _rt_yaml.compose(frontmatter_text)
     if not isinstance(document, MappingNode):
-        return frontmatter_text
+        return None
 
     replacements: list[tuple[int, int, str]] = []
     for key_node, value_node in document.value:
@@ -233,15 +234,31 @@ def _replace_list_valued_tool_fields(frontmatter_text: str, data: dict[str, Yaml
             and isinstance(value, list)
             and isinstance(value_node, SequenceNode)
         ):
-            replacements.append((
-                key_node.end_mark.index,
-                value_node.end_mark.index,
-                f": {', '.join(str(item) for item in value)}",
-            ))
+            if (
+                value_node.start_mark.index < key_node.end_mark.index
+                or "&" in frontmatter_text[key_node.end_mark.index : value_node.end_mark.index]
+            ):
+                return None
+            replacement_value = ", ".join(str(item) for item in value) or "''"
+            replacements.append((key_node.end_mark.index, value_node.end_mark.index, f": {replacement_value}"))
 
     for start, end, replacement in reversed(replacements):
         frontmatter_text = f"{frontmatter_text[:start]}{replacement}{frontmatter_text[end:]}"
     return frontmatter_text
+
+
+def _dump_tool_list_fixes(frontmatter_text: str, tool_values: dict[str, str]) -> str | None:
+    data = _rt_yaml.load(frontmatter_text)
+    if not isinstance(data, CommentedMap):
+        return None
+    for field_name, value in tool_values.items():
+        original_value = data.get(field_name)
+        if isinstance(original_value, CommentedSeq) and original_value.anchor.value is not None:
+            original_value.yaml_set_anchor(original_value.anchor.value, always_dump=True)
+        data[field_name] = value
+    buffer = StringIO()
+    _rt_yaml.dump(data, buffer)
+    return buffer.getvalue()
 
 
 def _fix_unquoted_colons(frontmatter_text: str) -> tuple[str, list[str], list[str]]:
@@ -2428,9 +2445,20 @@ class FrontmatterValidator:
             if isinstance(original_data.get(field_name), list)
         }
         if set(fixes) == tool_list_fixes:
-            return content.replace(
-                frontmatter_text, _replace_list_valued_tool_fields(frontmatter_text, original_data), 1
-            ), fixes
+            rewritten_frontmatter = _replace_list_valued_tool_fields(frontmatter_text, original_data)
+            if rewritten_frontmatter is not None:
+                return content.replace(frontmatter_text, rewritten_frontmatter, 1), fixes
+            tool_values = {
+                field_name: value
+                for field_name, value in normalized_dict.items()
+                if field_name in {"tools", "disallowedTools", "allowed-tools"}
+                and isinstance(original_data.get(field_name), list)
+                and isinstance(value, str)
+            }
+        if len(tool_values) == len(fixes):
+            yaml = _dump_tool_list_fixes(frontmatter_text, tool_values)
+            if yaml is not None:
+                return f"---\n{yaml}---\n{body}", fixes
         return f"---\n{_dump_yaml(normalized_dict)}---\n{body}", fixes
 
     def _apply_fixes(self, content: str, file_type: FileType, file_path: Path | None = None) -> tuple[str, list[str]]:

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -223,7 +223,7 @@ def _dump_yaml(data: dict[str, YamlValue]) -> str:
 
 def _replace_list_valued_tool_fields(frontmatter_text: str, data: dict[str, YamlValue]) -> str | None:
     document = _rt_yaml.compose(frontmatter_text)
-    if not isinstance(document, MappingNode):
+    if not isinstance(document, MappingNode) or document.flow_style:
         return None
 
     replacements: list[tuple[int, int, str]] = []

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -2344,9 +2344,9 @@ class FrontmatterValidator:
             normalized_dict["skills"] = original_data["skills"]
         tool_fields = {"tools", "disallowedTools", "allowed-tools"}
         for field_name in tool_fields:
-            val = normalized_dict.get(field_name)
-            if isinstance(val, list):
-                normalized_dict[field_name] = ", ".join(str(x) for x in val)
+            original_value = original_data.get(field_name)
+            if isinstance(original_value, list):
+                normalized_dict[field_name] = ", ".join(str(x) for x in original_value)
                 fixes.append(f"Converted {field_name} from YAML array to comma-separated string")
         for key, value in normalized_dict.items():
             if key in tool_fields:

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -2444,17 +2444,17 @@ class FrontmatterValidator:
             for field_name in ("tools", "disallowedTools", "allowed-tools")
             if isinstance(original_data.get(field_name), list)
         }
+        tool_values = {
+            field_name: value
+            for field_name, value in normalized_dict.items()
+            if field_name in {"tools", "disallowedTools", "allowed-tools"}
+            and isinstance(original_data.get(field_name), list)
+            and isinstance(value, str)
+        }
         if set(fixes) == tool_list_fixes:
             rewritten_frontmatter = _replace_list_valued_tool_fields(frontmatter_text, original_data)
             if rewritten_frontmatter is not None:
                 return content.replace(frontmatter_text, rewritten_frontmatter, 1), fixes
-            tool_values = {
-                field_name: value
-                for field_name, value in normalized_dict.items()
-                if field_name in {"tools", "disallowedTools", "allowed-tools"}
-                and isinstance(original_data.get(field_name), list)
-                and isinstance(value, str)
-            }
         if len(tool_values) == len(fixes):
             yaml = _dump_tool_list_fixes(frontmatter_text, tool_values)
             if yaml is not None:

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -227,6 +227,7 @@ def _replace_list_valued_tool_fields(frontmatter_text: str, data: dict[str, Yaml
         return None
 
     replacements: list[tuple[int, int, str]] = []
+    replaced_fields: set[str] = set()
     for key_node, value_node in document.value:
         field_name = key_node.value
         value = data.get(field_name)
@@ -247,8 +248,14 @@ def _replace_list_valued_tool_fields(frontmatter_text: str, data: dict[str, Yaml
             _rt_yaml.dump({"value": ", ".join(str(item) for item in value if item is not None)}, scalar_buffer)
             replacement_value = scalar_buffer.getvalue().removeprefix("value: ").rstrip()
             replacements.append((key_node.end_mark.index, value_node.end_mark.index, f": {replacement_value}"))
+            replaced_fields.add(field_name)
 
-    if not replacements:
+    requested_fields = {
+        field_name
+        for field_name in ("tools", "disallowedTools", "allowed-tools")
+        if isinstance(data.get(field_name), list)
+    }
+    if not replacements or replaced_fields != requested_fields:
         return None
     for start, end, replacement in reversed(replacements):
         frontmatter_text = f"{frontmatter_text[:start]}{replacement}{frontmatter_text[end:]}"

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -2413,7 +2413,11 @@ class FrontmatterValidator:
         tool_fields = {"tools", "disallowedTools", "allowed-tools"}
         for field_name in tool_fields:
             original_value = original_data.get(field_name)
-            if isinstance(original_value, list):
+            if isinstance(original_value, list) and all(
+                str(value) and "," not in str(value) and not re.search(r"\s", str(value))
+                for value in original_value
+                if value is not None
+            ):
                 normalized_dict[field_name] = ", ".join(str(x) for x in original_value if x is not None)
                 fixes.append(f"Converted {field_name} from YAML array to comma-separated string")
         for key, value in normalized_dict.items():

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -257,7 +257,7 @@ def _replace_list_valued_tool_fields(frontmatter_text: str, data: dict[str, Yaml
 
 def _comment_lines(comment_data: object) -> list[str]:
     if isinstance(comment_data, CommentToken):
-        return [line.lstrip("# ") for line in comment_data.value.splitlines()]
+        return [line.removeprefix("#").removeprefix(" ") for line in comment_data.value.splitlines()]
     if isinstance(comment_data, list):
         return [line for item in comment_data for line in _comment_lines(item)]
     if isinstance(comment_data, tuple):

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -51,6 +51,7 @@ from git.exc import InvalidGitRepositoryError, NoSuchPathError
 from git.index.fun import entry_key
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from ruamel.yaml import YAML, YAMLError
+from ruamel.yaml.nodes import MappingNode, SequenceNode
 from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 
 import skilllint.rules  # ruff: ignore[unused-import] — ensures all 15 series modules register into RULE_REGISTRY
@@ -216,6 +217,31 @@ def _dump_yaml(data: dict[str, YamlValue]) -> str:
     buf = StringIO()
     _rt_yaml.dump(prepared, buf)
     return buf.getvalue()
+
+
+def _replace_list_valued_tool_fields(frontmatter_text: str, data: dict[str, YamlValue]) -> str:
+    document = _rt_yaml.compose(frontmatter_text)
+    if not isinstance(document, MappingNode):
+        return frontmatter_text
+
+    replacements: list[tuple[int, int, str]] = []
+    for key_node, value_node in document.value:
+        field_name = key_node.value
+        value = data.get(field_name)
+        if (
+            field_name in {"tools", "disallowedTools", "allowed-tools"}
+            and isinstance(value, list)
+            and isinstance(value_node, SequenceNode)
+        ):
+            replacements.append((
+                key_node.end_mark.index,
+                value_node.end_mark.index,
+                f": {', '.join(str(item) for item in value)}",
+            ))
+
+    for start, end, replacement in reversed(replacements):
+        frontmatter_text = f"{frontmatter_text[:start]}{replacement}{frontmatter_text[end:]}"
+    return frontmatter_text
 
 
 def _fix_unquoted_colons(frontmatter_text: str) -> tuple[str, list[str], list[str]]:
@@ -2363,6 +2389,7 @@ class FrontmatterValidator:
 
     def _compute_normalized_fixes(
         self,
+        content: str,
         original_data: dict[str, YamlValue],
         frontmatter_text: str,
         body: str,
@@ -2395,6 +2422,15 @@ class FrontmatterValidator:
         )
         if not fixes:
             return None
+        tool_list_fixes = {
+            f"Converted {field_name} from YAML array to comma-separated string"
+            for field_name in ("tools", "disallowedTools", "allowed-tools")
+            if isinstance(original_data.get(field_name), list)
+        }
+        if set(fixes) == tool_list_fixes:
+            return content.replace(
+                frontmatter_text, _replace_list_valued_tool_fields(frontmatter_text, original_data), 1
+            ), fixes
         return f"---\n{_dump_yaml(normalized_dict)}---\n{body}", fixes
 
     def _apply_fixes(self, content: str, file_type: FileType, file_path: Path | None = None) -> tuple[str, list[str]]:
@@ -2422,7 +2458,13 @@ class FrontmatterValidator:
 
         if isinstance(original_data, dict):
             computed = self._compute_normalized_fixes(
-                original_data, frontmatter_text, body, file_type=file_type, file_path=file_path, colon_fixes=colon_fixes
+                content,
+                original_data,
+                frontmatter_text,
+                body,
+                file_type=file_type,
+                file_path=file_path,
+                colon_fixes=colon_fixes,
             )
             if computed is not None:
                 result_content, result_fixes = computed

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -2479,6 +2479,10 @@ class FrontmatterValidator:
             file_type=file_type,
             file_path=file_path,
         )
+        for field_name in ("tools", "disallowedTools", "allowed-tools"):
+            original_value = original_data.get(field_name)
+            if isinstance(original_value, list) and not _is_losslessly_scalar_tool_list(original_value):
+                normalized_dict[field_name] = original_value
         if not fixes:
             return None
         tool_list_fixes = {

--- a/packages/skilllint/tests/test_frontmatter_validator.py
+++ b/packages/skilllint/tests/test_frontmatter_validator.py
@@ -271,9 +271,9 @@ class TestFrontmatterAutoFix:
 
         assert any(issue.code == "FM007" and issue.field == field_name for issue in before_result.warnings)
         assert first_fixes != []
-        assert first_content != before
-        assert b"marker: maintain-this-byte\n" in first_content
-        assert first_content.endswith(b"\nBody bytes remain unchanged.\n")
+        assert first_content == before.replace(
+            f"{field_name}:\n  - Read\n  - Grep\n".encode(), f"{field_name}: Read, Grep\n".encode()
+        )
         assert not any(issue.code == "FM007" and issue.field == field_name for issue in after_first_result.warnings)
         assert second_fixes == []
         assert capability_file.read_bytes() == first_content

--- a/packages/skilllint/tests/test_frontmatter_validator.py
+++ b/packages/skilllint/tests/test_frontmatter_validator.py
@@ -267,6 +267,32 @@ class TestFrontmatterAutoFix:
         assert validator.validate(agent_md).errors == []
 
     @pytest.mark.parametrize(
+        "tool_yaml",
+        ["defaults: &defaults {tools: [Read, Grep]}\n<<: *defaults", "? tools\n: [Read, Grep]", 'tools: ["*"]'],
+    )
+    def test_fix_preserves_yaml_syntax_for_nonstandard_tool_lists(self, tmp_path: Path, tool_yaml: str) -> None:
+        agent_md = tmp_path / "agents" / "tool-list.md"
+        agent_md.parent.mkdir()
+        agent_md.write_text(
+            "---\n"
+            "name: tool-list\n"
+            "description: Use this agent when testing tool-list YAML.\n"
+            f"{tool_yaml}\n"
+            "---\n"
+            "Body.\n",
+            encoding="utf-8",
+        )
+
+        validator = FrontmatterValidator()
+        validator.fix(agent_md)
+
+        fixed = agent_md.read_text(encoding="utf-8")
+        assert validator.validate(agent_md).errors == []
+        assert all(issue.code != "FM007" for issue in validator.validate(agent_md).warnings)
+        assert validator.fix(agent_md) == []
+        assert agent_md.read_text(encoding="utf-8") == fixed
+
+    @pytest.mark.parametrize(
         ("relative_path", "field_name"),
         [
             ("skills/tool-list/SKILL.md", "allowed-tools"),

--- a/packages/skilllint/tests/test_frontmatter_validator.py
+++ b/packages/skilllint/tests/test_frontmatter_validator.py
@@ -364,14 +364,17 @@ class TestFrontmatterAutoFix:
         agent_md = tmp_path / "agents" / "tool-list.md"
         agent_md.parent.mkdir()
         agent_md.write_text(
-            "---\nname: tool-list\ndescription: 'Use: atomic tool list.'\ntools: [\"Bash(git log:*)\"]\n---\nBody.\n",
+            '---\nname: tool-list\ndescription: Use: atomic tool list.\ntools: ["Bash(git log:*)"]\n'
+            "disallowedTools: [Read, Grep]\n---\nBody.\n",
             encoding="utf-8",
         )
 
         validator = FrontmatterValidator()
         validator.fix(agent_md)
 
-        assert 'tools: ["Bash(git log:*)"]' in agent_md.read_text(encoding="utf-8")
+        fixed = agent_md.read_text(encoding="utf-8")
+        assert "Bash(git log:*)" in fixed
+        assert validator.validate(agent_md).errors == []
 
     def test_fix_leaves_empty_tool_list_entries_unchanged(self, tmp_path: Path) -> None:
         agent_md = tmp_path / "agents" / "tool-list.md"

--- a/packages/skilllint/tests/test_frontmatter_validator.py
+++ b/packages/skilllint/tests/test_frontmatter_validator.py
@@ -332,6 +332,34 @@ class TestFrontmatterAutoFix:
         assert "None" not in fixed
         assert all(issue.code != "FM007" for issue in validator.validate(agent_md).warnings)
 
+    def test_fix_falls_back_when_merged_tool_field_has_no_source_node(self, tmp_path: Path) -> None:
+        agent_md = tmp_path / "agents" / "tool-list.md"
+        agent_md.parent.mkdir()
+        agent_md.write_text(
+            "---\nname: tool-list\ndescription: Merged tool-list verification.\n"
+            "defaults: &d {tools: [Read, Grep]}\n<<: *d\ndisallowedTools: [Write]\n---\nBody.\n",
+            encoding="utf-8",
+        )
+
+        validator = FrontmatterValidator()
+        validator.fix(agent_md)
+
+        assert all(issue.code != "FM007" for issue in validator.validate(agent_md).warnings)
+
+    def test_fix_leaves_unrepresentable_tool_list_entries_unchanged(self, tmp_path: Path) -> None:
+        agent_md = tmp_path / "agents" / "tool-list.md"
+        agent_md.parent.mkdir()
+        original = (
+            "---\nname: tool-list\ndescription: Atomic tool-list verification.\n"
+            'tools: ["Bash(git log:*)"]\n---\nBody.\n'
+        )
+        agent_md.write_text(original, encoding="utf-8")
+
+        validator = FrontmatterValidator()
+
+        assert validator.fix(agent_md) == []
+        assert agent_md.read_text(encoding="utf-8") == original
+
     @pytest.mark.parametrize(
         ("relative_path", "field_name"),
         [

--- a/packages/skilllint/tests/test_frontmatter_validator.py
+++ b/packages/skilllint/tests/test_frontmatter_validator.py
@@ -373,6 +373,20 @@ class TestFrontmatterAutoFix:
         assert validator.fix(agent_md) == []
         assert agent_md.read_text(encoding="utf-8") == original
 
+    def test_fix_preserves_flow_mapping_tool_list_semantics(self, tmp_path: Path) -> None:
+        agent_md = tmp_path / "agents" / "tool-list.md"
+        agent_md.parent.mkdir()
+        agent_md.write_text(
+            "---\n{name: flow-agent, description: Flow tool-list verification., tools: [Read, Grep]}\n---\nBody.\n",
+            encoding="utf-8",
+        )
+
+        validator = FrontmatterValidator()
+        validator.fix(agent_md)
+
+        assert validator.validate(agent_md).errors == []
+        assert all(issue.code != "FM007" for issue in validator.validate(agent_md).warnings)
+
     @pytest.mark.parametrize(
         ("relative_path", "field_name"),
         [

--- a/packages/skilllint/tests/test_frontmatter_validator.py
+++ b/packages/skilllint/tests/test_frontmatter_validator.py
@@ -360,6 +360,19 @@ class TestFrontmatterAutoFix:
         assert validator.fix(agent_md) == []
         assert agent_md.read_text(encoding="utf-8") == original
 
+    def test_fix_preserves_unrepresentable_tool_list_with_unrelated_fix(self, tmp_path: Path) -> None:
+        agent_md = tmp_path / "agents" / "tool-list.md"
+        agent_md.parent.mkdir()
+        agent_md.write_text(
+            "---\nname: tool-list\ndescription: 'Use: atomic tool list.'\ntools: [\"Bash(git log:*)\"]\n---\nBody.\n",
+            encoding="utf-8",
+        )
+
+        validator = FrontmatterValidator()
+        validator.fix(agent_md)
+
+        assert 'tools: ["Bash(git log:*)"]' in agent_md.read_text(encoding="utf-8")
+
     def test_fix_leaves_empty_tool_list_entries_unchanged(self, tmp_path: Path) -> None:
         agent_md = tmp_path / "agents" / "tool-list.md"
         agent_md.parent.mkdir()

--- a/packages/skilllint/tests/test_frontmatter_validator.py
+++ b/packages/skilllint/tests/test_frontmatter_validator.py
@@ -301,7 +301,7 @@ class TestFrontmatterAutoFix:
             "description: Use this agent when testing tool-list YAML.\n"
             "tools:\n"
             "  # required for search\n"
-            "  - Grep # search tool\n"
+            "  - Grep # #TODO\n"
             "  - Read\n"
             "---\n"
             "Body.\n",
@@ -313,7 +313,7 @@ class TestFrontmatterAutoFix:
 
         fixed = agent_md.read_text(encoding="utf-8")
         assert "# required for search" in fixed
-        assert "# search tool" in fixed
+        assert "# #TODO" in fixed
         assert all(issue.code != "FM007" for issue in validator.validate(agent_md).warnings)
 
     @pytest.mark.parametrize(

--- a/packages/skilllint/tests/test_frontmatter_validator.py
+++ b/packages/skilllint/tests/test_frontmatter_validator.py
@@ -369,6 +369,28 @@ description: >-
         content = skill_md.read_text()
         assert ">-" not in content
 
+    def test_autofix_multiline_description_and_tool_list(self, tmp_path: Path) -> None:
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text("""---
+description: >-
+  A multiline description
+  for a skill.
+tools:
+  - Read
+  - Grep
+---
+
+# Content
+""")
+
+        fixes = FrontmatterValidator().fix(skill_md)
+
+        content = skill_md.read_text()
+        assert any("multiline" in fix.lower() for fix in fixes)
+        assert any("YAML array" in fix for fix in fixes)
+        assert ">-" not in content
+        assert "tools: Read, Grep" in content
+
     def test_autofix_unquoted_colon(self, tmp_path: Path) -> None:
         """Test auto-fix quotes descriptions with colons (FM009).
 

--- a/packages/skilllint/tests/test_frontmatter_validator.py
+++ b/packages/skilllint/tests/test_frontmatter_validator.py
@@ -14,11 +14,14 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+import skilllint.plugin_validator as plugin_validator
 from skilllint.frontmatter_core import SkillFrontmatter
 from skilllint.plugin_validator import FrontmatterValidator
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from typer.testing import CliRunner
 
 
 class TestFrontmatterValidatorBasic:
@@ -243,7 +246,7 @@ class TestFrontmatterAutoFix:
         ],
     )
     def test_fix_normalizes_declared_tool_list_without_changing_unrelated_bytes(
-        self, tmp_path: Path, relative_path: str, field_name: str
+        self, cli_runner: CliRunner, tmp_path: Path, relative_path: str, field_name: str
     ) -> None:
         capability_file = tmp_path / relative_path
         capability_file.parent.mkdir(parents=True)
@@ -251,7 +254,7 @@ class TestFrontmatterAutoFix:
             "---\n"
             "name: tool-list\n"
             "description: Use this component when testing declared tool-list fixes.\n"
-            "marker: maintain-this-byte\n"
+            "marker: maintain-this-byte # preserve this YAML comment\n"
             f"{field_name}:\n"
             "  - Read\n"
             "  - Grep\n"
@@ -259,23 +262,24 @@ class TestFrontmatterAutoFix:
             "\nBody bytes remain unchanged.\n",
             encoding="utf-8",
         )
-        validator = FrontmatterValidator()
-
         before = capability_file.read_bytes()
-        before_result = validator.validate(capability_file)
-
-        first_fixes = validator.fix(capability_file)
+        check_result = cli_runner.invoke(plugin_validator.app, ["check", str(capability_file)])
+        after_check_content = capability_file.read_bytes()
+        first_fix_result = cli_runner.invoke(plugin_validator.app, ["check", "--fix", str(capability_file)])
         first_content = capability_file.read_bytes()
-        after_first_result = validator.validate(capability_file)
-        second_fixes = validator.fix(capability_file)
+        after_first_check_result = cli_runner.invoke(plugin_validator.app, ["check", str(capability_file)])
+        second_fix_result = cli_runner.invoke(plugin_validator.app, ["check", "--fix", str(capability_file)])
 
-        assert any(issue.code == "FM007" and issue.field == field_name for issue in before_result.warnings)
-        assert first_fixes != []
+        assert check_result.exit_code == 0
+        assert "[FM007]" in check_result.stdout
+        assert after_check_content == before
+        assert first_fix_result.exit_code == 0
         assert first_content == before.replace(
             f"{field_name}:\n  - Read\n  - Grep\n".encode(), f"{field_name}: Read, Grep\n".encode()
         )
-        assert not any(issue.code == "FM007" and issue.field == field_name for issue in after_first_result.warnings)
-        assert second_fixes == []
+        assert after_first_check_result.exit_code == 0
+        assert "[FM007]" not in after_first_check_result.stdout
+        assert second_fix_result.exit_code == 0
         assert capability_file.read_bytes() == first_content
 
     def test_autofix_yaml_array_to_csv(self, tmp_path: Path) -> None:

--- a/packages/skilllint/tests/test_frontmatter_validator.py
+++ b/packages/skilllint/tests/test_frontmatter_validator.py
@@ -316,6 +316,22 @@ class TestFrontmatterAutoFix:
         assert "# #TODO" in fixed
         assert all(issue.code != "FM007" for issue in validator.validate(agent_md).warnings)
 
+    def test_fix_drops_null_tool_list_entries(self, tmp_path: Path) -> None:
+        agent_md = tmp_path / "agents" / "tool-list.md"
+        agent_md.parent.mkdir()
+        agent_md.write_text(
+            "---\nname: tool-list\ndescription: Null tool-list entry verification.\ntools: [Read, null]\n---\nBody.\n",
+            encoding="utf-8",
+        )
+
+        validator = FrontmatterValidator()
+        validator.fix(agent_md)
+
+        fixed = agent_md.read_text(encoding="utf-8")
+        assert "tools: Read" in fixed
+        assert "None" not in fixed
+        assert all(issue.code != "FM007" for issue in validator.validate(agent_md).warnings)
+
     @pytest.mark.parametrize(
         ("relative_path", "field_name"),
         [

--- a/packages/skilllint/tests/test_frontmatter_validator.py
+++ b/packages/skilllint/tests/test_frontmatter_validator.py
@@ -237,6 +237,36 @@ class TestFrontmatterAutoFix:
     """Test auto-fix functionality."""
 
     @pytest.mark.parametrize(
+        ("tool_yaml", "expected_yaml"),
+        [
+            ("tools: []", "tools: ''"),
+            ("defaults: &shared [Read, Grep]\ntools: *shared", "defaults: &shared [Read, Grep]\ntools: Read, Grep"),
+            ("tools: &shared [Read, Grep]\nskills: *shared", "tools: Read, Grep\nskills: &shared [Read, Grep]"),
+        ],
+    )
+    def test_fix_preserves_tool_list_yaml_alias_contract(
+        self, tmp_path: Path, tool_yaml: str, expected_yaml: str
+    ) -> None:
+        agent_md = tmp_path / "agents" / "tool-list.md"
+        agent_md.parent.mkdir()
+        agent_md.write_text(
+            "---\n"
+            "name: tool-list\n"
+            "description: Use this agent when testing tool-list YAML.\n"
+            f"{tool_yaml}\n"
+            "---\n"
+            "Body.\n",
+            encoding="utf-8",
+        )
+
+        validator = FrontmatterValidator()
+        validator.fix(agent_md)
+
+        fixed = agent_md.read_text(encoding="utf-8")
+        assert expected_yaml in fixed
+        assert validator.validate(agent_md).errors == []
+
+    @pytest.mark.parametrize(
         ("relative_path", "field_name"),
         [
             ("skills/tool-list/SKILL.md", "allowed-tools"),

--- a/packages/skilllint/tests/test_frontmatter_validator.py
+++ b/packages/skilllint/tests/test_frontmatter_validator.py
@@ -292,6 +292,30 @@ class TestFrontmatterAutoFix:
         assert validator.fix(agent_md) == []
         assert agent_md.read_text(encoding="utf-8") == fixed
 
+    def test_fix_preserves_comments_inside_tool_list(self, tmp_path: Path) -> None:
+        agent_md = tmp_path / "agents" / "tool-list.md"
+        agent_md.parent.mkdir()
+        agent_md.write_text(
+            "---\n"
+            "name: tool-list\n"
+            "description: Use this agent when testing tool-list YAML.\n"
+            "tools:\n"
+            "  # required for search\n"
+            "  - Grep # search tool\n"
+            "  - Read\n"
+            "---\n"
+            "Body.\n",
+            encoding="utf-8",
+        )
+
+        validator = FrontmatterValidator()
+        validator.fix(agent_md)
+
+        fixed = agent_md.read_text(encoding="utf-8")
+        assert "# required for search" in fixed
+        assert "# search tool" in fixed
+        assert all(issue.code != "FM007" for issue in validator.validate(agent_md).warnings)
+
     @pytest.mark.parametrize(
         ("relative_path", "field_name"),
         [

--- a/packages/skilllint/tests/test_frontmatter_validator.py
+++ b/packages/skilllint/tests/test_frontmatter_validator.py
@@ -360,6 +360,19 @@ class TestFrontmatterAutoFix:
         assert validator.fix(agent_md) == []
         assert agent_md.read_text(encoding="utf-8") == original
 
+    def test_fix_leaves_empty_tool_list_entries_unchanged(self, tmp_path: Path) -> None:
+        agent_md = tmp_path / "agents" / "tool-list.md"
+        agent_md.parent.mkdir()
+        original = (
+            '---\nname: tool-list\ndescription: Empty tool-list verification.\ntools: ["", Workflow]\n---\nBody.\n'
+        )
+        agent_md.write_text(original, encoding="utf-8")
+
+        validator = FrontmatterValidator()
+
+        assert validator.fix(agent_md) == []
+        assert agent_md.read_text(encoding="utf-8") == original
+
     @pytest.mark.parametrize(
         ("relative_path", "field_name"),
         [

--- a/packages/skilllint/tests/test_frontmatter_validator.py
+++ b/packages/skilllint/tests/test_frontmatter_validator.py
@@ -233,6 +233,51 @@ echo "test"
 class TestFrontmatterAutoFix:
     """Test auto-fix functionality."""
 
+    @pytest.mark.parametrize(
+        ("relative_path", "field_name"),
+        [
+            ("skills/tool-list/SKILL.md", "allowed-tools"),
+            ("commands/tool-list.md", "allowed-tools"),
+            ("agents/tool-list.md", "tools"),
+            ("agents/tool-list.md", "disallowedTools"),
+        ],
+    )
+    def test_fix_normalizes_declared_tool_list_without_changing_unrelated_bytes(
+        self, tmp_path: Path, relative_path: str, field_name: str
+    ) -> None:
+        capability_file = tmp_path / relative_path
+        capability_file.parent.mkdir(parents=True)
+        capability_file.write_text(
+            "---\n"
+            "name: tool-list\n"
+            "description: Use this component when testing declared tool-list fixes.\n"
+            "marker: maintain-this-byte\n"
+            f"{field_name}:\n"
+            "  - Read\n"
+            "  - Grep\n"
+            "---\n"
+            "\nBody bytes remain unchanged.\n",
+            encoding="utf-8",
+        )
+        validator = FrontmatterValidator()
+
+        before = capability_file.read_bytes()
+        before_result = validator.validate(capability_file)
+
+        first_fixes = validator.fix(capability_file)
+        first_content = capability_file.read_bytes()
+        after_first_result = validator.validate(capability_file)
+        second_fixes = validator.fix(capability_file)
+
+        assert any(issue.code == "FM007" and issue.field == field_name for issue in before_result.warnings)
+        assert first_fixes != []
+        assert first_content != before
+        assert b"marker: maintain-this-byte\n" in first_content
+        assert first_content.endswith(b"\nBody bytes remain unchanged.\n")
+        assert not any(issue.code == "FM007" and issue.field == field_name for issue in after_first_result.warnings)
+        assert second_fixes == []
+        assert capability_file.read_bytes() == first_content
+
     def test_autofix_yaml_array_to_csv(self, tmp_path: Path) -> None:
         """Test auto-fix converts YAML arrays to CSV strings (FM007).
 


### PR DESCRIPTION
Part of #232

Fixes tool-list persistence by detecting authored YAML lists before model coercion.

Evidence:
- Regression matrix covers SKILL/command allowed-tools and agent tools/disallowedTools through check -> fix -> check -> fix.
- Confirms first-change bytes, preserved marker/body bytes, cleared FM007, and byte-idempotent second fix.
- Manual CLI check -> fix -> check -> fix converted allowed-tools once and second fix was byte-identical.
- uv run prek run --all-files passed.

Non-goals:
- No adapter-directory discovery changes.
- No tool-syntax expansion or frontmatter-serialization redesign.

Full uv run pytest: 1606 passed, 10 skipped; 4 existing PL002 timeout failures in CLI/AS008 fixture tests remain.