### PR TITLE
fix(cache): validate sidecar timestamps at ingest

### DIFF
--- a/docs/vendor-cache-reference.md
+++ b/docs/vendor-cache-reference.md
@@ -860,7 +860,7 @@ Write a `.meta.json` sidecar alongside a saved file.
 **Signature**
 
 ```python
-def write_sidecar(md_path: Path, *, url: str, content: str) -> Path:
+def write_sidecar(md_path: Path, *, url: str, content: str, fetched_at: datetime | None = None) -> Path:
 ```
 
 **Parameters**
@@ -870,6 +870,7 @@ def write_sidecar(md_path: Path, *, url: str, content: str) -> Path:
 | `md_path` | `Path` | Path to the saved content file (typically a `.md` file) |
 | `url` | `str` | The URL the content was fetched from |
 | `content` | `str` | The raw text content that was saved |
+| `fetched_at` | `datetime \| None` | Timestamp to record; defaults to the current UTC time |
 
 **Returns**
 

--- a/docs/vendor-cache-reference.md
+++ b/docs/vendor-cache-reference.md
@@ -894,7 +894,7 @@ Load the `.meta.json` sidecar for a given file path.
 **Signature**
 
 ```python
-def load_sidecar(md_path: Path) -> dict[str, Any] | None:
+def load_sidecar(md_path: Path) -> SidecarMetadata | None:
 ```
 
 **Parameters**
@@ -905,7 +905,8 @@ def load_sidecar(md_path: Path) -> dict[str, Any] | None:
 
 **Returns**
 
-`dict[str, Any] | None` — Parsed sidecar dict, or `None` if the sidecar is missing or corrupt
+`SidecarMetadata | None` — Validated sidecar metadata, or `None` if the sidecar is missing or malformed.
+Use its `url`, `fetched_at`, `sha256`, and `byte_count` attributes rather than mapping access.
 
 #### utc_now_iso
 

--- a/packages/skilllint/boundary/vendor_sidecar_ingest.py
+++ b/packages/skilllint/boundary/vendor_sidecar_ingest.py
@@ -1,0 +1,51 @@
+"""Typed ingress for cached-document sidecar metadata."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_serializer, field_validator
+
+
+class SidecarMetadata(BaseModel):
+    """Validated metadata stored beside a cached vendor document."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    url: str
+    fetched_at: datetime
+    sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    byte_count: int
+
+    @field_validator("fetched_at")
+    @classmethod
+    def fetched_at_must_be_aware(cls, value: datetime) -> datetime:
+        """Reject naive timestamps before cache freshness arithmetic.
+
+        Returns:
+            The validated aware timestamp.
+        """
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("fetched_at must include a timezone")
+        return value
+
+    @field_serializer("fetched_at")
+    def serialize_fetched_at(self, value: datetime) -> str:
+        """Preserve the sidecar's ISO 8601 UTC offset representation.
+
+        Returns:
+            The offset-preserving timestamp string.
+        """
+        return value.isoformat()
+
+
+def parse_sidecar_metadata(text: str) -> SidecarMetadata | None:
+    """Parse external sidecar JSON into concrete metadata, or reject it.
+
+    Returns:
+        Validated metadata, or None when parsing fails.
+    """
+    try:
+        return SidecarMetadata.model_validate_json(text)
+    except ValidationError:
+        return None

--- a/packages/skilllint/boundary/vendor_sidecar_ingest.py
+++ b/packages/skilllint/boundary/vendor_sidecar_ingest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from urllib.parse import urlsplit
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_serializer, field_validator
 
@@ -15,7 +16,20 @@ class SidecarMetadata(BaseModel):
     url: str
     fetched_at: datetime
     sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
-    byte_count: int
+    byte_count: int = Field(ge=0)
+
+    @field_validator("url")
+    @classmethod
+    def url_must_be_absolute_http(cls, value: str) -> str:
+        """Reject sidecars whose provenance is not an absolute HTTP(S) URL.
+
+        Returns:
+            The validated source URL without normalization.
+        """
+        parsed = urlsplit(value)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("url must be an absolute HTTP(S) URL")
+        return value
 
     @field_validator("fetched_at")
     @classmethod

