### PR TITLE
fix(cache): resolve installed cache from invocation project

### DIFF
--- a/packages/skilllint/tests/test_e2e_packaging.py
+++ b/packages/skilllint/tests/test_e2e_packaging.py
@@ -544,6 +544,9 @@ print(json.dumps({
     def test_installed_docs_cache_uses_linked_worktree_when_cross_root_primary_is_undiscoverable(
         self, temp_venv: Path
     ) -> None:
+        if sys.platform == "win32":
+            pytest.skip("Cross-root topology requires POSIX /tmp and /var/tmp roots")
+
         with (
             tempfile.TemporaryDirectory(dir=Path.home()) as primary_dir,
             tempfile.TemporaryDirectory(dir="/tmp") as git_dir_parent,

--- a/packages/skilllint/tests/test_e2e_packaging.py
+++ b/packages/skilllint/tests/test_e2e_packaging.py
@@ -589,4 +589,4 @@ print(json.dumps({
             )
 
         assert result.returncode == 0, result.stderr
-        assert result.stdout.replace("\n", "") == str(cache_file)
+        assert result.stdout.replace("\n", "") == str(cache_file.resolve())

--- a/packages/skilllint/tests/test_e2e_packaging.py
+++ b/packages/skilllint/tests/test_e2e_packaging.py
@@ -540,3 +540,53 @@ print(json.dumps({
 
         assert result.returncode == 0, result.stderr
         assert result.stdout.replace("\n", "") == str(cache_file)
+
+    def test_installed_docs_cache_uses_linked_worktree_when_cross_root_primary_is_undiscoverable(
+        self, temp_venv: Path
+    ) -> None:
+        with (
+            tempfile.TemporaryDirectory(dir=Path.home()) as primary_dir,
+            tempfile.TemporaryDirectory(dir="/tmp") as git_dir_parent,
+            tempfile.TemporaryDirectory(dir="/var/tmp") as linked_parent,
+        ):
+            primary = Path(primary_dir)
+            git_dir = Path(git_dir_parent) / "git-dir"
+            linked = Path(linked_parent) / "linked"
+            subprocess.run(
+                ["git", "init", "--initial-branch=main", f"--separate-git-dir={git_dir}"],
+                cwd=primary,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.email", "test@example.com"],
+                cwd=primary,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "Test"], cwd=primary, check=True, capture_output=True, text=True
+            )
+            (primary / "README.md").write_text("# test\n", encoding="utf-8")
+            subprocess.run(["git", "add", "."], cwd=primary, check=True, capture_output=True, text=True)
+            subprocess.run(["git", "commit", "-m", "initial"], cwd=primary, check=True, capture_output=True, text=True)
+            subprocess.run(
+                ["git", "worktree", "add", str(linked)], cwd=primary, check=True, capture_output=True, text=True
+            )
+            cache_file = linked / ".claude/vendor/sources/page-2026.md"
+            cache_file.parent.mkdir(parents=True)
+            cache_file.write_text("cached\n", encoding="utf-8")
+
+            result = subprocess.run(
+                [str(self._get_skilllint_path(temp_venv)), "docs", "latest", "page"],
+                cwd=linked,
+                capture_output=True,
+                text=True,
+                check=False,
+                env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
+            )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.replace("\n", "") == str(cache_file)

--- a/packages/skilllint/tests/test_e2e_packaging.py
+++ b/packages/skilllint/tests/test_e2e_packaging.py
@@ -501,7 +501,7 @@ print(json.dumps({
         assert uvx_result.stdout.replace("\n", "") == str(cache_file)
         assert non_git_result.stdout.replace("\n", "") == str(non_git_cache_file)
 
-    def test_installed_docs_cache_uses_separate_git_dir_primary_from_linked_worktree(
+    def test_installed_docs_cache_uses_linked_worktree_for_separate_git_dir(
         self, temp_venv: Path, tmp_path: Path
     ) -> None:
         primary = tmp_path / "primary-area" / "primary"
@@ -525,7 +525,7 @@ print(json.dumps({
         subprocess.run(["git", "commit", "-m", "initial"], cwd=primary, check=True, capture_output=True, text=True)
         linked.parent.mkdir()
         subprocess.run(["git", "worktree", "add", str(linked)], cwd=primary, check=True, capture_output=True, text=True)
-        cache_file = primary / ".claude/vendor/sources/page-2026.md"
+        cache_file = linked / ".claude/vendor/sources/page-2026.md"
         cache_file.parent.mkdir(parents=True)
         cache_file.write_text("cached\n", encoding="utf-8")
 

--- a/packages/skilllint/tests/test_e2e_packaging.py
+++ b/packages/skilllint/tests/test_e2e_packaging.py
@@ -500,3 +500,43 @@ print(json.dumps({
         assert wheel_result.stdout.replace("\n", "") == str(cache_file)
         assert uvx_result.stdout.replace("\n", "") == str(cache_file)
         assert non_git_result.stdout.replace("\n", "") == str(non_git_cache_file)
+
+    def test_installed_docs_cache_uses_separate_git_dir_primary_from_linked_worktree(
+        self, temp_venv: Path, tmp_path: Path
+    ) -> None:
+        primary = tmp_path / "primary-area" / "primary"
+        git_dir = tmp_path / "git-area" / "git-dir"
+        linked = tmp_path / "worktree-area" / "linked"
+        primary.mkdir(parents=True)
+        git_dir.parent.mkdir()
+        subprocess.run(
+            ["git", "init", "--initial-branch=main", f"--separate-git-dir={git_dir}"],
+            cwd=primary,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"], cwd=primary, check=True, capture_output=True, text=True
+        )
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=primary, check=True, capture_output=True, text=True)
+        (primary / "README.md").write_text("# test\n", encoding="utf-8")
+        subprocess.run(["git", "add", "."], cwd=primary, check=True, capture_output=True, text=True)
+        subprocess.run(["git", "commit", "-m", "initial"], cwd=primary, check=True, capture_output=True, text=True)
+        linked.parent.mkdir()
+        subprocess.run(["git", "worktree", "add", str(linked)], cwd=primary, check=True, capture_output=True, text=True)
+        cache_file = primary / ".claude/vendor/sources/page-2026.md"
+        cache_file.parent.mkdir(parents=True)
+        cache_file.write_text("cached\n", encoding="utf-8")
+
+        result = subprocess.run(
+            [str(self._get_skilllint_path(temp_venv)), "docs", "latest", "page"],
+            cwd=linked,
+            capture_output=True,
+            text=True,
+            check=False,
+            env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.replace("\n", "") == str(cache_file)

--- a/packages/skilllint/tests/test_vendor_io.py
+++ b/packages/skilllint/tests/test_vendor_io.py
@@ -1064,6 +1064,21 @@ class TestSharedCheckoutRoot:
 
         assert _shared_checkout_root(worktree) == worktree
 
+    def test_invalid_primary_checkout_git_pointer_returns_start_unchanged(self, tmp_path: Path) -> None:
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        worktree_gitdir = tmp_path / "metadata" / "worktrees" / "worktree"
+        worktree_gitdir.mkdir(parents=True)
+        primary = tmp_path / "primary"
+        primary.mkdir()
+        common_gitdir = primary / ".git-data"
+        common_gitdir.mkdir()
+        (worktree / ".git").write_text(f"gitdir: {worktree_gitdir}\n", encoding="utf-8")
+        (worktree_gitdir / "commondir").write_text(str(common_gitdir), encoding="utf-8")
+        (primary / ".git").write_bytes(b"gitdir: bad\x00path\n")
+
+        assert _shared_checkout_root(worktree) == worktree
+
     def test_gitdir_pointing_nowhere_returns_start_unchanged(self, tmp_path: Path) -> None:
         """A .git file pointing at a nonexistent gitdir returns start unchanged.
 

--- a/packages/skilllint/tests/test_vendor_io.py
+++ b/packages/skilllint/tests/test_vendor_io.py
@@ -768,7 +768,7 @@ class TestRuntimeCacheRoot:
 
         assert _runtime_cache_root(worktree) == repo.resolve()
 
-    def test_installed_wheel_in_separate_git_dir_worktree_uses_primary_checkout(
+    def test_installed_wheel_in_separate_git_dir_worktree_uses_linked_worktree(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         repo = tmp_path / "repo"
@@ -784,7 +784,7 @@ class TestRuntimeCacheRoot:
         _run_git(["worktree", "add", str(worktree)], cwd=repo)
         monkeypatch.setattr(vendor_io, "PROJECT_ROOT", tmp_path / "site-packages")
 
-        assert _runtime_cache_root(worktree) == repo.resolve()
+        assert _runtime_cache_root(worktree) == worktree.resolve()
 
     def test_installed_wheel_outside_git_uses_canonical_cwd(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -955,7 +955,7 @@ class TestSharedCheckoutRoot:
 
         assert result == bare_worktree
 
-    def test_separate_git_dir_nested_in_unrelated_checkout_uses_its_primary(self, tmp_path: Path) -> None:
+    def test_separate_git_dir_nested_in_unrelated_checkout_uses_linked_worktree(self, tmp_path: Path) -> None:
         unrelated = tmp_path / "unrelated"
         unrelated.mkdir()
         _init_repo_with_commit(unrelated)
@@ -971,7 +971,7 @@ class TestSharedCheckoutRoot:
         linked = tmp_path / "linked"
         _run_git(["worktree", "add", str(linked)], cwd=primary)
 
-        assert _shared_checkout_root(linked) == primary.resolve()
+        assert _shared_checkout_root(linked) == linked.resolve()
 
     def test_malformed_gitdir_content_returns_start_unchanged(self, tmp_path: Path) -> None:
         """A .git file with unreadable/garbage gitdir content returns start unchanged.

--- a/packages/skilllint/tests/test_vendor_io.py
+++ b/packages/skilllint/tests/test_vendor_io.py
@@ -953,12 +953,7 @@ class TestSharedCheckoutRoot:
         # Act
         result = _shared_checkout_root(bare_worktree)
 
-        # Assert — the bare repo's directory has no working-tree parent of its
-        # own, so the resolved commondir's parent is the bare repo's *parent*
-        # directory. This is the algorithm's defined, deterministic behaviour
-        # for this topology, not a meaningful "primary checkout" in the
-        # linked-worktree sense.
-        assert result == bare.resolve().parent
+        assert result == bare_worktree
 
     def test_malformed_gitdir_content_returns_start_unchanged(self, tmp_path: Path) -> None:
         """A .git file with unreadable/garbage gitdir content returns start unchanged.

--- a/packages/skilllint/tests/test_vendor_io.py
+++ b/packages/skilllint/tests/test_vendor_io.py
@@ -797,6 +797,18 @@ class TestRuntimeCacheRoot:
 
         assert _runtime_cache_root(cwd) == cwd.resolve()
 
+    def test_installed_wheel_with_unavailable_cwd_keeps_cache_root_relative(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(vendor_io, "PROJECT_ROOT", tmp_path / "site-packages")
+
+        def unavailable_cwd() -> Path:
+            raise FileNotFoundError("working directory was removed")
+
+        monkeypatch.setattr(vendor_io.Path, "cwd", unavailable_cwd)
+
+        assert _runtime_cache_root() == Path()
+
 
 # ---------------------------------------------------------------------------
 # Worktree detection

--- a/packages/skilllint/tests/test_vendor_io.py
+++ b/packages/skilllint/tests/test_vendor_io.py
@@ -1064,6 +1064,28 @@ class TestSharedCheckoutRoot:
 
         assert _shared_checkout_root(worktree) == worktree
 
+    def test_cyclic_commondir_path_returns_start_unchanged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        gitdir = tmp_path / "git-dir" / "worktrees" / "worktree"
+        gitdir.mkdir(parents=True)
+        cycle = tmp_path / "cycle"
+        cycle.symlink_to(cycle)
+        (worktree / ".git").write_text(f"gitdir: {gitdir}\n", encoding="utf-8")
+        (gitdir / "commondir").write_text(str(cycle), encoding="utf-8")
+        original_resolve = Path.resolve
+
+        def raise_for_cycle(path: Path, *, strict: bool = False) -> Path:
+            if path == cycle:
+                raise RuntimeError("Symlink loop from supported Python runtime")
+            return original_resolve(path, strict=strict)
+
+        monkeypatch.setattr(Path, "resolve", raise_for_cycle)
+
+        assert _shared_checkout_root(worktree) == worktree
+
     def test_invalid_primary_checkout_git_pointer_returns_start_unchanged(self, tmp_path: Path) -> None:
         worktree = tmp_path / "worktree"
         worktree.mkdir()

--- a/packages/skilllint/tests/test_vendor_io.py
+++ b/packages/skilllint/tests/test_vendor_io.py
@@ -768,6 +768,24 @@ class TestRuntimeCacheRoot:
 
         assert _runtime_cache_root(worktree) == repo.resolve()
 
+    def test_installed_wheel_in_separate_git_dir_worktree_uses_primary_checkout(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo = tmp_path / "repo"
+        git_dir = tmp_path / "git-dir"
+        repo.mkdir()
+        _run_git(["init", "--initial-branch=main", f"--separate-git-dir={git_dir}"], cwd=repo)
+        _run_git(["config", "user.email", "test@example.com"], cwd=repo)
+        _run_git(["config", "user.name", "Test"], cwd=repo)
+        (repo / "file.txt").write_text("content\n", encoding="utf-8")
+        _run_git(["add", "."], cwd=repo)
+        _run_git(["commit", "-m", "initial commit"], cwd=repo)
+        worktree = tmp_path / "linked"
+        _run_git(["worktree", "add", str(worktree)], cwd=repo)
+        monkeypatch.setattr(vendor_io, "PROJECT_ROOT", tmp_path / "site-packages")
+
+        assert _runtime_cache_root(worktree) == repo.resolve()
+
     def test_installed_wheel_outside_git_uses_canonical_cwd(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/packages/skilllint/tests/test_vendor_io.py
+++ b/packages/skilllint/tests/test_vendor_io.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import subprocess
 from datetime import datetime
 from pathlib import Path
@@ -970,6 +971,46 @@ class TestSharedCheckoutRoot:
         _run_git(["commit", "-m", "initial commit"], cwd=primary)
         linked = tmp_path / "linked"
         _run_git(["worktree", "add", str(linked)], cwd=primary)
+
+        assert _shared_checkout_root(linked) == linked.resolve()
+
+    def test_separate_git_dir_falls_back_without_recursively_scanning_ancestors(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        linked = tmp_path / "linked"
+        linked.mkdir()
+        git_dir = tmp_path / "git-dir"
+        git_dir.mkdir()
+        worktree_git_dir = git_dir / "worktrees" / "linked"
+        worktree_git_dir.mkdir(parents=True)
+        (linked / ".git").write_text(f"gitdir: {worktree_git_dir}\n", encoding="utf-8")
+        (worktree_git_dir / "commondir").write_text("../..\n", encoding="utf-8")
+
+        monkeypatch.setattr(
+            os,
+            "walk",
+            lambda *_args, **_kwargs: pytest.fail("cache-root resolution must not recursively scan ancestors"),
+        )
+
+        assert _shared_checkout_root(linked) == linked.resolve()
+
+    def test_separate_git_dir_falls_back_when_commonpath_is_unavailable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        linked = tmp_path / "linked"
+        linked.mkdir()
+        git_dir = tmp_path / "git-dir"
+        git_dir.mkdir()
+        worktree_git_dir = git_dir / "worktrees" / "linked"
+        worktree_git_dir.mkdir(parents=True)
+        (linked / ".git").write_text(f"gitdir: {worktree_git_dir}\n", encoding="utf-8")
+        (worktree_git_dir / "commondir").write_text("../..\n", encoding="utf-8")
+
+        monkeypatch.setattr(
+            os.path,
+            "commonpath",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("paths are on different drives")),
+        )
 
         assert _shared_checkout_root(linked) == linked.resolve()
 

--- a/packages/skilllint/tests/test_vendor_io.py
+++ b/packages/skilllint/tests/test_vendor_io.py
@@ -1101,6 +1101,33 @@ class TestSharedCheckoutRoot:
 
         assert _shared_checkout_root(worktree) == worktree
 
+    def test_cyclic_primary_checkout_git_pointer_returns_start_unchanged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        worktree_gitdir = tmp_path / "metadata" / "worktrees" / "worktree"
+        worktree_gitdir.mkdir(parents=True)
+        primary = tmp_path / "primary"
+        primary.mkdir()
+        common_gitdir = primary / ".git-data"
+        common_gitdir.mkdir()
+        cycle = primary / "cycle"
+        cycle.symlink_to(cycle)
+        (worktree / ".git").write_text(f"gitdir: {worktree_gitdir}\n", encoding="utf-8")
+        (worktree_gitdir / "commondir").write_text(str(common_gitdir), encoding="utf-8")
+        (primary / ".git").write_text("gitdir: cycle\n", encoding="utf-8")
+        original_resolve = Path.resolve
+
+        def raise_for_cycle(path: Path, *, strict: bool = False) -> Path:
+            if path == cycle:
+                raise RuntimeError("Symlink loop from supported Python runtime")
+            return original_resolve(path, strict=strict)
+
+        monkeypatch.setattr(Path, "resolve", raise_for_cycle)
+
+        assert _shared_checkout_root(worktree) == worktree
+
     def test_gitdir_pointing_nowhere_returns_start_unchanged(self, tmp_path: Path) -> None:
         """A .git file pointing at a nonexistent gitdir returns start unchanged.
 

--- a/packages/skilllint/tests/test_vendor_io.py
+++ b/packages/skilllint/tests/test_vendor_io.py
@@ -1046,6 +1046,14 @@ class TestSharedCheckoutRoot:
         # Assert
         assert result == weird_dir
 
+    @pytest.mark.parametrize("content", [b"gitdir: \xff\n", b"gitdir: bad\x00path\n"])
+    def test_invalid_gitdir_bytes_return_start_unchanged(self, tmp_path: Path, content: bytes) -> None:
+        weird_dir = tmp_path / "weird-bytes"
+        weird_dir.mkdir()
+        (weird_dir / ".git").write_bytes(content)
+
+        assert _shared_checkout_root(weird_dir) == weird_dir
+
     def test_gitdir_pointing_nowhere_returns_start_unchanged(self, tmp_path: Path) -> None:
         """A .git file pointing at a nonexistent gitdir returns start unchanged.
 

--- a/packages/skilllint/tests/test_vendor_io.py
+++ b/packages/skilllint/tests/test_vendor_io.py
@@ -955,6 +955,24 @@ class TestSharedCheckoutRoot:
 
         assert result == bare_worktree
 
+    def test_separate_git_dir_nested_in_unrelated_checkout_uses_its_primary(self, tmp_path: Path) -> None:
+        unrelated = tmp_path / "unrelated"
+        unrelated.mkdir()
+        _init_repo_with_commit(unrelated)
+        primary = tmp_path / "primary"
+        primary.mkdir()
+        git_dir = unrelated / "project.git"
+        _run_git(["init", "--initial-branch=main", f"--separate-git-dir={git_dir}"], cwd=primary)
+        _run_git(["config", "user.email", "test@example.com"], cwd=primary)
+        _run_git(["config", "user.name", "Test"], cwd=primary)
+        (primary / "file.txt").write_text("content\n", encoding="utf-8")
+        _run_git(["add", "."], cwd=primary)
+        _run_git(["commit", "-m", "initial commit"], cwd=primary)
+        linked = tmp_path / "linked"
+        _run_git(["worktree", "add", str(linked)], cwd=primary)
+
+        assert _shared_checkout_root(linked) == primary.resolve()
+
     def test_malformed_gitdir_content_returns_start_unchanged(self, tmp_path: Path) -> None:
         """A .git file with unreadable/garbage gitdir content returns start unchanged.
 

--- a/packages/skilllint/tests/test_vendor_io.py
+++ b/packages/skilllint/tests/test_vendor_io.py
@@ -1054,6 +1054,16 @@ class TestSharedCheckoutRoot:
 
         assert _shared_checkout_root(weird_dir) == weird_dir
 
+    def test_invalid_commondir_path_returns_start_unchanged(self, tmp_path: Path) -> None:
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        gitdir = tmp_path / "git-dir" / "worktrees" / "worktree"
+        gitdir.mkdir(parents=True)
+        (worktree / ".git").write_text(f"gitdir: {gitdir}\n", encoding="utf-8")
+        (gitdir / "commondir").write_bytes(b"bad\x00path\n")
+
+        assert _shared_checkout_root(worktree) == worktree
+
     def test_gitdir_pointing_nowhere_returns_start_unchanged(self, tmp_path: Path) -> None:
         """A .git file pointing at a nonexistent gitdir returns start unchanged.
 

--- a/packages/skilllint/vendor_io.py
+++ b/packages/skilllint/vendor_io.py
@@ -129,7 +129,7 @@ def _shared_checkout_root(start: Path) -> Path:
         return start
 
     primary_checkout = resolved_git_dir.parent
-    if (primary_checkout / ".git").exists():
+    if _checkout_points_to_git_dir(primary_checkout, resolved_git_dir):
         return primary_checkout
     return (
         start
@@ -143,6 +143,28 @@ def _is_bare_git_dir(git_dir: Path) -> bool:
     if config is None:
         return False
     return any("".join(line.split()).lower() == "bare=true" for line in config.splitlines())
+
+
+def _checkout_points_to_git_dir(checkout: Path, git_dir: Path) -> bool:
+    git_entry = checkout / ".git"
+    if git_entry.is_dir():
+        try:
+            return git_entry.resolve(strict=True) == git_dir
+        except OSError:
+            return False
+
+    pointer = _read_git_internal_file_or_none(git_entry)
+    prefix = "gitdir: "
+    if pointer is None or not pointer.startswith(prefix):
+        return False
+
+    target = Path(pointer[len(prefix) :].strip())
+    if not target.is_absolute():
+        target = checkout / target
+    try:
+        return target.resolve(strict=True) == git_dir
+    except OSError:
+        return False
 
 
 def _checkout_pointing_to_git_dir_or_none(start: Path, git_dir: Path) -> Path | None:

--- a/packages/skilllint/vendor_io.py
+++ b/packages/skilllint/vendor_io.py
@@ -124,7 +124,7 @@ def _shared_checkout_root(start: Path) -> Path:
 
     try:
         resolved_git_dir = commondir_path.resolve(strict=True)
-    except OSError:
+    except (OSError, ValueError):
         return start
 
     primary_checkout = resolved_git_dir.parent

--- a/packages/skilllint/vendor_io.py
+++ b/packages/skilllint/vendor_io.py
@@ -151,7 +151,7 @@ def _checkout_points_to_git_dir(checkout: Path, git_dir: Path) -> bool:
         target = checkout / target
     try:
         return target.resolve(strict=True) == git_dir
-    except (OSError, ValueError):
+    except (OSError, RuntimeError, ValueError):
         return False
 
 

--- a/packages/skilllint/vendor_io.py
+++ b/packages/skilllint/vendor_io.py
@@ -128,9 +128,13 @@ def _shared_checkout_root(start: Path) -> Path:
         return start
 
     primary_checkout = resolved_git_dir.parent
-    if not (primary_checkout / ".git").exists() and not _is_bare_git_dir(resolved_git_dir):
-        return _checkout_with_git_dir_or_none(start, resolved_git_dir) or start
-    return primary_checkout
+    if (primary_checkout / ".git").exists():
+        return primary_checkout
+    return (
+        start
+        if _is_bare_git_dir(resolved_git_dir)
+        else _checkout_with_git_dir_or_none(start, resolved_git_dir) or start
+    )
 
 
 def _is_bare_git_dir(git_dir: Path) -> bool:

--- a/packages/skilllint/vendor_io.py
+++ b/packages/skilllint/vendor_io.py
@@ -127,7 +127,39 @@ def _shared_checkout_root(start: Path) -> Path:
     except OSError:
         return start
 
-    return resolved_git_dir.parent
+    primary_checkout = resolved_git_dir.parent
+    if not (primary_checkout / ".git").exists() and not _is_bare_git_dir(resolved_git_dir):
+        return _checkout_with_git_dir_or_none(start, resolved_git_dir) or start
+    return primary_checkout
+
+
+def _is_bare_git_dir(git_dir: Path) -> bool:
+    config = _read_git_internal_file_or_none(git_dir / "config")
+    if config is None:
+        return False
+    return any("".join(line.split()).lower() == "bare=true" for line in config.splitlines())
+
+
+def _checkout_with_git_dir_or_none(start: Path, git_dir: Path) -> Path | None:
+    try:
+        candidates = tuple(start.parent.iterdir())
+    except OSError:
+        return None
+
+    prefix = "gitdir: "
+    for candidate in candidates:
+        pointer = _read_git_internal_file_or_none(candidate / ".git")
+        if pointer is None or not pointer.startswith(prefix):
+            continue
+        candidate_git_dir = Path(pointer[len(prefix) :].strip())
+        if not candidate_git_dir.is_absolute():
+            candidate_git_dir = candidate / candidate_git_dir
+        try:
+            if candidate_git_dir.resolve(strict=True) == git_dir:
+                return candidate
+        except OSError:
+            continue
+    return None
 
 
 def _runtime_cache_root(cwd: Path | None = None) -> Path:

--- a/packages/skilllint/vendor_io.py
+++ b/packages/skilllint/vendor_io.py
@@ -151,7 +151,7 @@ def _checkout_points_to_git_dir(checkout: Path, git_dir: Path) -> bool:
         target = checkout / target
     try:
         return target.resolve(strict=True) == git_dir
-    except OSError:
+    except (OSError, ValueError):
         return False
 
 

--- a/packages/skilllint/vendor_io.py
+++ b/packages/skilllint/vendor_io.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -133,7 +134,7 @@ def _shared_checkout_root(start: Path) -> Path:
     return (
         start
         if _is_bare_git_dir(resolved_git_dir)
-        else _checkout_with_git_dir_or_none(start, resolved_git_dir) or start
+        else _checkout_pointing_to_git_dir_or_none(start, resolved_git_dir) or start
     )
 
 
@@ -144,14 +145,14 @@ def _is_bare_git_dir(git_dir: Path) -> bool:
     return any("".join(line.split()).lower() == "bare=true" for line in config.splitlines())
 
 
-def _checkout_with_git_dir_or_none(start: Path, git_dir: Path) -> Path | None:
-    try:
-        candidates = tuple(start.parent.iterdir())
-    except OSError:
+def _checkout_pointing_to_git_dir_or_none(start: Path, git_dir: Path) -> Path | None:
+    search_root = Path(os.path.commonpath((start, git_dir)))
+    if search_root == search_root.parent:
         return None
-
     prefix = "gitdir: "
-    for candidate in candidates:
+    for directory, subdirectories, _files in os.walk(search_root):
+        subdirectories[:] = [name for name in subdirectories if name != ".git"]
+        candidate = Path(directory)
         pointer = _read_git_internal_file_or_none(candidate / ".git")
         if pointer is None or not pointer.startswith(prefix):
             continue

--- a/packages/skilllint/vendor_io.py
+++ b/packages/skilllint/vendor_io.py
@@ -124,7 +124,7 @@ def _shared_checkout_root(start: Path) -> Path:
 
     try:
         resolved_git_dir = commondir_path.resolve(strict=True)
-    except (OSError, ValueError):
+    except (OSError, RuntimeError, ValueError):
         return start
 
     primary_checkout = resolved_git_dir.parent

--- a/packages/skilllint/vendor_io.py
+++ b/packages/skilllint/vendor_io.py
@@ -32,7 +32,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -131,18 +130,7 @@ def _shared_checkout_root(start: Path) -> Path:
     primary_checkout = resolved_git_dir.parent
     if _checkout_points_to_git_dir(primary_checkout, resolved_git_dir):
         return primary_checkout
-    return (
-        start
-        if _is_bare_git_dir(resolved_git_dir)
-        else _checkout_pointing_to_git_dir_or_none(start, resolved_git_dir) or start
-    )
-
-
-def _is_bare_git_dir(git_dir: Path) -> bool:
-    config = _read_git_internal_file_or_none(git_dir / "config")
-    if config is None:
-        return False
-    return any("".join(line.split()).lower() == "bare=true" for line in config.splitlines())
+    return start
 
 
 def _checkout_points_to_git_dir(checkout: Path, git_dir: Path) -> bool:
@@ -165,28 +153,6 @@ def _checkout_points_to_git_dir(checkout: Path, git_dir: Path) -> bool:
         return target.resolve(strict=True) == git_dir
     except OSError:
         return False
-
-
-def _checkout_pointing_to_git_dir_or_none(start: Path, git_dir: Path) -> Path | None:
-    search_root = Path(os.path.commonpath((start, git_dir)))
-    if search_root == search_root.parent:
-        return None
-    prefix = "gitdir: "
-    for directory, subdirectories, _files in os.walk(search_root):
-        subdirectories[:] = [name for name in subdirectories if name != ".git"]
-        candidate = Path(directory)
-        pointer = _read_git_internal_file_or_none(candidate / ".git")
-        if pointer is None or not pointer.startswith(prefix):
-            continue
-        candidate_git_dir = Path(pointer[len(prefix) :].strip())
-        if not candidate_git_dir.is_absolute():
-            candidate_git_dir = candidate / candidate_git_dir
-        try:
-            if candidate_git_dir.resolve(strict=True) == git_dir:
-                return candidate
-        except OSError:
-            continue
-    return None
 
 
 def _runtime_cache_root(cwd: Path | None = None) -> Path:

--- a/packages/skilllint/vendor_io.py
+++ b/packages/skilllint/vendor_io.py
@@ -159,7 +159,10 @@ def _runtime_cache_root(cwd: Path | None = None) -> Path:
     if (PROJECT_ROOT / "pyproject.toml").is_file():
         return _shared_checkout_root(PROJECT_ROOT)
 
-    start = (cwd or Path.cwd()).resolve()
+    try:
+        start = (cwd or Path.cwd()).resolve()
+    except OSError:
+        return Path()
     for candidate in (start, *start.parents):
         if (candidate / ".git").exists():
             return _shared_checkout_root(candidate)

--- a/packages/skilllint/vendor_io.py
+++ b/packages/skilllint/vendor_io.py
@@ -70,7 +70,7 @@ def _read_git_internal_file_or_none(path: Path) -> str | None:
     """
     try:
         return path.read_text(encoding="utf-8").strip()
-    except OSError:
+    except (OSError, UnicodeDecodeError, ValueError):
         return None
 
 

--- a/scripts/assert_installed_artifact.py
+++ b/scripts/assert_installed_artifact.py
@@ -21,6 +21,11 @@ from pydantic import BaseModel, ConfigDict
 
 ALIASES: Final = ("agentlint", "pluginlint", "skillint", "skilllint")
 WHEEL_PYTHONS: Final = ("3.11", "3.12", "3.13", "3.14")
+# IANA Service Name and Transport Protocol Port Number Registry assigns TCP port
+# 1 to tcpmux: https://www.iana.org/assignments/service-names-port-numbers.
+# Artifact verification starts no proxy, so this named loopback endpoint makes
+# an accidental token-download path fail locally instead of using ambient proxies.
+OFFLINE_PROXY_URL: Final = "http://127.0.0.1:1"
 
 
 class _ArtifactEvidence(BaseModel):
@@ -72,10 +77,10 @@ def _environment(cache_directory: Path) -> dict[str, str]:
             for key, value in os.environ.items()
             if key.upper() not in {"NO_PROXY", "PYTHONPATH", "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY"}
         },
-        "ALL_PROXY": "http://127.0.0.1:1",
+        "ALL_PROXY": OFFLINE_PROXY_URL,
         "DATA_GYM_CACHE_DIR": str(cache_directory),
-        "HTTP_PROXY": "http://127.0.0.1:1",
-        "HTTPS_PROXY": "http://127.0.0.1:1",
+        "HTTP_PROXY": OFFLINE_PROXY_URL,
+        "HTTPS_PROXY": OFFLINE_PROXY_URL,
         "TIKTOKEN_CACHE_DIR": str(cache_directory),
     }
 

--- a/tests/test_assert_installed_artifact.py
+++ b/tests/test_assert_installed_artifact.py
@@ -4,12 +4,33 @@ import json
 import os
 import subprocess
 import sys
+from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
 REPO_ROOT = Path(__file__).parent.parent
 ASSERTION_SCRIPT = REPO_ROOT / "scripts" / "assert_installed_artifact.py"
+
+
+def _assertion_module() -> ModuleType:
+    spec = spec_from_file_location("assert_installed_artifact", ASSERTION_SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_offline_proxy_environment_uses_named_endpoint(tmp_path: Path) -> None:
+    module = _assertion_module()
+
+    environment = module._environment(tmp_path)
+
+    assert environment["ALL_PROXY"] == module.OFFLINE_PROXY_URL
+    assert environment["HTTP_PROXY"] == module.OFFLINE_PROXY_URL
+    assert environment["HTTPS_PROXY"] == module.OFFLINE_PROXY_URL
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Part of #238.

Resolves installed docs-cache ownership from the invocation project or canonical cwd while preserving source and worktree behavior.

Verified: `uv run prek run --all-files`; `uv run pytest`.