### PR TITLE
fix(cli): reject --fix with explicit platform

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     default: ""
 
   fix:
-    description: "Auto-fix issues where possible. Mutually exclusive with check-only."
+    description: "Auto-fix issues where possible. Mutually exclusive with check-only and platform."
     required: false
     default: "false"
 

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -4558,6 +4558,14 @@ def main(
     if not paths:
         _show_help_and_exit(ctx, code=0)
 
+    if check and fix:
+        typer.echo("Error: Cannot use both --check and --fix flags", err=True)
+        raise typer.Exit(2) from None
+
+    if fix and platform:
+        typer.echo("Error: Cannot use --fix with --platform", err=True)
+        raise typer.Exit(2) from None
+
     # Validate that all provided paths exist; report non-existent ones
     bad_paths = [str(p) for p in paths if not p.exists()]
     if bad_paths:
@@ -4581,10 +4589,6 @@ def main(
 
         if tokens_only:
             _handle_tokens_only(expanded_paths, batch=is_batch)
-
-        if check and fix:
-            typer.echo("Error: Cannot use both --check and --fix flags", err=True)
-            raise typer.Exit(2) from None
 
         # One shared cache per scan run — prevents re-walking the directory
         # tree for every file when many files share the same config root.

--- a/packages/skilllint/tests/test_cli.py
+++ b/packages/skilllint/tests/test_cli.py
@@ -145,6 +145,35 @@ description: Test skill with invalid name format
         assert result.exit_code == 2
         assert "Cannot use both" in result.stdout or "Cannot use both" in result.stderr
 
+    def test_exit_2_on_fix_with_platform_without_modifying_file(
+        self, cli_runner: CliRunner, tmp_path: Path, no_color_env: None
+    ) -> None:
+        """--fix with --platform is rejected before it can modify its target."""
+        skill_dir = tmp_path / "platform-fix-skill"
+        skill_dir.mkdir()
+        skill_file = skill_dir / "SKILL.md"
+        original_content = (
+            "---\n"
+            "name: platform-fix-skill\n"
+            "description: Use when testing the platform fix conflict.\n"
+            "tools:\n"
+            "  - Read\n"
+            "  - Write\n"
+            "---\n\n"
+            "# Skill\n"
+        )
+        skill_file.write_text(original_content, encoding="utf-8")
+
+        result = cli_runner.invoke(
+            plugin_validator.app, ["check", "--fix", "--platform", "claude-code", str(skill_file)]
+        )
+
+        assert result.exit_code == 2
+        assert (
+            "Cannot use --fix with --platform" in result.stdout or "Cannot use --fix with --platform" in result.stderr
+        )
+        assert skill_file.read_text(encoding="utf-8") == original_content
+
 
 class TestCheckFlag:
     """Test --check flag behavior (validate only, no fixes)."""


### PR DESCRIPTION
Part of #231.

Reject `--fix` with an explicit `--platform` before path expansion or validation, so no file can be modified. The Action input metadata documents the same incompatibility.