### PR TITLE
fix(cache): normalize empty successful responses

### DIFF
--- a/packages/skilllint/tests/test_cli_docs.py
+++ b/packages/skilllint/tests/test_cli_docs.py
@@ -19,6 +19,7 @@ import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 import pytest
 
@@ -201,7 +202,7 @@ class TestDocsFetch:
         server = ThreadingHTTPServer(("127.0.0.1", 0), EmptyResponseHandler)
         thread = threading.Thread(target=server.serve_forever)
         thread.start()
-        url = f"http://127.0.0.1:{server.server_port}/empty-response"
+        url = f"http://127.0.0.1:{server.server_port}/empty-response-{uuid4().hex}"
         try:
             result = subprocess.run(
                 [sys.executable, "-m", "skilllint.plugin_validator", "docs", "fetch", url],

--- a/packages/skilllint/tests/test_cli_docs.py
+++ b/packages/skilllint/tests/test_cli_docs.py
@@ -13,6 +13,10 @@ Why: The docs subcommand group is a pure CLI adapter over vendor_cache.
 
 from __future__ import annotations
 
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -186,6 +190,34 @@ class TestDocsFetch:
         # Assert
         assert result.exit_code == 1
         assert _TEST_URL in result.output
+
+    def test_empty_successful_response_exits_one_without_traceback(self) -> None:
+        class EmptyResponseHandler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                self.send_response(200)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), EmptyResponseHandler)
+        thread = threading.Thread(target=server.serve_forever)
+        thread.start()
+        url = f"http://127.0.0.1:{server.server_port}/empty-response"
+        try:
+            result = subprocess.run(
+                [sys.executable, "-m", "skilllint.plugin_validator", "docs", "fetch", url],
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+        finally:
+            server.shutdown()
+            thread.join()
+            server.server_close()
+
+        assert result.returncode == 1
+        assert url in result.stderr
+        assert "Empty response body" in result.stderr
+        assert "Traceback" not in result.stderr
 
     def test_force_flag_passes_force_true_to_fetch_or_cached(
         self, cli_runner: CliRunner, mocker: MockerFixture

--- a/packages/skilllint/tests/test_vendor_cache.py
+++ b/packages/skilllint/tests/test_vendor_cache.py
@@ -42,7 +42,7 @@ from skilllint.vendor_cache import (
     read_section,
     verify_integrity,
 )
-from skilllint.vendor_io import sha256_hex
+from skilllint.vendor_io import EmptyResponseError, sha256_hex
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -582,6 +582,21 @@ class TestFetchOrCachedNew:
 
         assert exc_info.value.url == url
 
+    def test_fetch_or_cached_raises_no_cache_error_when_empty_response_has_no_cache(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        mocker.patch("skilllint.vendor_cache.SOURCES_DIR", tmp_path)
+        url = "https://example.com/docs/en/empty.md"
+        mocker.patch(
+            "skilllint.vendor_cache.fetch_url_text", side_effect=EmptyResponseError(f"Empty response body from {url!r}")
+        )
+
+        with pytest.raises(NoCacheError) as exc_info:
+            fetch_or_cached(url)
+
+        assert exc_info.value.url == url
+        assert exc_info.value.reason == f"Empty response body from {url!r}"
+
 
 class TestFetchOrCachedForce:
     """Tests for fetch_or_cached — force=True bypasses the TTL check."""
@@ -695,6 +710,32 @@ class TestFetchOrCachedForce:
         # Assert
         assert result.status == CacheStatus.STALE
         assert result.path == md_path
+
+    def test_fetch_or_cached_force_serves_stale_when_response_is_empty(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        mocker.patch("skilllint.vendor_cache.SOURCES_DIR", tmp_path)
+        url = "https://example.com/docs/settings.md"
+        content = "# Settings\n"
+        md_path = _write_md(tmp_path, "settings-2026-03-23-1400.md", content)
+        sidecar_path = _write_sidecar(
+            md_path,
+            url=url,
+            sha256=hashlib.sha256(content.encode()).hexdigest(),
+            byte_count=len(content.encode()),
+            fetched_at=_fresh_fetched_at(),
+        )
+        original_sidecar = sidecar_path.read_bytes()
+        mocker.patch(
+            "skilllint.vendor_cache.fetch_url_text", side_effect=EmptyResponseError(f"Empty response body from {url!r}")
+        )
+
+        result = fetch_or_cached(url, force=True)
+
+        assert result.status == CacheStatus.STALE
+        assert result.path == md_path
+        assert md_path.read_text(encoding="utf-8") == content
+        assert sidecar_path.read_bytes() == original_sidecar
 
 
 # ---------------------------------------------------------------------------

--- a/packages/skilllint/vendor_cache.py
+++ b/packages/skilllint/vendor_cache.py
@@ -47,6 +47,7 @@ from marko.block import Heading as MarkoHeading
 
 from skilllint.vendor_io import (
     SOURCES_DIR,
+    EmptyResponseError,
     fetch_url_text,
     load_sidecar,
     read_text_or_none,
@@ -377,7 +378,7 @@ def fetch_or_cached(url: str, *, ttl_hours: float = 4.0, force: bool = False) ->
         try:
             new_content = fetch_url_text(url)
         except Exception as exc:
-            if _is_network_error(exc):
+            if _is_network_error(exc) or isinstance(exc, EmptyResponseError):
                 return CacheResult(path=cached_path, status=CacheStatus.STALE, page_name=page_name, url=url)
             raise
 
@@ -402,7 +403,7 @@ def fetch_or_cached(url: str, *, ttl_hours: float = 4.0, force: bool = False) ->
     try:
         new_content = fetch_url_text(url)
     except Exception as exc:
-        if _is_network_error(exc):
+        if _is_network_error(exc) or isinstance(exc, EmptyResponseError):
             if cached_path is not None:
                 # force=True but network down; serve stale.
                 return CacheResult(path=cached_path, status=CacheStatus.STALE, page_name=page_name, url=url)

--- a/packages/skilllint/vendor_io.py
+++ b/packages/skilllint/vendor_io.py
@@ -38,6 +38,11 @@ from typing import Any
 
 import httpx
 
+
+class EmptyResponseError(ValueError):
+    """Raised when a successful HTTP response has no body."""
+
+
 # ---------------------------------------------------------------------------
 # Directory constants
 # ---------------------------------------------------------------------------
@@ -238,7 +243,7 @@ def fetch_url_text(url: str, *, timeout: float = 30.0, follow_redirects: bool = 
         response.raise_for_status()
         text = response.text
         if not text:
-            raise ValueError(f"Empty response body from {url!r}")
+            raise EmptyResponseError(f"Empty response body from {url!r}")
         return text
 
 


### PR DESCRIPTION
Part of #235.

Normalizes exact zero-length successful response bodies at the cache boundary: cached content is served STALE without modifying its pair; uncached requests receive NoCacheError; docs fetch exits 1 without a traceback.

Tests: `uv run prek run --all-files`; focused cache and real subprocess CLI checks.