--- a/packages/skilllint/tests/test_vendor_cache.py
+++ b/packages/skilllint/tests/test_vendor_cache.py
@@ -450,6 +450,25 @@ class TestFetchOrCachedFresh:
         assert repaired["url"] == url
         assert datetime.fromisoformat(repaired["fetched_at"]).tzinfo is not None
 
+    def test_fetch_or_cached_repairs_incomplete_sidecar_to_an_intact_pair(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        # Given
+        mocker.patch("skilllint.vendor_cache.SOURCES_DIR", tmp_path)
+        url = "https://example.com/docs/incomplete-sidecar.md"
+        content = "# Cached\nSome content."
+        md_path = _write_md(tmp_path, "incomplete-sidecar-2026-03-23-1000.md", content)
+        md_path.with_suffix(".meta.json").write_text("{}", encoding="utf-8")
+        mock_fetch = mocker.patch("skilllint.vendor_cache.fetch_url_text", return_value=content)
+
+        # When
+        result = fetch_or_cached(url, ttl_hours=4.0)
+
+        # Then
+        mock_fetch.assert_called_once_with(url)
+        assert result.status == CacheStatus.UNCHANGED
+        assert verify_integrity(md_path).status == IntegrityStatus.INTACT
+
 
 class TestFetchOrCachedStale:
     """Tests for fetch_or_cached — stale cache scenarios."""

--- a/packages/skilllint/tests/test_vendor_cache.py
+++ b/packages/skilllint/tests/test_vendor_cache.py
@@ -428,6 +428,28 @@ class TestFetchOrCachedFresh:
         assert result.status == CacheStatus.UNCHANGED
         assert result.path == md_path
 
+    def test_fetch_or_cached_repairs_list_sidecar_when_content_is_unchanged(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        # Given
+        mocker.patch("skilllint.vendor_cache.SOURCES_DIR", tmp_path)
+        url = "https://example.com/docs/list-sidecar.md"
+        content = "# Cached\nSome content."
+        md_path = _write_md(tmp_path, "list-sidecar-2026-03-23-1000.md", content)
+        sidecar_path = md_path.with_suffix(".meta.json")
+        sidecar_path.write_text("[]", encoding="utf-8")
+        mock_fetch = mocker.patch("skilllint.vendor_cache.fetch_url_text", return_value=content)
+
+        # When
+        result = fetch_or_cached(url, ttl_hours=4.0)
+
+        # Then
+        mock_fetch.assert_called_once_with(url)
+        assert result.status == CacheStatus.UNCHANGED
+        repaired = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        assert repaired["url"] == url
+        assert datetime.fromisoformat(repaired["fetched_at"]).tzinfo is not None
+
 
 class TestFetchOrCachedStale:
     """Tests for fetch_or_cached — stale cache scenarios."""

--- a/packages/skilllint/tests/test_vendor_cache.py
+++ b/packages/skilllint/tests/test_vendor_cache.py
@@ -469,6 +469,35 @@ class TestFetchOrCachedFresh:
         assert result.status == CacheStatus.UNCHANGED
         assert verify_integrity(md_path).status == IntegrityStatus.INTACT
 
+    @pytest.mark.parametrize(
+        "stored_url", ["", "https://example.com/docs/different-source.md"], ids=["empty", "mismatched"]
+    )
+    def test_fetch_or_cached_repairs_wrong_sidecar_url_to_an_intact_pair(
+        self, tmp_path: Path, mocker: MockerFixture, stored_url: str
+    ) -> None:
+        # Given
+        mocker.patch("skilllint.vendor_cache.SOURCES_DIR", tmp_path)
+        url = "https://example.com/docs/provenance.md"
+        content = "# Cached\nSome content."
+        md_path = _write_md(tmp_path, "provenance-2026-03-23-1000.md", content)
+        sidecar_path = _write_sidecar(
+            md_path,
+            url=stored_url,
+            sha256=hashlib.sha256(content.encode()).hexdigest(),
+            byte_count=len(content.encode()),
+            fetched_at=_stale_fetched_at(),
+        )
+        mock_fetch = mocker.patch("skilllint.vendor_cache.fetch_url_text", return_value=content)
+
+        # When
+        result = fetch_or_cached(url, ttl_hours=4.0)
+
+        # Then
+        mock_fetch.assert_called_once_with(url)
+        assert result.status == CacheStatus.UNCHANGED
+        assert json.loads(sidecar_path.read_text(encoding="utf-8"))["url"] == url
+        assert verify_integrity(md_path).status == IntegrityStatus.INTACT
+
 
 class TestFetchOrCachedStale:
     """Tests for fetch_or_cached — stale cache scenarios."""

--- a/packages/skilllint/tests/test_vendor_cache.py
+++ b/packages/skilllint/tests/test_vendor_cache.py
@@ -367,6 +367,67 @@ class TestFetchOrCachedFresh:
         assert result.path == md_path
         assert result.url == url
 
+    @pytest.mark.parametrize(
+        "invalid_fetched_at", ["not-a-timestamp", 1, "2026-01-01T00:00:00"], ids=["malformed", "wrong-type", "naive"]
+    )
+    def test_fetch_or_cached_refreshes_invalid_sidecar_timestamp(
+        self, tmp_path: Path, mocker: MockerFixture, invalid_fetched_at: str | int
+    ) -> None:
+        # Given
+        mocker.patch("skilllint.vendor_cache.SOURCES_DIR", tmp_path)
+        url = "https://example.com/docs/invalid-timestamp.md"
+        content = "# Cached\nSome content."
+        md_path = _write_md(tmp_path, "invalid-timestamp-2026-03-23-1000.md", content)
+        sidecar_path = _write_sidecar(
+            md_path,
+            url=url,
+            sha256=hashlib.sha256(content.encode()).hexdigest(),
+            byte_count=len(content.encode()),
+            fetched_at=_fresh_fetched_at(),
+        )
+        sidecar = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        sidecar["fetched_at"] = invalid_fetched_at
+        sidecar_path.write_text(json.dumps(sidecar), encoding="utf-8")
+        mock_fetch = mocker.patch("skilllint.vendor_cache.fetch_url_text", return_value=content)
+
+        # When
+        result = fetch_or_cached(url, ttl_hours=4.0)
+
+        # Then
+        mock_fetch.assert_called_once_with(url)
+        assert result.status == CacheStatus.UNCHANGED
+        assert result.path == md_path
+        assert (
+            datetime.fromisoformat(json.loads(sidecar_path.read_text(encoding="utf-8"))["fetched_at"]).tzinfo
+            is not None
+        )
+
+    def test_fetch_or_cached_refreshes_missing_sidecar_timestamp(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        # Given
+        mocker.patch("skilllint.vendor_cache.SOURCES_DIR", tmp_path)
+        url = "https://example.com/docs/missing-timestamp.md"
+        content = "# Cached\nSome content."
+        md_path = _write_md(tmp_path, "missing-timestamp-2026-03-23-1000.md", content)
+        sidecar_path = _write_sidecar(
+            md_path,
+            url=url,
+            sha256=hashlib.sha256(content.encode()).hexdigest(),
+            byte_count=len(content.encode()),
+            fetched_at=_fresh_fetched_at(),
+        )
+        sidecar = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        del sidecar["fetched_at"]
+        sidecar_path.write_text(json.dumps(sidecar), encoding="utf-8")
+        mock_fetch = mocker.patch("skilllint.vendor_cache.fetch_url_text", return_value=content)
+
+        # When
+        result = fetch_or_cached(url, ttl_hours=4.0)
+
+        # Then
+        mock_fetch.assert_called_once_with(url)
+        assert result.status == CacheStatus.UNCHANGED
+        assert result.path == md_path
+
 
 class TestFetchOrCachedStale:
     """Tests for fetch_or_cached — stale cache scenarios."""

--- a/packages/skilllint/tests/test_vendor_io.py
+++ b/packages/skilllint/tests/test_vendor_io.py
@@ -21,13 +21,15 @@ from __future__ import annotations
 import hashlib
 import json
 import subprocess
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import httpx
 import pytest
+from hypothesis import given, strategies as st
 
+from skilllint.boundary.vendor_sidecar_ingest import parse_sidecar_metadata
 from skilllint.vendor_io import (
     PROJECT_ROOT,
     SOURCES_DIR,
@@ -615,6 +617,64 @@ class TestLoadSidecar:
         assert result.url == "https://example.com/page.md"
         assert result.fetched_at.tzinfo is not None
 
+    @given(
+        url=st.sampled_from(("https://example.com/page.md", "http://example.net/docs?version=1")),
+        fetched_at=st.datetimes(timezones=st.just(UTC)),
+        sha256=st.text(alphabet="0123456789abcdef", min_size=64, max_size=64),
+        byte_count=st.integers(min_value=0),
+    )
+    def test_parse_sidecar_metadata_accepts_valid_aware_sidecars(
+        self, url: str, fetched_at: datetime, sha256: str, byte_count: int
+    ) -> None:
+        # Given
+        sidecar_json = json.dumps({
+            "url": url,
+            "fetched_at": fetched_at.isoformat(),
+            "sha256": sha256,
+            "byte_count": byte_count,
+        })
+
+        # When
+        result = parse_sidecar_metadata(sidecar_json)
+
+        # Then
+        assert result is not None
+        assert result.url == url
+        assert result.fetched_at == fetched_at
+        assert result.sha256 == sha256
+        assert result.byte_count == byte_count
+
+    @given(st.sampled_from(("{", "[]", "null")))
+    def test_parse_sidecar_metadata_rejects_malformed_or_non_object_json(self, sidecar_json: str) -> None:
+        # Given / When
+        result = parse_sidecar_metadata(sidecar_json)
+
+        # Then
+        assert result is None
+
+    @given(
+        url=st.one_of(
+            st.none(),
+            st.integers(),
+            st.lists(st.text()),
+            st.sampled_from(("", "not a url", "ftp://example.com", "/relative")),
+        ),
+        fetched_at=st.one_of(st.none(), st.integers(), st.sampled_from(("2026-03-23T14:00:00", "invalid"))),
+        sha256=st.one_of(st.integers(), st.sampled_from(("a" * 63, "g" * 64))),
+        byte_count=st.one_of(st.text(), st.integers(max_value=-1)),
+    )
+    def test_parse_sidecar_metadata_rejects_invalid_field_values(
+        self, url: str | int | list[str] | None, fetched_at: str | int | None, sha256: str | int, byte_count: str | int
+    ) -> None:
+        # Given
+        sidecar_json = json.dumps({"url": url, "fetched_at": fetched_at, "sha256": sha256, "byte_count": byte_count})
+
+        # When
+        result = parse_sidecar_metadata(sidecar_json)
+
+        # Then
+        assert result is None
+
     @pytest.mark.parametrize(
         "sidecar_json",
         [
@@ -623,8 +683,20 @@ class TestLoadSidecar:
             '{"url":"https://example.com/page.md","fetched_at":"2026-03-23T14:00:00+00:00","sha256":"abc"}',
             '{"url":1,"fetched_at":"2026-03-23T14:00:00+00:00","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","byte_count":3}',
             '{"url":"https://example.com/page.md","fetched_at":"2026-03-23T14:00:00+00:00","sha256":"abc","byte_count":3}',
+            '{"url":"","fetched_at":"2026-03-23T14:00:00+00:00","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","byte_count":3}',
+            '{"url":"not a url","fetched_at":"2026-03-23T14:00:00+00:00","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","byte_count":3}',
+            '{"url":"https://example.com/page.md","fetched_at":"2026-03-23T14:00:00+00:00","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","byte_count":-1}',
         ],
-        ids=["naive-timestamp", "wrong-timestamp-type", "missing-byte-count", "wrong-url-type", "wrong-sha256"],
+        ids=[
+            "naive-timestamp",
+            "wrong-timestamp-type",
+            "missing-byte-count",
+            "wrong-url-type",
+            "wrong-sha256",
+            "empty-url",
+            "invalid-url",
+            "negative-byte-count",
+        ],
     )
     def test_load_sidecar_invalid_metadata_returns_none(self, tmp_path: Path, sidecar_json: str) -> None:
         # Given

--- a/packages/skilllint/tests/test_vendor_io.py
+++ b/packages/skilllint/tests/test_vendor_io.py
@@ -568,19 +568,19 @@ class TestWriteSidecar:
 class TestLoadSidecar:
     """Tests for load_sidecar — .meta.json loader."""
 
-    def test_load_sidecar_valid_sidecar_returns_dict(self, tmp_path: Path) -> None:
-        """load_sidecar returns the parsed dict for a valid .meta.json file.
+    def test_load_sidecar_valid_sidecar_returns_metadata(self, tmp_path: Path) -> None:
+        """load_sidecar returns validated metadata for a valid .meta.json file.
 
         Tests: load_sidecar happy path
         How: Write a .meta.json file, call load_sidecar for the .md path.
-        Why: Cache freshness checks depend on reading back the stored fetched_at value.
+        Why: Cache freshness checks require a validated, aware fetched_at value.
         """
         # Arrange
         md_path = tmp_path / "page.md"
         sidecar_data = {
             "url": "https://example.com/",
             "fetched_at": "2026-03-23T14:00:00+00:00",
-            "sha256": "abc",
+            "sha256": "a" * 64,
             "byte_count": 3,
         }
         md_path.with_suffix(".meta.json").write_text(json.dumps(sidecar_data), encoding="utf-8")
@@ -589,7 +589,53 @@ class TestLoadSidecar:
         result = load_sidecar(md_path)
 
         # Assert
-        assert result == sidecar_data
+        assert result is not None
+        assert result.url == sidecar_data["url"]
+        assert result.sha256 == sidecar_data["sha256"]
+        assert result.byte_count == sidecar_data["byte_count"]
+
+    def test_load_sidecar_returns_concrete_metadata_with_aware_timestamp(self, tmp_path: Path) -> None:
+        # Given
+        md_path = tmp_path / "page.md"
+        md_path.with_suffix(".meta.json").write_text(
+            json.dumps({
+                "url": "https://example.com/page.md",
+                "fetched_at": "2026-03-23T14:00:00+00:00",
+                "sha256": "a" * 64,
+                "byte_count": 3,
+            }),
+            encoding="utf-8",
+        )
+
+        # When
+        result = load_sidecar(md_path)
+
+        # Then
+        assert result is not None
+        assert result.url == "https://example.com/page.md"
+        assert result.fetched_at.tzinfo is not None
+
+    @pytest.mark.parametrize(
+        "sidecar_json",
+        [
+            '{"url":"https://example.com/page.md","fetched_at":"2026-03-23T14:00:00","sha256":"abc","byte_count":3}',
+            '{"url":"https://example.com/page.md","fetched_at":1,"sha256":"abc","byte_count":3}',
+            '{"url":"https://example.com/page.md","fetched_at":"2026-03-23T14:00:00+00:00","sha256":"abc"}',
+            '{"url":1,"fetched_at":"2026-03-23T14:00:00+00:00","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","byte_count":3}',
+            '{"url":"https://example.com/page.md","fetched_at":"2026-03-23T14:00:00+00:00","sha256":"abc","byte_count":3}',
+        ],
+        ids=["naive-timestamp", "wrong-timestamp-type", "missing-byte-count", "wrong-url-type", "wrong-sha256"],
+    )
+    def test_load_sidecar_invalid_metadata_returns_none(self, tmp_path: Path, sidecar_json: str) -> None:
+        # Given
+        md_path = tmp_path / "page.md"
+        md_path.with_suffix(".meta.json").write_text(sidecar_json, encoding="utf-8")
+
+        # When
+        result = load_sidecar(md_path)
+
+        # Then
+        assert result is None
 
     def test_load_sidecar_missing_sidecar_returns_none(self, tmp_path: Path) -> None:
         """load_sidecar returns None when no .meta.json file exists.

--- a/packages/skilllint/tests/test_vendor_io.py
+++ b/packages/skilllint/tests/test_vendor_io.py
@@ -653,21 +653,64 @@ class TestLoadSidecar:
         assert result is None
 
     @given(
-        url=st.one_of(
-            st.none(),
-            st.integers(),
-            st.lists(st.text()),
-            st.sampled_from(("", "not a url", "ftp://example.com", "/relative")),
-        ),
-        fetched_at=st.one_of(st.none(), st.integers(), st.sampled_from(("2026-03-23T14:00:00", "invalid"))),
-        sha256=st.one_of(st.integers(), st.sampled_from(("a" * 63, "g" * 64))),
-        byte_count=st.one_of(st.text(), st.integers(max_value=-1)),
+        invalid_field=st.one_of(
+            st.tuples(
+                st.just("url"),
+                st.one_of(
+                    st.none(),
+                    st.integers(),
+                    st.lists(st.text()),
+                    st.sampled_from(("", "not a url", "ftp://example.com", "/relative")),
+                ),
+            ),
+            st.tuples(
+                st.just("fetched_at"),
+                st.one_of(st.none(), st.integers(), st.sampled_from(("2026-03-23T14:00:00", "invalid"))),
+            ),
+            st.tuples(
+                st.just("sha256"),
+                st.one_of(st.none(), st.integers(), st.sampled_from(("a" * 63, "a" * 65, "A" * 64, "g" * 64))),
+            ),
+            st.tuples(
+                st.just("byte_count"),
+                st.one_of(
+                    st.text(),
+                    st.floats(allow_nan=False, allow_infinity=False),
+                    st.booleans(),
+                    st.integers(max_value=-1),
+                ),
+            ),
+        )
     )
-    def test_parse_sidecar_metadata_rejects_invalid_field_values(
-        self, url: str | int | list[str] | None, fetched_at: str | int | None, sha256: str | int, byte_count: str | int
+    def test_parse_sidecar_metadata_rejects_each_invalid_field_with_other_fields_valid(
+        self, invalid_field: tuple[str, str | int | float | bool | list[str] | None]
     ) -> None:
         # Given
-        sidecar_json = json.dumps({"url": url, "fetched_at": fetched_at, "sha256": sha256, "byte_count": byte_count})
+        sidecar: dict[str, str | int | float | bool | list[str] | None] = {
+            "url": "https://example.com/page.md",
+            "fetched_at": "2026-03-23T14:00:00+00:00",
+            "sha256": "a" * 64,
+            "byte_count": 3,
+        }
+        field, value = invalid_field
+        sidecar[field] = value
+        sidecar_json = json.dumps(sidecar)
+
+        # When
+        result = parse_sidecar_metadata(sidecar_json)
+
+        # Then
+        assert result is None
+
+    @given(byte_count=st.one_of(st.text(), st.floats(allow_nan=False, allow_infinity=False), st.booleans()))
+    def test_parse_sidecar_metadata_rejects_wrong_type_byte_count(self, byte_count: str | float | bool) -> None:
+        # Given
+        sidecar_json = json.dumps({
+            "url": "https://example.com/page.md",
+            "fetched_at": "2026-03-23T14:00:00+00:00",
+            "sha256": "a" * 64,
+            "byte_count": byte_count,
+        })
 
         # When
         result = parse_sidecar_metadata(sidecar_json)

--- a/packages/skilllint/tests/test_vendor_io.py
+++ b/packages/skilllint/tests/test_vendor_io.py
@@ -625,6 +625,20 @@ class TestLoadSidecar:
         # Assert
         assert result is None
 
+    @pytest.mark.parametrize(
+        "sidecar_json", ["[]", "null", "1", '"metadata"'], ids=["list", "null", "number", "string"]
+    )
+    def test_load_sidecar_wrong_top_level_shape_returns_none(self, tmp_path: Path, sidecar_json: str) -> None:
+        # Given
+        md_path = tmp_path / "page.md"
+        md_path.with_suffix(".meta.json").write_text(sidecar_json, encoding="utf-8")
+
+        # When
+        result = load_sidecar(md_path)
+
+        # Then
+        assert result is None
+
 
 # ---------------------------------------------------------------------------
 # UTC timestamp

--- a/packages/skilllint/vendor_cache.py
+++ b/packages/skilllint/vendor_cache.py
@@ -53,7 +53,6 @@ from skilllint.vendor_io import (
     read_text_or_none,
     sha256_hex,
     utc_now_iso,
-    write_json,
     write_sidecar,
 )
 
@@ -213,16 +212,9 @@ def _is_network_error(exc: Exception) -> bool:
     return isinstance(exc, (httpx.ConnectError, httpx.TimeoutException, httpx.HTTPError))
 
 
-def _age_hours(fetched_at_iso: str | None) -> float:
-    """Return age in hours between *fetched_at_iso* and now (UTC)."""
-    if not isinstance(fetched_at_iso, str):
-        return float("inf")
-    try:
-        fetched_at = datetime.fromisoformat(fetched_at_iso)
-    except (ValueError, TypeError):
-        # Treat unparseable timestamps as maximally stale.
-        return float("inf")
-    if fetched_at.tzinfo is None or fetched_at.utcoffset() is None:
+def _age_hours(fetched_at: datetime | None) -> float:
+    """Return age in hours between validated *fetched_at* and now (UTC)."""
+    if fetched_at is None:
         return float("inf")
     now = datetime.now(UTC)
     delta = now - fetched_at
@@ -371,7 +363,7 @@ def fetch_or_cached(url: str, *, ttl_hours: float = 4.0, force: bool = False) ->
 
     if cached_path is not None:
         sidecar = load_sidecar(cached_path)
-        fetched_at = sidecar.get("fetched_at") if sidecar else None
+        fetched_at = sidecar.fetched_at if sidecar else None
         age = _age_hours(fetched_at)
 
         if not force and age < ttl_hours:
@@ -391,12 +383,12 @@ def fetch_or_cached(url: str, *, ttl_hours: float = 4.0, force: bool = False) ->
             # Content unchanged — touch sidecar only.
             if (
                 sidecar is not None
-                and sidecar.get("url") == url
+                and sidecar.url == url
                 and verify_integrity(cached_path).status is IntegrityStatus.INTACT
             ):
-                sidecar["fetched_at"] = utc_now_iso()
-                sidecar_path = cached_path.with_suffix(".meta.json")
-                write_json(sidecar_path, sidecar)
+                write_sidecar(
+                    cached_path, url=url, content=new_content, fetched_at=datetime.fromisoformat(utc_now_iso())
+                )
             else:
                 write_sidecar(cached_path, url=url, content=new_content)
             return CacheResult(path=cached_path, status=CacheStatus.UNCHANGED, page_name=page_name, url=url)
@@ -654,8 +646,8 @@ def verify_integrity(file_path: Path) -> IntegrityResult:
             expected_bytes=None,
         )
 
-    expected_sha256: str | None = sidecar.get("sha256")
-    expected_bytes: int | None = sidecar.get("byte_count")
+    expected_sha256 = sidecar.sha256
+    expected_bytes = sidecar.byte_count
 
     if computed_sha256 == expected_sha256 and computed_bytes == expected_bytes:
         status = IntegrityStatus.INTACT

--- a/packages/skilllint/vendor_cache.py
+++ b/packages/skilllint/vendor_cache.py
@@ -391,7 +391,7 @@ def fetch_or_cached(url: str, *, ttl_hours: float = 4.0, force: bool = False) ->
             # Content unchanged — touch sidecar only.
             if (
                 sidecar is not None
-                and isinstance(sidecar.get("url"), str)
+                and sidecar.get("url") == url
                 and verify_integrity(cached_path).status is IntegrityStatus.INTACT
             ):
                 sidecar["fetched_at"] = utc_now_iso()

--- a/packages/skilllint/vendor_cache.py
+++ b/packages/skilllint/vendor_cache.py
@@ -389,7 +389,11 @@ def fetch_or_cached(url: str, *, ttl_hours: float = 4.0, force: bool = False) ->
         old_content = read_text_or_none(cached_path) or ""
         if sha256_hex(new_content) == sha256_hex(old_content):
             # Content unchanged — touch sidecar only.
-            if sidecar is not None:
+            if (
+                sidecar is not None
+                and isinstance(sidecar.get("url"), str)
+                and verify_integrity(cached_path).status is IntegrityStatus.INTACT
+            ):
                 sidecar["fetched_at"] = utc_now_iso()
                 sidecar_path = cached_path.with_suffix(".meta.json")
                 write_json(sidecar_path, sidecar)

--- a/packages/skilllint/vendor_cache.py
+++ b/packages/skilllint/vendor_cache.py
@@ -213,12 +213,16 @@ def _is_network_error(exc: Exception) -> bool:
     return isinstance(exc, (httpx.ConnectError, httpx.TimeoutException, httpx.HTTPError))
 
 
-def _age_hours(fetched_at_iso: str) -> float:
+def _age_hours(fetched_at_iso: str | None) -> float:
     """Return age in hours between *fetched_at_iso* and now (UTC)."""
+    if not isinstance(fetched_at_iso, str):
+        return float("inf")
     try:
         fetched_at = datetime.fromisoformat(fetched_at_iso)
     except (ValueError, TypeError):
         # Treat unparseable timestamps as maximally stale.
+        return float("inf")
+    if fetched_at.tzinfo is None or fetched_at.utcoffset() is None:
         return float("inf")
     now = datetime.now(UTC)
     delta = now - fetched_at
@@ -367,7 +371,7 @@ def fetch_or_cached(url: str, *, ttl_hours: float = 4.0, force: bool = False) ->
 
     if cached_path is not None:
         sidecar = load_sidecar(cached_path)
-        fetched_at = sidecar.get("fetched_at", "") if sidecar else ""
+        fetched_at = sidecar.get("fetched_at") if sidecar else None
         age = _age_hours(fetched_at)
 
         if not force and age < ttl_hours:

--- a/packages/skilllint/vendor_io.py
+++ b/packages/skilllint/vendor_io.py
@@ -296,7 +296,8 @@ def load_sidecar(md_path: Path) -> dict[str, Any] | None:
         md_path: Path to the content file whose sidecar to load.
 
     Returns:
-        Parsed sidecar dict, or None if the sidecar is missing or corrupt.
+        Parsed sidecar dict, or None if the sidecar is missing, corrupt, or not a JSON object.
     """
     sidecar_path = md_path.with_suffix(".meta.json")
-    return load_json_or_none(sidecar_path)
+    sidecar = load_json_or_none(sidecar_path)
+    return sidecar if isinstance(sidecar, dict) else None

--- a/packages/skilllint/vendor_io.py
+++ b/packages/skilllint/vendor_io.py
@@ -38,6 +38,8 @@ from typing import Any
 
 import httpx
 
+from skilllint.boundary.vendor_sidecar_ingest import SidecarMetadata, parse_sidecar_metadata
+
 
 class EmptyResponseError(ValueError):
     """Raised when a successful HTTP response has no body."""
@@ -261,7 +263,7 @@ def utc_now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
-def write_sidecar(md_path: Path, *, url: str, content: str) -> Path:
+def write_sidecar(md_path: Path, *, url: str, content: str, fetched_at: datetime | None = None) -> Path:
     """Write a ``.meta.json`` sidecar alongside a saved file.
 
     Records provenance metadata: source URL, fetch timestamp, SHA-256 digest,
@@ -274,30 +276,34 @@ def write_sidecar(md_path: Path, *, url: str, content: str) -> Path:
         md_path: Path to the saved content file (e.g. a ``.md`` file).
         url: The URL the content was fetched from.
         content: The raw text content that was saved.
+        fetched_at: Timestamp to record, or the current UTC time when omitted.
 
     Returns:
         Path to the written sidecar file.
     """
     sidecar_path = md_path.with_suffix(".meta.json")
-    metadata: dict[str, Any] = {
-        "url": url,
-        "fetched_at": utc_now_iso(),
-        "sha256": sha256_hex(content),
-        "byte_count": len(content.encode()),
-    }
-    write_json(sidecar_path, metadata)
+    metadata = SidecarMetadata(
+        url=url,
+        fetched_at=fetched_at or datetime.fromisoformat(utc_now_iso()),
+        sha256=sha256_hex(content),
+        byte_count=len(content.encode()),
+    )
+    sidecar_path.parent.mkdir(parents=True, exist_ok=True)
+    sidecar_path.write_text(metadata.model_dump_json(indent=2) + "\n", encoding="utf-8")
     return sidecar_path
 
 
-def load_sidecar(md_path: Path) -> dict[str, Any] | None:
+def load_sidecar(md_path: Path) -> SidecarMetadata | None:
     """Load the ``.meta.json`` sidecar for a given file path.
 
     Args:
         md_path: Path to the content file whose sidecar to load.
 
     Returns:
-        Parsed sidecar dict, or None if the sidecar is missing, corrupt, or not a JSON object.
+        Validated sidecar metadata, or None if it is missing or malformed.
     """
     sidecar_path = md_path.with_suffix(".meta.json")
-    sidecar = load_json_or_none(sidecar_path)
-    return sidecar if isinstance(sidecar, dict) else None
+    try:
+        return parse_sidecar_metadata(sidecar_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError):
+        return None


### PR DESCRIPTION
Part of #236

Treat missing, malformed, wrong-type, and timezone-naive sidecar timestamps as stale evidence before freshness arithmetic.

Validation:
- `uv run pytest -o addopts= -q packages/skilllint/tests/test_vendor_cache.py`
- Manual public API probe: naive timestamp -> `UNCHANGED` and repaired aware sidecar
- `uv run prek run --files packages/skilllint/vendor_cache.py packages/skilllint/tests/test_vendor_cache.py`

Full gates were each started once; `prek --all-files` reformatted the new test and otherwise passed, while its follow-up targeted hook run passed. The detached full pytest result was not recoverable after completion.