### PR TITLE
fix(action): bind requested Python and verify outcomes

### DIFF
--- a/.github/workflows/action-integration.yml
+++ b/.github/workflows/action-integration.yml
@@ -9,135 +9,108 @@ permissions:
 
 jobs:
   action-contract:
-    name: Composite Action contract
+    name: action-contract (${{ matrix.case }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - case: clean
+            paths: packages/skilllint/tests/fixtures/claude_code/valid_skill.md
+            platform: claude-code
+            filter: ""
+            check_only: "false"
+            fix: "false"
+            expected_result: passed
+            expected_exit_code: "0"
+            expected_inspected_count: "1"
+            expected_finding: ""
+            allow_failure: false
+          - case: warning
+            paths: tests/fixtures/action/agents/warning-agent.md
+            platform: ""
+            filter: ""
+            check_only: "false"
+            fix: "false"
+            expected_result: passed
+            expected_exit_code: "0"
+            expected_inspected_count: "1"
+            expected_finding: AG003
+            allow_failure: false
+          - case: zero-files
+            paths: packages/skilllint/tests/fixtures/claude_code
+            platform: ""
+            filter: "*.does-not-exist"
+            check_only: "false"
+            fix: "false"
+            expected_result: passed
+            expected_exit_code: "0"
+            expected_inspected_count: "0"
+            expected_finding: ""
+            allow_failure: false
+          - case: validation-error
+            paths: packages/skilllint/tests/fixtures/claude_code/invalid-skill/SKILL.md
+            platform: claude-code
+            filter: ""
+            check_only: "false"
+            fix: "false"
+            expected_result: failed
+            expected_exit_code: "1"
+            expected_inspected_count: "1"
+            expected_finding: FM010
+            allow_failure: true
+          - case: usage-error
+            paths: packages/skilllint/tests/fixtures/claude_code/valid_skill.md
+            platform: ""
+            filter: ""
+            check_only: "true"
+            fix: "true"
+            expected_result: failed
+            expected_exit_code: "2"
+            expected_inspected_count: ""
+            expected_finding: ""
+            allow_failure: true
+          - case: continue-on-error
+            paths: packages/skilllint/tests/fixtures/claude_code/invalid-skill/SKILL.md
+            platform: claude-code
+            filter: ""
+            check_only: "false"
+            fix: "false"
+            expected_result: failed
+            expected_exit_code: "1"
+            expected_inspected_count: "1"
+            expected_finding: FM010
+            allow_failure: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Clean fixture
-        id: clean
+      - name: Run composite Action
+        id: action
+        continue-on-error: ${{ matrix.allow_failure }}
         uses: ./
         with:
-          paths: packages/skilllint/tests/fixtures/claude_code/valid_skill.md
-          platform: claude-code
+          paths: ${{ matrix.paths }}
+          platform: ${{ matrix.platform }}
+          filter: ${{ matrix.filter }}
+          check-only: ${{ matrix.check_only }}
+          fix: ${{ matrix.fix }}
           python-version: "3.11"
           version: "1.19.2"
 
-      - name: Assert clean fixture
+      - name: Assert composite Action outcome
         env:
-          ACTION_RESULT: ${{ steps.clean.outputs.result }}
-          ACTION_EXIT_CODE: ${{ steps.clean.outputs.exit-code }}
-          ACTION_INSPECTED_COUNT: ${{ steps.clean.outputs.inspected-count }}
-          ACTION_FINDINGS: ${{ steps.clean.outputs.findings }}
-          ACTION_TOOL_PYTHON: ${{ steps.clean.outputs.tool-python }}
-          ACTION_TOOL_VERSION: ${{ steps.clean.outputs.tool-version }}
-          EXPECTED_RESULT: passed
-          EXPECTED_EXIT_CODE: "0"
-          EXPECTED_INSPECTED_COUNT: "1"
-          EXPECTED_FINDING: ""
-          EXPECTED_PYTHON_VERSION: "3.11"
-          EXPECTED_PACKAGE_VERSION: "1.19.2"
-        run: python scripts/assert_action_contract.py
-
-      - name: Warning-only fixture
-        id: warning
-        uses: ./
-        with:
-          paths: tests/fixtures/action/agents/warning-agent.md
-          python-version: "3.11"
-          version: "1.19.2"
-
-      - name: Assert warning-only fixture
-        env:
-          ACTION_RESULT: ${{ steps.warning.outputs.result }}
-          ACTION_EXIT_CODE: ${{ steps.warning.outputs.exit-code }}
-          ACTION_INSPECTED_COUNT: ${{ steps.warning.outputs.inspected-count }}
-          ACTION_FINDINGS: ${{ steps.warning.outputs.findings }}
-          ACTION_TOOL_PYTHON: ${{ steps.warning.outputs.tool-python }}
-          ACTION_TOOL_VERSION: ${{ steps.warning.outputs.tool-version }}
-          EXPECTED_RESULT: passed
-          EXPECTED_EXIT_CODE: "0"
-          EXPECTED_INSPECTED_COUNT: "1"
-          EXPECTED_FINDING: AG003
-          EXPECTED_PYTHON_VERSION: "3.11"
-          EXPECTED_PACKAGE_VERSION: "1.19.2"
-        run: python scripts/assert_action_contract.py
-
-      - name: Zero-selected-file fixture
-        id: zero-selected
-        uses: ./
-        with:
-          paths: packages/skilllint/tests/fixtures/claude_code
-          filter: "*.does-not-exist"
-          python-version: "3.11"
-          version: "1.19.2"
-
-      - name: Assert zero-selected-file fixture
-        env:
-          ACTION_RESULT: ${{ steps.zero-selected.outputs.result }}
-          ACTION_EXIT_CODE: ${{ steps.zero-selected.outputs.exit-code }}
-          ACTION_INSPECTED_COUNT: ${{ steps.zero-selected.outputs.inspected-count }}
-          ACTION_FINDINGS: ${{ steps.zero-selected.outputs.findings }}
-          ACTION_TOOL_PYTHON: ${{ steps.zero-selected.outputs.tool-python }}
-          ACTION_TOOL_VERSION: ${{ steps.zero-selected.outputs.tool-version }}
-          EXPECTED_RESULT: passed
-          EXPECTED_EXIT_CODE: "0"
-          EXPECTED_INSPECTED_COUNT: "0"
-          EXPECTED_FINDING: ""
-          EXPECTED_PYTHON_VERSION: "3.11"
-          EXPECTED_PACKAGE_VERSION: "1.19.2"
-        run: python scripts/assert_action_contract.py
-
-      - name: Validation fixture
-        id: validation
-        continue-on-error: true
-        uses: ./
-        with:
-          paths: packages/skilllint/tests/fixtures/claude_code/invalid-skill/SKILL.md
-          platform: claude-code
-          python-version: "3.11"
-          version: "1.19.2"
-
-      - name: Assert validation fixture
-        env:
-          ACTION_RESULT: ${{ steps.validation.outputs.result }}
-          ACTION_EXIT_CODE: ${{ steps.validation.outputs.exit-code }}
-          ACTION_INSPECTED_COUNT: ${{ steps.validation.outputs.inspected-count }}
-          ACTION_FINDINGS: ${{ steps.validation.outputs.findings }}
-          ACTION_TOOL_PYTHON: ${{ steps.validation.outputs.tool-python }}
-          ACTION_TOOL_VERSION: ${{ steps.validation.outputs.tool-version }}
-          EXPECTED_RESULT: failed
-          EXPECTED_EXIT_CODE: "1"
-          EXPECTED_INSPECTED_COUNT: "1"
-          EXPECTED_FINDING: FM010
-          EXPECTED_PYTHON_VERSION: "3.11"
-          EXPECTED_PACKAGE_VERSION: "1.19.2"
-        run: python scripts/assert_action_contract.py
-
-      - name: Invalid usage fixture
-        id: usage
-        continue-on-error: true
-        uses: ./
-        with:
-          paths: packages/skilllint/tests/fixtures/claude_code/valid_skill.md
-          check-only: "true"
-          fix: "true"
-          python-version: "3.11"
-          version: "1.19.2"
-
-      - name: Assert invalid usage fixture
-        env:
-          ACTION_RESULT: ${{ steps.usage.outputs.result }}
-          ACTION_EXIT_CODE: ${{ steps.usage.outputs.exit-code }}
-          ACTION_INSPECTED_COUNT: ${{ steps.usage.outputs.inspected-count }}
-          ACTION_FINDINGS: ${{ steps.usage.outputs.findings }}
-          ACTION_TOOL_PYTHON: ${{ steps.usage.outputs.tool-python }}
-          ACTION_TOOL_VERSION: ${{ steps.usage.outputs.tool-version }}
-          EXPECTED_RESULT: failed
-          EXPECTED_EXIT_CODE: "2"
-          EXPECTED_INSPECTED_COUNT: ""
-          EXPECTED_FINDING: ""
+          CASE: ${{ matrix.case }}
+          ACTION_RESULT: ${{ steps.action.outputs.result }}
+          ACTION_EXIT_CODE: ${{ steps.action.outputs.exit-code }}
+          ACTION_INSPECTED_COUNT: ${{ steps.action.outputs.inspected-count }}
+          ACTION_FINDINGS: ${{ steps.action.outputs.findings }}
+          ACTION_TOOL_PYTHON: ${{ steps.action.outputs.tool-python }}
+          ACTION_TOOL_VERSION: ${{ steps.action.outputs.tool-version }}
+          EXPECTED_RESULT: ${{ matrix.expected_result }}
+          EXPECTED_EXIT_CODE: ${{ matrix.expected_exit_code }}
+          EXPECTED_INSPECTED_COUNT: ${{ matrix.expected_inspected_count }}
+          EXPECTED_FINDING: ${{ matrix.expected_finding }}
           EXPECTED_PYTHON_VERSION: "3.11"
           EXPECTED_PACKAGE_VERSION: "1.19.2"
         run: python scripts/assert_action_contract.py

--- a/.github/workflows/action-integration.yml
+++ b/.github/workflows/action-integration.yml
@@ -21,6 +21,7 @@ jobs:
             filter: ""
             check_only: "false"
             fix: "false"
+            tokens_only: "true"
             show_summary: "false"
             expected_result: passed
             expected_exit_code: "0"
@@ -97,6 +98,7 @@ jobs:
           filter: ${{ matrix.filter }}
           check-only: ${{ matrix.check_only }}
           fix: ${{ matrix.fix }}
+          tokens-only: ${{ matrix.tokens_only || 'false' }}
           show-summary: ${{ matrix.show_summary || 'true' }}
           python-version: "3.11"
           version: "1.19.2"

--- a/.github/workflows/action-integration.yml
+++ b/.github/workflows/action-integration.yml
@@ -21,21 +21,22 @@ jobs:
             filter: ""
             check_only: "false"
             fix: "false"
+            show_summary: "false"
             expected_result: passed
             expected_exit_code: "0"
             expected_inspected_count: "1"
             expected_finding: ""
             allow_failure: false
           - case: warning
-            paths: tests/fixtures/action/agents/warning-agent.md
+            paths: tests/fixtures/action/skills/fixable-skill
             platform: ""
             filter: ""
             check_only: "false"
-            fix: "false"
+            fix: "true"
             expected_result: passed
             expected_exit_code: "0"
             expected_inspected_count: "1"
-            expected_finding: AG003
+            expected_finding: FM004 FM007
             allow_failure: false
           - case: zero-files
             paths: packages/skilllint/tests/fixtures/claude_code
@@ -95,6 +96,7 @@ jobs:
           filter: ${{ matrix.filter }}
           check-only: ${{ matrix.check_only }}
           fix: ${{ matrix.fix }}
+          show-summary: ${{ matrix.show_summary || 'true' }}
           python-version: "3.11"
           version: "1.19.2"
 

--- a/.github/workflows/action-integration.yml
+++ b/.github/workflows/action-integration.yml
@@ -56,6 +56,7 @@ jobs:
             filter: ""
             check_only: "false"
             fix: "false"
+            no_color: "false"
             expected_result: failed
             expected_exit_code: "1"
             expected_inspected_count: "1"
@@ -98,6 +99,7 @@ jobs:
           filter: ${{ matrix.filter }}
           check-only: ${{ matrix.check_only }}
           fix: ${{ matrix.fix }}
+          no-color: ${{ matrix.no_color || 'true' }}
           tokens-only: ${{ matrix.tokens_only || 'false' }}
           show-summary: ${{ matrix.show_summary || 'true' }}
           python-version: "3.11"

--- a/.github/workflows/action-integration.yml
+++ b/.github/workflows/action-integration.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         include:
           - case: clean
-            paths: packages/skilllint/tests/fixtures/claude_code/valid_skill.md
+            paths: packages/skilllint/tests/fixtures/claude_code/valid_skill.md packages/skilllint/tests/fixtures/claude_code/invalid_skill.md
             platform: claude-code
             filter: ""
             check_only: "false"
@@ -25,7 +25,7 @@ jobs:
             show_summary: "false"
             expected_result: passed
             expected_exit_code: "0"
-            expected_inspected_count: "1"
+            expected_inspected_count: "2"
             expected_finding: ""
             allow_failure: false
           - case: warning
@@ -37,7 +37,7 @@ jobs:
             expected_result: passed
             expected_exit_code: "0"
             expected_inspected_count: "1"
-            expected_finding: FM004 FM007
+            expected_finding: FM004 FM007 SK005
             allow_failure: false
           - case: zero-files
             paths: packages/skilllint/tests/fixtures/claude_code

--- a/.github/workflows/action-integration.yml
+++ b/.github/workflows/action-integration.yml
@@ -1,0 +1,143 @@
+name: Action integration
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  action-contract:
+    name: Composite Action contract
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Clean fixture
+        id: clean
+        uses: ./
+        with:
+          paths: packages/skilllint/tests/fixtures/claude_code/valid_skill.md
+          platform: claude-code
+          python-version: "3.11"
+          version: "1.19.2"
+
+      - name: Assert clean fixture
+        env:
+          ACTION_RESULT: ${{ steps.clean.outputs.result }}
+          ACTION_EXIT_CODE: ${{ steps.clean.outputs.exit-code }}
+          ACTION_INSPECTED_COUNT: ${{ steps.clean.outputs.inspected-count }}
+          ACTION_FINDINGS: ${{ steps.clean.outputs.findings }}
+          ACTION_TOOL_PYTHON: ${{ steps.clean.outputs.tool-python }}
+          ACTION_TOOL_VERSION: ${{ steps.clean.outputs.tool-version }}
+          EXPECTED_RESULT: passed
+          EXPECTED_EXIT_CODE: "0"
+          EXPECTED_INSPECTED_COUNT: "1"
+          EXPECTED_FINDING: ""
+          EXPECTED_PYTHON_VERSION: "3.11"
+          EXPECTED_PACKAGE_VERSION: "1.19.2"
+        run: python scripts/assert_action_contract.py
+
+      - name: Warning-only fixture
+        id: warning
+        uses: ./
+        with:
+          paths: tests/fixtures/action/agents/warning-agent.md
+          python-version: "3.11"
+          version: "1.19.2"
+
+      - name: Assert warning-only fixture
+        env:
+          ACTION_RESULT: ${{ steps.warning.outputs.result }}
+          ACTION_EXIT_CODE: ${{ steps.warning.outputs.exit-code }}
+          ACTION_INSPECTED_COUNT: ${{ steps.warning.outputs.inspected-count }}
+          ACTION_FINDINGS: ${{ steps.warning.outputs.findings }}
+          ACTION_TOOL_PYTHON: ${{ steps.warning.outputs.tool-python }}
+          ACTION_TOOL_VERSION: ${{ steps.warning.outputs.tool-version }}
+          EXPECTED_RESULT: passed
+          EXPECTED_EXIT_CODE: "0"
+          EXPECTED_INSPECTED_COUNT: "1"
+          EXPECTED_FINDING: AG003
+          EXPECTED_PYTHON_VERSION: "3.11"
+          EXPECTED_PACKAGE_VERSION: "1.19.2"
+        run: python scripts/assert_action_contract.py
+
+      - name: Zero-selected-file fixture
+        id: zero-selected
+        uses: ./
+        with:
+          paths: packages/skilllint/tests/fixtures/claude_code
+          filter: "*.does-not-exist"
+          python-version: "3.11"
+          version: "1.19.2"
+
+      - name: Assert zero-selected-file fixture
+        env:
+          ACTION_RESULT: ${{ steps.zero-selected.outputs.result }}
+          ACTION_EXIT_CODE: ${{ steps.zero-selected.outputs.exit-code }}
+          ACTION_INSPECTED_COUNT: ${{ steps.zero-selected.outputs.inspected-count }}
+          ACTION_FINDINGS: ${{ steps.zero-selected.outputs.findings }}
+          ACTION_TOOL_PYTHON: ${{ steps.zero-selected.outputs.tool-python }}
+          ACTION_TOOL_VERSION: ${{ steps.zero-selected.outputs.tool-version }}
+          EXPECTED_RESULT: passed
+          EXPECTED_EXIT_CODE: "0"
+          EXPECTED_INSPECTED_COUNT: "0"
+          EXPECTED_FINDING: ""
+          EXPECTED_PYTHON_VERSION: "3.11"
+          EXPECTED_PACKAGE_VERSION: "1.19.2"
+        run: python scripts/assert_action_contract.py
+
+      - name: Validation fixture
+        id: validation
+        continue-on-error: true
+        uses: ./
+        with:
+          paths: packages/skilllint/tests/fixtures/claude_code/invalid-skill/SKILL.md
+          platform: claude-code
+          python-version: "3.11"
+          version: "1.19.2"
+
+      - name: Assert validation fixture
+        env:
+          ACTION_RESULT: ${{ steps.validation.outputs.result }}
+          ACTION_EXIT_CODE: ${{ steps.validation.outputs.exit-code }}
+          ACTION_INSPECTED_COUNT: ${{ steps.validation.outputs.inspected-count }}
+          ACTION_FINDINGS: ${{ steps.validation.outputs.findings }}
+          ACTION_TOOL_PYTHON: ${{ steps.validation.outputs.tool-python }}
+          ACTION_TOOL_VERSION: ${{ steps.validation.outputs.tool-version }}
+          EXPECTED_RESULT: failed
+          EXPECTED_EXIT_CODE: "1"
+          EXPECTED_INSPECTED_COUNT: "1"
+          EXPECTED_FINDING: FM010
+          EXPECTED_PYTHON_VERSION: "3.11"
+          EXPECTED_PACKAGE_VERSION: "1.19.2"
+        run: python scripts/assert_action_contract.py
+
+      - name: Invalid usage fixture
+        id: usage
+        continue-on-error: true
+        uses: ./
+        with:
+          paths: packages/skilllint/tests/fixtures/claude_code/valid_skill.md
+          check-only: "true"
+          fix: "true"
+          python-version: "3.11"
+          version: "1.19.2"
+
+      - name: Assert invalid usage fixture
+        env:
+          ACTION_RESULT: ${{ steps.usage.outputs.result }}
+          ACTION_EXIT_CODE: ${{ steps.usage.outputs.exit-code }}
+          ACTION_INSPECTED_COUNT: ${{ steps.usage.outputs.inspected-count }}
+          ACTION_FINDINGS: ${{ steps.usage.outputs.findings }}
+          ACTION_TOOL_PYTHON: ${{ steps.usage.outputs.tool-python }}
+          ACTION_TOOL_VERSION: ${{ steps.usage.outputs.tool-version }}
+          EXPECTED_RESULT: failed
+          EXPECTED_EXIT_CODE: "2"
+          EXPECTED_INSPECTED_COUNT: ""
+          EXPECTED_FINDING: ""
+          EXPECTED_PYTHON_VERSION: "3.11"
+          EXPECTED_PACKAGE_VERSION: "1.19.2"
+        run: python scripts/assert_action_contract.py

--- a/.github/workflows/action-integration.yml
+++ b/.github/workflows/action-integration.yml
@@ -59,7 +59,7 @@ jobs:
             expected_result: failed
             expected_exit_code: "1"
             expected_inspected_count: "1"
-            expected_finding: FM010
+            expected_finding: FM010 SK005
             allow_failure: true
           - case: usage-error
             paths: packages/skilllint/tests/fixtures/claude_code/valid_skill.md
@@ -82,7 +82,7 @@ jobs:
             expected_result: failed
             expected_exit_code: "1"
             expected_inspected_count: "1"
-            expected_finding: FM010
+            expected_finding: FM010 SK005
             allow_failure: true
     steps:
       - name: Checkout code

--- a/.github/workflows/action-integration.yml
+++ b/.github/workflows/action-integration.yml
@@ -21,12 +21,14 @@ jobs:
             filter: ""
             check_only: "false"
             fix: "false"
-            tokens_only: "true"
+            tokens_only: "false"
+            verbose: "true"
+            no_color: "false"
             show_summary: "false"
             expected_result: passed
             expected_exit_code: "0"
             expected_inspected_count: "2"
-            expected_finding: ""
+            expected_finding: TC001
             allow_failure: false
           - case: warning
             paths: tests/fixtures/action/skills/fixable-skill
@@ -100,6 +102,7 @@ jobs:
           filter: ${{ matrix.filter }}
           check-only: ${{ matrix.check_only }}
           fix: ${{ matrix.fix }}
+          verbose: ${{ matrix.verbose || 'false' }}
           no-color: ${{ matrix.no_color || 'true' }}
           tokens-only: ${{ matrix.tokens_only || 'false' }}
           show-summary: ${{ matrix.show_summary || 'true' }}

--- a/.github/workflows/action-integration.yml
+++ b/.github/workflows/action-integration.yml
@@ -34,6 +34,7 @@ jobs:
             filter: ""
             check_only: "false"
             fix: "true"
+            no_color: "false"
             expected_result: passed
             expected_exit_code: "0"
             expected_inspected_count: "1"

--- a/.github/workflows/action-integration.yml
+++ b/.github/workflows/action-integration.yml
@@ -66,6 +66,7 @@ jobs:
             filter: ""
             check_only: "true"
             fix: "true"
+            show_summary: "false"
             expected_result: failed
             expected_exit_code: "2"
             expected_inspected_count: ""

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Use `bitflight-devops/skilllint` as a GitHub Action to validate skills, plugins,
   with:
     paths: "plugins/"
     platform: "claude-code"
+    version: "1.19.2"
     show-summary: "true"
 ```
 
@@ -138,6 +139,7 @@ jobs:
         with:
           paths: "plugins/ .claude/"
           platform: "claude-code"
+          version: "1.19.2"
           show-summary: "true"
           verbose: "false"
 ```
@@ -150,6 +152,7 @@ jobs:
   uses: bitflight-devops/skilllint@v1.7.0
   with:
     paths: "plugins/"
+    version: "1.19.2"
   continue-on-error: true
 
 - name: Print result

--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ Use `bitflight-devops/skilllint` as a GitHub Action to validate skills, plugins,
 |---|---|
 | `result` | `passed` when exit code is 0; `failed` for any non-zero exit code |
 | `exit-code` | Raw exit code: `0` = pass · `1` = errors · `2` = usage error |
+| `inspected-count` | Number of files inspected by skilllint |
+| `findings` | Distinct finding codes emitted by skilllint |
+| `tool-python` | Python runtime used by the installed skilllint tool |
+| `tool-version` | Version reported by the installed skilllint tool |
 
 ### Example: fail the CI on validation errors
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Use `bitflight-devops/skilllint` as a GitHub Action to validate skills, plugins,
 | Input | Description | Default |
 |---|---|---|
 | `paths` | Space-separated paths to validate | `.` |
-| `platform` | Platform adapter: `claude-code`, `cursor`, `codex` | _(all)_ |
+| `platform` | Platform adapter: `claude-code`, `cursor`, `codex`; omit to validate each selected file with every matching adapter | _(matching adapters)_ |
 | `fix` | Auto-fix issues where possible | `false` |
 | `check-only` | Validate only, do not auto-fix | `false` |
 | `verbose` | Show detailed output including info messages | `false` |

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     description: >
       Platform adapter to use for validation.
       Supported values: claude-code, cursor, codex.
-      Leave empty to validate each file with every matching platform adapter.
+      Leave empty to validate each selected file with every matching platform adapter.
     required: false
     default: ""
 

--- a/action.yml
+++ b/action.yml
@@ -202,7 +202,7 @@ runs:
         cat "${OUTPUT_FILE}"
 
         INSPECTED_COUNT="$(sed -n 's/^Total files: \([0-9][0-9]*\)$/\1/p' "${OUTPUT_FILE}" | tail -n 1)"
-        if [ -z "${INSPECTED_COUNT}" ] && { [ "${INPUT_SHOW_SUMMARY}" != "true" ] || [ "${INPUT_TOKENS_ONLY}" = "true" ] || [ "${INPUT_NO_COLOR}" != "true" ]; }; then
+        if [ "${EXIT_CODE}" -ne 2 ] && [ -z "${INSPECTED_COUNT}" ] && { [ "${INPUT_SHOW_SUMMARY}" != "true" ] || [ "${INPUT_TOKENS_ONLY}" = "true" ] || [ "${INPUT_NO_COLOR}" != "true" ]; }; then
           COUNT_ARGS=()
           for ARG in "${ARGS[@]}"; do
             if [ "${ARG}" != "--check" ] && [ "${ARG}" != "--fix" ] && [ "${ARG}" != "--tokens-only" ]; then

--- a/action.yml
+++ b/action.yml
@@ -201,7 +201,7 @@ runs:
 
         cat "${OUTPUT_FILE}"
 
-        INSPECTED_COUNT="$(sed -n 's/^Total files: \([0-9][0-9]*\)$/\1/p' "${OUTPUT_FILE}" | tail -n 1)"
+        INSPECTED_COUNT="$(tr -d '\r' < "${OUTPUT_FILE}" | sed -n 's/^Total files: \([0-9][0-9]*\)$/\1/p' | tail -n 1)"
         if [ "${INPUT_TOKENS_ONLY}" = "true" ] && [ "${EXIT_CODE}" -ne 2 ]; then
           INSPECTED_COUNT="$(grep -cE '^[0-9]+($|[[:blank:]])' "${OUTPUT_FILE}")"
         elif [ "${EXIT_CODE}" -ne 2 ] && [ -z "${INSPECTED_COUNT}" ] && { [ "${INPUT_SHOW_SUMMARY}" != "true" ] || [ "${INPUT_NO_COLOR}" != "true" ]; }; then
@@ -212,7 +212,7 @@ runs:
             fi
           done
           COUNT_OUTPUT="$(skilllint check --no-color "${COUNT_ARGS[@]}" --show-summary "${PATH_ARGS[@]}" 2>&1 || true)"
-          INSPECTED_COUNT="$(sed -n 's/^Total files: \([0-9][0-9]*\)$/\1/p' <<< "${COUNT_OUTPUT}" | tail -n 1)"
+          INSPECTED_COUNT="$(tr -d '\r' <<< "${COUNT_OUTPUT}" | sed -n 's/^Total files: \([0-9][0-9]*\)$/\1/p' | tail -n 1)"
         fi
 
         echo "exit-code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -202,7 +202,9 @@ runs:
         cat "${OUTPUT_FILE}"
 
         INSPECTED_COUNT="$(sed -n 's/^Total files: \([0-9][0-9]*\)$/\1/p' "${OUTPUT_FILE}" | tail -n 1)"
-        if [ "${EXIT_CODE}" -ne 2 ] && [ -z "${INSPECTED_COUNT}" ] && { [ "${INPUT_SHOW_SUMMARY}" != "true" ] || [ "${INPUT_TOKENS_ONLY}" = "true" ] || [ "${INPUT_NO_COLOR}" != "true" ]; }; then
+        if [ "${INPUT_TOKENS_ONLY}" = "true" ] && [ "${EXIT_CODE}" -ne 2 ]; then
+          INSPECTED_COUNT="$(grep -cE '^[0-9]+$' "${OUTPUT_FILE}")"
+        elif [ "${EXIT_CODE}" -ne 2 ] && [ -z "${INSPECTED_COUNT}" ] && { [ "${INPUT_SHOW_SUMMARY}" != "true" ] || [ "${INPUT_NO_COLOR}" != "true" ]; }; then
           COUNT_ARGS=()
           for ARG in "${ARGS[@]}"; do
             if [ "${ARG}" != "--check" ] && [ "${ARG}" != "--fix" ] && [ "${ARG}" != "--tokens-only" ]; then

--- a/action.yml
+++ b/action.yml
@@ -220,7 +220,7 @@ runs:
         echo "inspected-count=${INSPECTED_COUNT}" >> "$GITHUB_OUTPUT"
         FINDINGS_OUTPUT="$(sed -E $'s/\033\[[0-?]*[ -\/]*[@-~]//g' "${OUTPUT_FILE}")"
         echo "findings=$(grep -oE '(^[[:space:]]*(✗ (ERROR|WARN|INFO)|⚠ (WARN|INFO)|❌|⚠|🔧|ℹ|i INFO) |^FIXED )\[[A-Z]{2}[0-9]{3}(, [A-Z]{2}[0-9]{3})*\]' <<< "${FINDINGS_OUTPUT}" | sed -E 's/^.*\[//; s/\]$//' | tr -d ',' | tr ' ' '\n' | sort -u | xargs)" >> "$GITHUB_OUTPUT"
-        TOOL_PYTHON="$(uv tool list --show-python | sed -n 's/^skilllint .*\[CPython \([^]]*\)\]$/Python \1/p')"
+        TOOL_PYTHON="$(uv tool list --show-python | sed -n 's/^skilllint .*\[\([^]]*\)\]$/\1/p' | sed 's/^CPython /Python /')"
         echo "tool-python=${TOOL_PYTHON}" >> "$GITHUB_OUTPUT"
         echo "tool-version=$(skilllint --version)" >> "$GITHUB_OUTPUT"
         if [ "${EXIT_CODE}" -eq 0 ]; then

--- a/action.yml
+++ b/action.yml
@@ -96,6 +96,22 @@ outputs:
       0 = all checks passed, 1 = validation errors found, 2 = usage/configuration error.
     value: ${{ steps.run-skilllint.outputs.exit-code }}
 
+  inspected-count:
+    description: "Number of files inspected by skilllint."
+    value: ${{ steps.run-skilllint.outputs.inspected-count }}
+
+  findings:
+    description: "Distinct finding codes emitted by skilllint."
+    value: ${{ steps.run-skilllint.outputs.findings }}
+
+  tool-python:
+    description: "Python runtime used by the installed skilllint tool."
+    value: ${{ steps.run-skilllint.outputs.tool-python }}
+
+  tool-version:
+    description: "Version reported by the installed skilllint tool."
+    value: ${{ steps.run-skilllint.outputs.tool-version }}
+
 runs:
   using: "composite"
   steps:
@@ -114,11 +130,12 @@ runs:
       shell: bash
       env:
         INPUT_VERSION: ${{ inputs.version }}
+        INPUT_PYTHON_VERSION: ${{ inputs.python-version }}
       run: |
         if [ "${INPUT_VERSION}" = "latest" ]; then
-          uv tool install skilllint
+          uv tool install --python "${INPUT_PYTHON_VERSION}" skilllint
         else
-          uv tool install "skilllint==${INPUT_VERSION}"
+          uv tool install --python "${INPUT_PYTHON_VERSION}" "skilllint==${INPUT_VERSION}"
         fi
 
     - name: Run skilllint check
@@ -178,10 +195,19 @@ runs:
         # Paths (space-separated, split into individual arguments)
         read -ra PATH_ARGS <<< "${INPUT_PATHS}"
 
-        skilllint check "${ARGS[@]}" "${PATH_ARGS[@]}"
+        OUTPUT_FILE="$(mktemp)"
+        skilllint check "${ARGS[@]}" "${PATH_ARGS[@]}" >"${OUTPUT_FILE}" 2>&1
         EXIT_CODE=$?
 
+        cat "${OUTPUT_FILE}"
+
         echo "exit-code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
+        echo "inspected-count=$(sed -n 's/^Total files: \([0-9][0-9]*\)$/\1/p' "${OUTPUT_FILE}" | tail -n 1)" >> "$GITHUB_OUTPUT"
+        echo "findings=$(grep -oE '\[[A-Z]{2}[0-9]{3}\]' "${OUTPUT_FILE}" | tr -d '[]' | sort -u | xargs)" >> "$GITHUB_OUTPUT"
+        TOOL_PATH="$(command -v skilllint)"
+        TOOL_PYTHON="$(sed -n '1s/^#!//p' "${TOOL_PATH}")"
+        echo "tool-python=$("${TOOL_PYTHON}" --version)" >> "$GITHUB_OUTPUT"
+        echo "tool-version=$(skilllint --version)" >> "$GITHUB_OUTPUT"
         if [ "${EXIT_CODE}" -eq 0 ]; then
           echo "result=passed" >> "$GITHUB_OUTPUT"
         else

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     default: ""
 
   fix:
-    description: "Auto-fix issues where possible. Mutually exclusive with check-only."
+    description: "Auto-fix issues where possible. Mutually exclusive with check-only and platform."
     required: false
     default: "false"
 

--- a/action.yml
+++ b/action.yml
@@ -218,7 +218,7 @@ runs:
         echo "exit-code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
         echo "inspected-count=${INSPECTED_COUNT}" >> "$GITHUB_OUTPUT"
         FINDINGS_OUTPUT="$(sed -E $'s/\033\[[0-?]*[ -\/]*[@-~]//g' "${OUTPUT_FILE}")"
-        echo "findings=$(grep -oE '(^[[:space:]]*(✗ (ERROR|WARN|INFO)|⚠ (WARN|INFO)|❌|⚠|i INFO) |^FIXED )\[[A-Z]{2}[0-9]{3}(, [A-Z]{2}[0-9]{3})*\]' <<< "${FINDINGS_OUTPUT}" | sed -E 's/^.*\[//; s/\]$//' | tr -d ',' | tr ' ' '\n' | sort -u | xargs)" >> "$GITHUB_OUTPUT"
+        echo "findings=$(grep -oE '(^[[:space:]]*(✗ (ERROR|WARN|INFO)|⚠ (WARN|INFO)|❌|⚠|🔧|i INFO) |^FIXED )\[[A-Z]{2}[0-9]{3}(, [A-Z]{2}[0-9]{3})*\]' <<< "${FINDINGS_OUTPUT}" | sed -E 's/^.*\[//; s/\]$//' | tr -d ',' | tr ' ' '\n' | sort -u | xargs)" >> "$GITHUB_OUTPUT"
         TOOL_PATH="$(command -v skilllint)"
         TOOL_PYTHON="$(sed -n '1s/^#!//p' "${TOOL_PATH}")"
         echo "tool-python=$("${TOOL_PYTHON}" --version)" >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -203,7 +203,7 @@ runs:
 
         INSPECTED_COUNT="$(sed -n 's/^Total files: \([0-9][0-9]*\)$/\1/p' "${OUTPUT_FILE}" | tail -n 1)"
         if [ "${INPUT_TOKENS_ONLY}" = "true" ] && [ "${EXIT_CODE}" -ne 2 ]; then
-          INSPECTED_COUNT="$(grep -cE '^[0-9]+$' "${OUTPUT_FILE}")"
+          INSPECTED_COUNT="$(grep -cE '^[0-9]+($|\t)' "${OUTPUT_FILE}")"
         elif [ "${EXIT_CODE}" -ne 2 ] && [ -z "${INSPECTED_COUNT}" ] && { [ "${INPUT_SHOW_SUMMARY}" != "true" ] || [ "${INPUT_NO_COLOR}" != "true" ]; }; then
           COUNT_ARGS=()
           for ARG in "${ARGS[@]}"; do
@@ -217,7 +217,7 @@ runs:
 
         echo "exit-code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
         echo "inspected-count=${INSPECTED_COUNT}" >> "$GITHUB_OUTPUT"
-        echo "findings=$(grep -oE '\[[A-Z]{2}[0-9]{3}(, [A-Z]{2}[0-9]{3})*\]' "${OUTPUT_FILE}" | tr -d '[],' | tr ' ' '\n' | sort -u | xargs)" >> "$GITHUB_OUTPUT"
+        echo "findings=$(grep -oE '(ERROR|WARN|FIXED) \[[A-Z]{2}[0-9]{3}(, [A-Z]{2}[0-9]{3})*\]' "${OUTPUT_FILE}" | sed -E 's/^[A-Z]+ \[//; s/\]$//' | tr -d ',' | tr ' ' '\n' | sort -u | xargs)" >> "$GITHUB_OUTPUT"
         TOOL_PATH="$(command -v skilllint)"
         TOOL_PYTHON="$(sed -n '1s/^#!//p' "${TOOL_PATH}")"
         echo "tool-python=$("${TOOL_PYTHON}" --version)" >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -201,9 +201,21 @@ runs:
 
         cat "${OUTPUT_FILE}"
 
+        INSPECTED_COUNT="$(sed -n 's/^Total files: \([0-9][0-9]*\)$/\1/p' "${OUTPUT_FILE}" | tail -n 1)"
+        if [ -z "${INSPECTED_COUNT}" ] && { [ "${INPUT_SHOW_SUMMARY}" != "true" ] || [ "${INPUT_TOKENS_ONLY}" = "true" ]; }; then
+          COUNT_ARGS=()
+          for ARG in "${ARGS[@]}"; do
+            if [ "${ARG}" != "--check" ] && [ "${ARG}" != "--fix" ] && [ "${ARG}" != "--tokens-only" ]; then
+              COUNT_ARGS+=("${ARG}")
+            fi
+          done
+          COUNT_OUTPUT="$(skilllint check "${COUNT_ARGS[@]}" --show-summary "${PATH_ARGS[@]}" 2>&1 || true)"
+          INSPECTED_COUNT="$(sed -n 's/^Total files: \([0-9][0-9]*\)$/\1/p' <<< "${COUNT_OUTPUT}" | tail -n 1)"
+        fi
+
         echo "exit-code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
-        echo "inspected-count=$(sed -n 's/^Total files: \([0-9][0-9]*\)$/\1/p' "${OUTPUT_FILE}" | tail -n 1)" >> "$GITHUB_OUTPUT"
-        echo "findings=$(grep -oE '\[[A-Z]{2}[0-9]{3}\]' "${OUTPUT_FILE}" | tr -d '[]' | sort -u | xargs)" >> "$GITHUB_OUTPUT"
+        echo "inspected-count=${INSPECTED_COUNT}" >> "$GITHUB_OUTPUT"
+        echo "findings=$(grep -oE '[A-Z]{2}[0-9]{3}' "${OUTPUT_FILE}" | sort -u | xargs)" >> "$GITHUB_OUTPUT"
         TOOL_PATH="$(command -v skilllint)"
         TOOL_PYTHON="$(sed -n '1s/^#!//p' "${TOOL_PATH}")"
         echo "tool-python=$("${TOOL_PYTHON}" --version)" >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -219,7 +219,7 @@ runs:
         echo "inspected-count=${INSPECTED_COUNT}" >> "$GITHUB_OUTPUT"
         FINDINGS_OUTPUT="$(sed -E $'s/\033\[[0-?]*[ -\/]*[@-~]//g' "${OUTPUT_FILE}")"
         echo "findings=$(grep -oE '(^[[:space:]]*(✗ (ERROR|WARN|INFO)|⚠ (WARN|INFO)|❌|⚠|🔧|ℹ|i INFO) |^FIXED )\[[A-Z]{2}[0-9]{3}(, [A-Z]{2}[0-9]{3})*\]' <<< "${FINDINGS_OUTPUT}" | sed -E 's/^.*\[//; s/\]$//' | tr -d ',' | tr ' ' '\n' | sort -u | xargs)" >> "$GITHUB_OUTPUT"
-        TOOL_PYTHON="$(uv tool list --show-python | sed -n 's/^skilllint .* - \(Python .*\)$/\1/p')"
+        TOOL_PYTHON="$(uv tool list --show-python | sed -n 's/^skilllint .*\[CPython \([^]]*\)\]$/Python \1/p')"
         echo "tool-python=${TOOL_PYTHON}" >> "$GITHUB_OUTPUT"
         echo "tool-version=$(skilllint --version)" >> "$GITHUB_OUTPUT"
         if [ "${EXIT_CODE}" -eq 0 ]; then

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     description: >
       Platform adapter to use for validation.
       Supported values: claude-code, cursor, codex.
-      Leave empty to validate each selected file with every matching platform adapter.
+      When omitted, validates each selected file with every matching platform adapter.
     required: false
     default: ""
 
@@ -219,9 +219,8 @@ runs:
         echo "inspected-count=${INSPECTED_COUNT}" >> "$GITHUB_OUTPUT"
         FINDINGS_OUTPUT="$(sed -E $'s/\033\[[0-?]*[ -\/]*[@-~]//g' "${OUTPUT_FILE}")"
         echo "findings=$(grep -oE '(^[[:space:]]*(✗ (ERROR|WARN|INFO)|⚠ (WARN|INFO)|❌|⚠|🔧|ℹ|i INFO) |^FIXED )\[[A-Z]{2}[0-9]{3}(, [A-Z]{2}[0-9]{3})*\]' <<< "${FINDINGS_OUTPUT}" | sed -E 's/^.*\[//; s/\]$//' | tr -d ',' | tr ' ' '\n' | sort -u | xargs)" >> "$GITHUB_OUTPUT"
-        TOOL_PATH="$(command -v skilllint)"
-        TOOL_PYTHON="$(sed -n '1s/^#!//p' "${TOOL_PATH}")"
-        echo "tool-python=$("${TOOL_PYTHON}" --version)" >> "$GITHUB_OUTPUT"
+        TOOL_PYTHON="$(uv tool list --show-python | sed -n 's/^skilllint .* - \(Python .*\)$/\1/p')"
+        echo "tool-python=${TOOL_PYTHON}" >> "$GITHUB_OUTPUT"
         echo "tool-version=$(skilllint --version)" >> "$GITHUB_OUTPUT"
         if [ "${EXIT_CODE}" -eq 0 ]; then
           echo "result=passed" >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -218,7 +218,7 @@ runs:
         echo "exit-code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
         echo "inspected-count=${INSPECTED_COUNT}" >> "$GITHUB_OUTPUT"
         FINDINGS_OUTPUT="$(sed -E $'s/\033\[[0-?]*[ -\/]*[@-~]//g' "${OUTPUT_FILE}")"
-        echo "findings=$(grep -oE '(^[[:space:]]*(✗ (ERROR|WARN|INFO)|⚠ (WARN|INFO)|❌|⚠|🔧|i INFO) |^FIXED )\[[A-Z]{2}[0-9]{3}(, [A-Z]{2}[0-9]{3})*\]' <<< "${FINDINGS_OUTPUT}" | sed -E 's/^.*\[//; s/\]$//' | tr -d ',' | tr ' ' '\n' | sort -u | xargs)" >> "$GITHUB_OUTPUT"
+        echo "findings=$(grep -oE '(^[[:space:]]*(✗ (ERROR|WARN|INFO)|⚠ (WARN|INFO)|❌|⚠|🔧|ℹ|i INFO) |^FIXED )\[[A-Z]{2}[0-9]{3}(, [A-Z]{2}[0-9]{3})*\]' <<< "${FINDINGS_OUTPUT}" | sed -E 's/^.*\[//; s/\]$//' | tr -d ',' | tr ' ' '\n' | sort -u | xargs)" >> "$GITHUB_OUTPUT"
         TOOL_PATH="$(command -v skilllint)"
         TOOL_PYTHON="$(sed -n '1s/^#!//p' "${TOOL_PATH}")"
         echo "tool-python=$("${TOOL_PYTHON}" --version)" >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -217,7 +217,8 @@ runs:
 
         echo "exit-code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
         echo "inspected-count=${INSPECTED_COUNT}" >> "$GITHUB_OUTPUT"
-        echo "findings=$(grep -oE '(^[[:space:]]*(✗ (ERROR|WARN|INFO)|⚠ (WARN|INFO)|❌|⚠|i INFO) |^FIXED )\[[A-Z]{2}[0-9]{3}(, [A-Z]{2}[0-9]{3})*\]' "${OUTPUT_FILE}" | sed -E 's/^.*\[//; s/\]$//' | tr -d ',' | tr ' ' '\n' | sort -u | xargs)" >> "$GITHUB_OUTPUT"
+        FINDINGS_OUTPUT="$(sed -E $'s/\033\[[0-?]*[ -\/]*[@-~]//g' "${OUTPUT_FILE}")"
+        echo "findings=$(grep -oE '(^[[:space:]]*(✗ (ERROR|WARN|INFO)|⚠ (WARN|INFO)|❌|⚠|i INFO) |^FIXED )\[[A-Z]{2}[0-9]{3}(, [A-Z]{2}[0-9]{3})*\]' <<< "${FINDINGS_OUTPUT}" | sed -E 's/^.*\[//; s/\]$//' | tr -d ',' | tr ' ' '\n' | sort -u | xargs)" >> "$GITHUB_OUTPUT"
         TOOL_PATH="$(command -v skilllint)"
         TOOL_PYTHON="$(sed -n '1s/^#!//p' "${TOOL_PATH}")"
         echo "tool-python=$("${TOOL_PYTHON}" --version)" >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -202,14 +202,14 @@ runs:
         cat "${OUTPUT_FILE}"
 
         INSPECTED_COUNT="$(sed -n 's/^Total files: \([0-9][0-9]*\)$/\1/p' "${OUTPUT_FILE}" | tail -n 1)"
-        if [ -z "${INSPECTED_COUNT}" ] && { [ "${INPUT_SHOW_SUMMARY}" != "true" ] || [ "${INPUT_TOKENS_ONLY}" = "true" ]; }; then
+        if [ -z "${INSPECTED_COUNT}" ] && { [ "${INPUT_SHOW_SUMMARY}" != "true" ] || [ "${INPUT_TOKENS_ONLY}" = "true" ] || [ "${INPUT_NO_COLOR}" != "true" ]; }; then
           COUNT_ARGS=()
           for ARG in "${ARGS[@]}"; do
             if [ "${ARG}" != "--check" ] && [ "${ARG}" != "--fix" ] && [ "${ARG}" != "--tokens-only" ]; then
               COUNT_ARGS+=("${ARG}")
             fi
           done
-          COUNT_OUTPUT="$(skilllint check "${COUNT_ARGS[@]}" --show-summary "${PATH_ARGS[@]}" 2>&1 || true)"
+          COUNT_OUTPUT="$(skilllint check --no-color "${COUNT_ARGS[@]}" --show-summary "${PATH_ARGS[@]}" 2>&1 || true)"
           INSPECTED_COUNT="$(sed -n 's/^Total files: \([0-9][0-9]*\)$/\1/p' <<< "${COUNT_OUTPUT}" | tail -n 1)"
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -201,9 +201,10 @@ runs:
 
         cat "${OUTPUT_FILE}"
 
-        INSPECTED_COUNT="$(tr -d '\r' < "${OUTPUT_FILE}" | sed -n 's/^Total files: \([0-9][0-9]*\)$/\1/p' | tail -n 1)"
+        NORMALIZED_OUTPUT="$(tr -d '\r' < "${OUTPUT_FILE}")"
+        INSPECTED_COUNT="$(sed -n 's/^Total files: \([0-9][0-9]*\)$/\1/p' <<< "${NORMALIZED_OUTPUT}" | tail -n 1)"
         if [ "${INPUT_TOKENS_ONLY}" = "true" ] && [ "${EXIT_CODE}" -ne 2 ]; then
-          INSPECTED_COUNT="$(grep -cE '^[0-9]+($|[[:blank:]])' "${OUTPUT_FILE}")"
+          INSPECTED_COUNT="$(grep -cE '^[0-9]+($|[[:blank:]])' <<< "${NORMALIZED_OUTPUT}")"
         elif [ "${EXIT_CODE}" -ne 2 ] && [ -z "${INSPECTED_COUNT}" ] && { [ "${INPUT_SHOW_SUMMARY}" != "true" ] || [ "${INPUT_NO_COLOR}" != "true" ]; }; then
           COUNT_ARGS=()
           for ARG in "${ARGS[@]}"; do

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     description: >
       Platform adapter to use for validation.
       Supported values: claude-code, cursor, codex.
-      Leave empty to use the default validation route.
+      Leave empty to validate each file with every matching platform adapter.
     required: false
     default: ""
 

--- a/action.yml
+++ b/action.yml
@@ -215,7 +215,7 @@ runs:
 
         echo "exit-code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
         echo "inspected-count=${INSPECTED_COUNT}" >> "$GITHUB_OUTPUT"
-        echo "findings=$(grep -oE '[A-Z]{2}[0-9]{3}' "${OUTPUT_FILE}" | sort -u | xargs)" >> "$GITHUB_OUTPUT"
+        echo "findings=$(grep -oE '\[[A-Z]{2}[0-9]{3}(, [A-Z]{2}[0-9]{3})*\]' "${OUTPUT_FILE}" | tr -d '[],' | tr ' ' '\n' | sort -u | xargs)" >> "$GITHUB_OUTPUT"
         TOOL_PATH="$(command -v skilllint)"
         TOOL_PYTHON="$(sed -n '1s/^#!//p' "${TOOL_PATH}")"
         echo "tool-python=$("${TOOL_PYTHON}" --version)" >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     description: >
       Platform adapter to use for validation.
       Supported values: claude-code, cursor, codex.
-      Leave empty to validate against all platforms.
+      Leave empty to use the default validation route.
     required: false
     default: ""
 

--- a/action.yml
+++ b/action.yml
@@ -203,7 +203,7 @@ runs:
 
         INSPECTED_COUNT="$(sed -n 's/^Total files: \([0-9][0-9]*\)$/\1/p' "${OUTPUT_FILE}" | tail -n 1)"
         if [ "${INPUT_TOKENS_ONLY}" = "true" ] && [ "${EXIT_CODE}" -ne 2 ]; then
-          INSPECTED_COUNT="$(grep -cE '^[0-9]+($|\t)' "${OUTPUT_FILE}")"
+          INSPECTED_COUNT="$(grep -cE '^[0-9]+($|[[:blank:]])' "${OUTPUT_FILE}")"
         elif [ "${EXIT_CODE}" -ne 2 ] && [ -z "${INSPECTED_COUNT}" ] && { [ "${INPUT_SHOW_SUMMARY}" != "true" ] || [ "${INPUT_NO_COLOR}" != "true" ]; }; then
           COUNT_ARGS=()
           for ARG in "${ARGS[@]}"; do
@@ -217,7 +217,7 @@ runs:
 
         echo "exit-code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
         echo "inspected-count=${INSPECTED_COUNT}" >> "$GITHUB_OUTPUT"
-        echo "findings=$(grep -oE '(ERROR|WARN|FIXED) \[[A-Z]{2}[0-9]{3}(, [A-Z]{2}[0-9]{3})*\]' "${OUTPUT_FILE}" | sed -E 's/^[A-Z]+ \[//; s/\]$//' | tr -d ',' | tr ' ' '\n' | sort -u | xargs)" >> "$GITHUB_OUTPUT"
+        echo "findings=$(grep -oE '(^[[:space:]]*(✗ (ERROR|WARN|INFO)|⚠ (WARN|INFO)|❌|⚠|i INFO) |^FIXED )\[[A-Z]{2}[0-9]{3}(, [A-Z]{2}[0-9]{3})*\]' "${OUTPUT_FILE}" | sed -E 's/^.*\[//; s/\]$//' | tr -d ',' | tr ' ' '\n' | sort -u | xargs)" >> "$GITHUB_OUTPUT"
         TOOL_PATH="$(command -v skilllint)"
         TOOL_PYTHON="$(sed -n '1s/^#!//p' "${TOOL_PATH}")"
         echo "tool-python=$("${TOOL_PYTHON}" --version)" >> "$GITHUB_OUTPUT"

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -4403,6 +4403,14 @@ def main(
     if not paths:
         _show_help_and_exit(ctx, code=0)
 
+    if check and fix:
+        typer.echo("Error: Cannot use both --check and --fix flags", err=True)
+        raise typer.Exit(2) from None
+
+    if fix and platform:
+        typer.echo("Error: Cannot use --fix with --platform", err=True)
+        raise typer.Exit(2) from None
+
     # Validate that all provided paths exist; report non-existent ones
     bad_paths = [str(p) for p in paths if not p.exists()]
     if bad_paths:
@@ -4426,10 +4434,6 @@ def main(
 
         if tokens_only:
             _handle_tokens_only(expanded_paths, batch=is_batch)
-
-        if check and fix:
-            typer.echo("Error: Cannot use both --check and --fix flags", err=True)
-            raise typer.Exit(2) from None
 
         # One shared cache per scan run — prevents re-walking the directory
         # tree for every file when many files share the same config root.

--- a/packages/skilllint/plugin_validator.py
+++ b/packages/skilllint/plugin_validator.py
@@ -123,7 +123,7 @@ _rt_yaml.width = 10000  # prevent line wrapping
 
 # Platform adapter registry — loaded once at module level.
 # Keys are adapter IDs (e.g. "claude_code", "cursor", "codex").
-ADAPTERS: dict[str, object] = {a.id(): a for a in load_adapters()}
+ADAPTERS: dict[str, PlatformAdapter] = {a.id(): a for a in load_adapters()}
 
 
 def _safe_load_yaml(text: str) -> YamlValue:
@@ -4415,7 +4415,12 @@ def main(
     record_console = _make_recording_console(no_color=no_color) if record is not None else None
 
     def _run_validation_command() -> None:
-        expanded_paths, is_batch = _resolve_filter_and_expand_paths(paths, filter_glob, filter_type)
+        expanded_paths, is_batch = _resolve_filter_and_expand_paths(
+            paths,
+            filter_glob,
+            filter_type,
+            platform_adapter=ADAPTERS[platform_override] if platform_override is not None else None,
+        )
         if platform_override is not None:
             expanded_paths = [_normalize_skill_folder(path) for path in expanded_paths]
 

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -359,12 +359,14 @@ def _platform_matching_paths(paths: list[Path], directory: Path, adapter: Platfo
         path
         for path in paths
         if path.is_file()
+        and not (adapter.id() == "claude_code" and _is_foreign_provider_target(path, directory))
         and (
             _matches_platform_path(adapter, path, directory)
             or (
                 adapter.id() == "claude_code"
                 and any(
-                    (target.is_file() or _is_skill_folder(target)) and (path == target or path.is_relative_to(target))
+                    (target.is_file() or _is_skill_folder(target) or _is_claude_marketplace_root(target))
+                    and (path == target or path.is_relative_to(target))
                     for target in semantic_targets
                 )
             )
@@ -397,6 +399,17 @@ def _semantic_platform_target(candidate: Path, semantic_targets: list[Path], ada
         return candidate
     if adapter.id() == "codex" and candidate.name == "AGENTS.md":
         return candidate
+    if adapter.id() == "claude_code":
+        marketplace_root = next(
+            (
+                semantic_target
+                for semantic_target in semantic_targets
+                if _is_claude_marketplace_root(semantic_target) and candidate.is_relative_to(semantic_target)
+            ),
+            None,
+        )
+        if marketplace_root is not None:
+            return marketplace_root
     if candidate.suffix != ".md":
         return candidate
     return next(
@@ -421,15 +434,23 @@ def _is_manifest_declared_target(target: Path, directory: Path) -> bool:
     return False
 
 
-def _matches_semantic_target(adapter: PlatformAdapter, target: Path, directory: Path) -> bool:
+def _is_claude_marketplace_root(target: Path) -> bool:
+    return (target / ".claude-plugin" / "marketplace.json").is_file()
+
+
+def _is_foreign_provider_target(target: Path, directory: Path) -> bool:
     foreign_provider_roots = (KNOWN_PROVIDER_DIRS | {".agents"}) - {".claude"}
-    if any(
+    return any(
         ancestor.name in foreign_provider_roots
         for ancestor in (target, *target.parents)
         if ancestor == directory or ancestor.is_relative_to(directory)
-    ):
+    )
+
+
+def _matches_semantic_target(adapter: PlatformAdapter, target: Path, directory: Path) -> bool:
+    if _is_foreign_provider_target(target, directory):
         return False
-    if any((target / ".claude-plugin" / name).is_file() for name in ("plugin.json", "marketplace.json")):
+    if (target / ".claude-plugin" / "plugin.json").is_file() or _is_claude_marketplace_root(target):
         return True
     if _is_manifest_declared_target(target, directory):
         return True

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -21,6 +21,7 @@ import typer
 from git import Repo
 from git.exc import InvalidGitRepositoryError, NoSuchPathError
 
+from .adapters import PlatformAdapter, matches_file
 from .reporting import CIReporter, ConsoleReporter, FileResults, Reporter
 
 if TYPE_CHECKING:
@@ -350,8 +351,37 @@ def _discover_validatable_paths(directory: Path) -> list[Path]:
     return _discover_bare_paths(directory)
 
 
+def _platform_matching_paths(paths: list[Path], directory: Path, adapter: PlatformAdapter | None) -> list[Path]:
+    if adapter is None:
+        return paths
+    return [path for path in paths if path.is_file() and matches_file(adapter, path.relative_to(directory))]
+
+
+def _discover_platform_paths(directory: Path, adapter: PlatformAdapter) -> list[Path]:
+    return sorted(
+        candidate
+        for candidate in _glob_excluding(directory, "**/*")
+        if candidate.is_file() and matches_file(adapter, candidate.relative_to(directory))
+    )
+
+
+def _validate_filter_options(filter_glob: str | None, filter_type: str | None) -> None:
+    if filter_glob is not None and filter_type is not None:
+        typer.echo("Error: --filter and --filter-type are mutually exclusive", err=True)
+        raise typer.Exit(2) from None
+
+    if filter_type is not None and filter_type not in FILTER_TYPE_MAP:
+        valid = ", ".join(FILTER_TYPE_MAP)
+        typer.echo(f"Error: --filter-type must be one of: {valid}", err=True)
+        raise typer.Exit(2) from None
+
+
 def _resolve_filter_and_expand_paths(
-    paths: list[Path], filter_glob: str | None, filter_type: str | None
+    paths: list[Path],
+    filter_glob: str | None,
+    filter_type: str | None,
+    *,
+    platform_adapter: PlatformAdapter | None = None,
 ) -> tuple[list[Path], bool]:
     """Resolve filter options and expand directory paths.
 
@@ -364,14 +394,7 @@ def _resolve_filter_and_expand_paths(
     Raises:
         typer.Exit: On invalid filter options.
     """
-    if filter_glob is not None and filter_type is not None:
-        typer.echo("Error: --filter and --filter-type are mutually exclusive", err=True)
-        raise typer.Exit(2) from None
-
-    if filter_type is not None and filter_type not in FILTER_TYPE_MAP:
-        valid = ", ".join(FILTER_TYPE_MAP)
-        typer.echo(f"Error: --filter-type must be one of: {valid}", err=True)
-        raise typer.Exit(2) from None
+    _validate_filter_options(filter_glob, filter_type)
 
     expanded_paths: list[Path] = []
     is_batch = False
@@ -387,16 +410,22 @@ def _resolve_filter_and_expand_paths(
             resolved_glob = filter_glob
         if resolved_glob is not None and path.is_dir():
             matched = sorted(path.glob(resolved_glob))
+            matched = _platform_matching_paths(matched, path, platform_adapter)
             if filter_type == "skills":
                 matched = [match.parent for match in matched]
             expanded_paths.extend(matched)
             is_batch = True
         elif resolved_glob is None and path.is_dir():
-            expanded_paths.extend(_discover_validatable_paths(path))
+            if platform_adapter is None:
+                expanded_paths.extend(_discover_validatable_paths(path))
+            else:
+                expanded_paths.extend(_discover_platform_paths(path, platform_adapter))
             is_batch = True
         else:
             expanded_paths.append(path)
-    return expanded_paths, is_batch
+    if platform_adapter is None:
+        return expanded_paths, is_batch
+    return list(dict.fromkeys(expanded_paths)), is_batch
 
 
 # ---------------------------------------------------------------------------
@@ -542,7 +571,7 @@ def _compute_scan_base(paths: list[Path]) -> Path | None:
 # This avoids circular imports: plugin_validator imports scan_runtime,
 # and passes its own functions as callbacks when calling run_validation_loop.
 ValidateSinglePathFn = Callable[..., "FileResults"]
-ValidateFileFn = Callable[[Path, dict[str, object], str | None], list[dict]]
+ValidateFileFn = Callable[[Path, dict[str, PlatformAdapter], str | None], list[dict]]
 ViolationsToResultFn = Callable[[list[dict]], Any]
 
 
@@ -583,7 +612,7 @@ def run_validation_loop(
     validate_single_path: ValidateSinglePathFn,
     validate_file: ValidateFileFn,
     violations_to_result: ViolationsToResultFn,
-    adapters: dict[str, object],
+    adapters: dict[str, PlatformAdapter],
     record_console: Console | None = None,
     include_gitignore: bool = False,
 ) -> NoReturn:

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -354,10 +354,8 @@ def _discover_validatable_paths(directory: Path) -> list[Path]:
 def _platform_matching_paths(paths: list[Path], directory: Path, adapter: PlatformAdapter | None) -> list[Path]:
     if adapter is None:
         return paths
-    semantic_files = {
-        target for target in _discover_validatable_paths(directory) if target.is_file() or _is_skill_folder(target)
-    }
-    return [
+    semantic_targets = sorted(_discover_validatable_paths(directory), key=lambda path: len(path.parts), reverse=True)
+    matched = [
         path
         for path in paths
         if path.is_file()
@@ -365,10 +363,13 @@ def _platform_matching_paths(paths: list[Path], directory: Path, adapter: Platfo
             _matches_platform_path(adapter, path, directory)
             or (
                 adapter.id() == "claude_code"
-                and any(path == target or path.is_relative_to(target) for target in semantic_files)
+                and any(path == target or path.is_relative_to(target) for target in semantic_targets)
             )
         )
     ]
+    if adapter.id() == "claude_code":
+        return matched
+    return sorted({_semantic_platform_target(path, semantic_targets) for path in matched})
 
 
 def _matches_platform_path(adapter: PlatformAdapter, candidate: Path, directory: Path) -> bool:
@@ -391,6 +392,18 @@ def _matches_platform_relative_path(adapter: PlatformAdapter, candidate: Path) -
     )
 
 
+def _semantic_platform_target(candidate: Path, semantic_targets: list[Path]) -> Path:
+    return next(
+        (
+            semantic_target
+            for semantic_target in semantic_targets
+            if candidate == semantic_target or candidate.is_relative_to(semantic_target)
+            if not (semantic_target / ".claude-plugin" / "plugin.json").is_file()
+        ),
+        candidate,
+    )
+
+
 def _discover_platform_paths(directory: Path, adapter: PlatformAdapter) -> list[Path]:
     if adapter.id() == "claude_code":
         return _discover_validatable_paths(directory)
@@ -399,16 +412,7 @@ def _discover_platform_paths(directory: Path, adapter: PlatformAdapter) -> list[
     for candidate in _glob_excluding(directory, "**/*"):
         if not candidate.is_file() or not _matches_platform_path(adapter, candidate, directory):
             continue
-        target = next(
-            (
-                semantic_target
-                for semantic_target in semantic_targets
-                if candidate == semantic_target or candidate.is_relative_to(semantic_target)
-                if not (semantic_target / ".claude-plugin" / "plugin.json").is_file()
-            ),
-            candidate,
-        )
-        discovered.add(target)
+        discovered.add(_semantic_platform_target(candidate, semantic_targets))
     return sorted(discovered)
 
 

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -360,11 +360,22 @@ def _platform_matching_paths(paths: list[Path], directory: Path, adapter: Platfo
 def _discover_platform_paths(directory: Path, adapter: PlatformAdapter) -> list[Path]:
     if adapter.id() == "claude_code":
         return _discover_validatable_paths(directory)
-    return sorted(
-        candidate
-        for candidate in _glob_excluding(directory, "**/*")
-        if candidate.is_file() and matches_file(adapter, candidate.relative_to(directory))
-    )
+    semantic_targets = sorted(_discover_validatable_paths(directory), key=lambda path: len(path.parts), reverse=True)
+    discovered: set[Path] = set()
+    for candidate in _glob_excluding(directory, "**/*"):
+        if not candidate.is_file() or not matches_file(adapter, candidate):
+            continue
+        target = next(
+            (
+                semantic_target
+                for semantic_target in semantic_targets
+                if candidate == semantic_target or candidate.is_relative_to(semantic_target)
+                if not (semantic_target / ".claude-plugin" / "plugin.json").is_file()
+            ),
+            candidate,
+        )
+        discovered.add(target if candidate.name == "SKILL.md" else candidate)
+    return sorted(discovered)
 
 
 def _validate_filter_options(filter_glob: str | None, filter_type: str | None) -> None:

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -434,6 +434,26 @@ def _is_manifest_declared_target(target: Path, directory: Path) -> bool:
     return False
 
 
+def _manifest_filter_type_paths(
+    directory: Path, filter_type: str | None, adapter: PlatformAdapter | None
+) -> list[Path]:
+    if adapter is None or adapter.id() != "claude_code" or detect_scan_context(directory) != ScanContext.PLUGIN:
+        return []
+    manifest = _parse_plugin_manifest(directory)
+    match filter_type:
+        case "agents":
+            declared_paths = manifest.agents
+        case "commands":
+            declared_paths = manifest.commands
+        case "skills":
+            declared_paths = manifest.skills
+        case _:
+            return []
+    if declared_paths is None:
+        return []
+    return [directory / path for path in declared_paths]
+
+
 def _is_claude_marketplace_root(target: Path) -> bool:
     return (target / ".claude-plugin" / "marketplace.json").is_file()
 
@@ -525,6 +545,7 @@ def _resolve_filter_and_expand_paths(
         if resolved_glob is not None and path.is_dir():
             matched = _glob_excluding(path, resolved_glob)
             matched = _platform_matching_paths(matched, path, platform_adapter)
+            matched.extend(_manifest_filter_type_paths(path, filter_type, platform_adapter))
             if filter_type == "skills" and platform_adapter is None:
                 matched = [match.parent for match in matched]
             expanded_paths.extend(matched)

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -370,7 +370,7 @@ def _platform_matching_paths(paths: list[Path], directory: Path, adapter: Platfo
             )
         )
     ]
-    return sorted({_semantic_platform_target(path, semantic_targets, adapter, directory) for path in matched})
+    return sorted({_semantic_platform_target(path, semantic_targets) for path in matched})
 
 
 def _matches_platform_path(adapter: PlatformAdapter, candidate: Path, directory: Path) -> bool:
@@ -393,9 +393,7 @@ def _matches_platform_relative_path(adapter: PlatformAdapter, candidate: Path) -
     )
 
 
-def _semantic_platform_target(
-    candidate: Path, semantic_targets: list[Path], adapter: PlatformAdapter, directory: Path
-) -> Path:
+def _semantic_platform_target(candidate: Path, semantic_targets: list[Path]) -> Path:
     if candidate.suffix != ".md":
         return candidate
     return next(
@@ -439,7 +437,7 @@ def _discover_platform_paths(directory: Path, adapter: PlatformAdapter) -> list[
     for candidate in _glob_excluding(directory, "**/*"):
         if not candidate.is_file() or not _matches_platform_path(adapter, candidate, directory):
             continue
-        discovered.add(_semantic_platform_target(candidate, semantic_targets, adapter, directory))
+        discovered.add(_semantic_platform_target(candidate, semantic_targets))
     return sorted(discovered)
 
 

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -358,11 +358,14 @@ def _platform_matching_paths(paths: list[Path], directory: Path, adapter: Platfo
 
 
 def _discover_platform_paths(directory: Path, adapter: PlatformAdapter) -> list[Path]:
-    return sorted(
+    discovered = {
         candidate
         for candidate in _glob_excluding(directory, "**/*")
         if candidate.is_file() and matches_file(adapter, candidate.relative_to(directory))
-    )
+    }
+    if adapter.id() == "claude_code":
+        discovered.update(path for path in _discover_validatable_paths(directory) if _is_skill_folder(path))
+    return sorted(discovered)
 
 
 def _validate_filter_options(filter_glob: str | None, filter_type: str | None) -> None:

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -452,7 +452,15 @@ def _manifest_filter_type_paths(
             return []
     if declared_paths is None:
         return []
-    return [directory / path for path in declared_paths]
+    targets: list[Path] = []
+    for declared_path in declared_paths:
+        target = directory / declared_path
+        if _is_foreign_provider_target(target, directory):
+            continue
+        if filter_type == "skills" and not target.exists():
+            target = directory / ".claude-plugin" / "plugin.json"
+        targets.append(target)
+    return targets
 
 
 def _is_claude_marketplace_root(target: Path) -> bool:

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -422,24 +422,23 @@ def _is_manifest_declared_target(target: Path, directory: Path) -> bool:
 
 
 def _matches_semantic_target(adapter: PlatformAdapter, target: Path, directory: Path) -> bool:
+    foreign_provider_roots = (KNOWN_PROVIDER_DIRS | {".agents"}) - {".claude"}
+    if any(
+        ancestor.name in foreign_provider_roots
+        for ancestor in (target, *target.parents)
+        if ancestor == directory or ancestor.is_relative_to(directory)
+    ):
+        return False
     if any((target / ".claude-plugin" / name).is_file() for name in ("plugin.json", "marketplace.json")):
         return True
     if _is_manifest_declared_target(target, directory):
         return True
-    foreign_provider_roots = (KNOWN_PROVIDER_DIRS | {".agents"}) - {".claude"}
     if target.is_dir():
-        if not _is_skill_folder(target):
-            return False
-        return all(
-            ancestor.name not in foreign_provider_roots
-            for ancestor in (target, *target.parents)
-            if ancestor == directory or ancestor.is_relative_to(directory)
-        )
+        return _is_skill_folder(target)
     relative_target = target.relative_to(directory)
     return _matches_platform_path(adapter, target, directory) or (
         target.suffix == ".md"
         and (target.name == "CLAUDE.md" or any(part in {"agents", "commands"} for part in relative_target.parts))
-        and not any(part in foreign_provider_roots for part in relative_target.parts)
     )
 
 

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -408,7 +408,7 @@ def _discover_platform_paths(directory: Path, adapter: PlatformAdapter) -> list[
             ),
             candidate,
         )
-        discovered.add(target if candidate.name == "SKILL.md" else candidate)
+        discovered.add(target)
     return sorted(discovered)
 
 

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -363,11 +363,14 @@ def _platform_matching_paths(paths: list[Path], directory: Path, adapter: Platfo
             _matches_platform_path(adapter, path, directory)
             or (
                 adapter.id() == "claude_code"
-                and any(path == target or path.is_relative_to(target) for target in semantic_targets)
+                and any(
+                    (target.is_file() or _is_skill_folder(target)) and (path == target or path.is_relative_to(target))
+                    for target in semantic_targets
+                )
             )
         )
     ]
-    return sorted({_semantic_platform_target(path, semantic_targets) for path in matched})
+    return sorted({_semantic_platform_target(path, semantic_targets, adapter, directory) for path in matched})
 
 
 def _matches_platform_path(adapter: PlatformAdapter, candidate: Path, directory: Path) -> bool:
@@ -390,7 +393,11 @@ def _matches_platform_relative_path(adapter: PlatformAdapter, candidate: Path) -
     )
 
 
-def _semantic_platform_target(candidate: Path, semantic_targets: list[Path]) -> Path:
+def _semantic_platform_target(
+    candidate: Path, semantic_targets: list[Path], adapter: PlatformAdapter, directory: Path
+) -> Path:
+    if candidate.suffix != ".md":
+        return candidate
     return next(
         (
             semantic_target
@@ -402,15 +409,37 @@ def _semantic_platform_target(candidate: Path, semantic_targets: list[Path]) -> 
     )
 
 
+def _matches_semantic_target(adapter: PlatformAdapter, target: Path, directory: Path) -> bool:
+    if (target / ".claude-plugin" / "plugin.json").is_file():
+        return True
+    if target.is_dir():
+        if not _is_skill_folder(target):
+            return False
+        foreign_provider_roots = (KNOWN_PROVIDER_DIRS | {".agents"}) - {".claude"}
+        return all(
+            ancestor.name not in foreign_provider_roots
+            for ancestor in (target, *target.parents)
+            if ancestor == directory or ancestor.is_relative_to(directory)
+        )
+    relative_target = target.relative_to(directory)
+    return _matches_platform_path(adapter, target, directory) or (
+        target.suffix == ".md" and relative_target.parts[0] in {"agents", "commands"}
+    )
+
+
 def _discover_platform_paths(directory: Path, adapter: PlatformAdapter) -> list[Path]:
     if adapter.id() == "claude_code":
-        return _discover_validatable_paths(directory)
+        return [
+            target
+            for target in _discover_validatable_paths(directory)
+            if _matches_semantic_target(adapter, target, directory)
+        ]
     semantic_targets = sorted(_discover_validatable_paths(directory), key=lambda path: len(path.parts), reverse=True)
     discovered: set[Path] = set()
     for candidate in _glob_excluding(directory, "**/*"):
         if not candidate.is_file() or not _matches_platform_path(adapter, candidate, directory):
             continue
-        discovered.add(_semantic_platform_target(candidate, semantic_targets))
+        discovered.add(_semantic_platform_target(candidate, semantic_targets, adapter, directory))
     return sorted(discovered)
 
 

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -408,7 +408,7 @@ def _semantic_platform_target(candidate: Path, semantic_targets: list[Path]) -> 
 
 
 def _matches_semantic_target(adapter: PlatformAdapter, target: Path, directory: Path) -> bool:
-    if (target / ".claude-plugin" / "plugin.json").is_file():
+    if any((target / ".claude-plugin" / name).is_file() for name in ("plugin.json", "marketplace.json")):
         return True
     if target.is_dir():
         if not _is_skill_folder(target):

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -367,8 +367,6 @@ def _platform_matching_paths(paths: list[Path], directory: Path, adapter: Platfo
             )
         )
     ]
-    if adapter.id() == "claude_code":
-        return matched
     return sorted({_semantic_platform_target(path, semantic_targets) for path in matched})
 
 
@@ -462,7 +460,7 @@ def _resolve_filter_and_expand_paths(
         if resolved_glob is not None and path.is_dir():
             matched = _glob_excluding(path, resolved_glob)
             matched = _platform_matching_paths(matched, path, platform_adapter)
-            if filter_type == "skills":
+            if filter_type == "skills" and platform_adapter is None:
                 matched = [match.parent for match in matched]
             expanded_paths.extend(matched)
             is_batch = True

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -373,9 +373,20 @@ def _platform_matching_paths(paths: list[Path], directory: Path, adapter: Platfo
 
 def _matches_platform_path(adapter: PlatformAdapter, candidate: Path, directory: Path) -> bool:
     relative_candidate = candidate.relative_to(directory)
-    if matches_file(adapter, relative_candidate):
+    if _matches_platform_relative_path(adapter, relative_candidate):
         return True
-    return directory.name.startswith(".") and matches_file(adapter, candidate.relative_to(directory.parent))
+    return directory.name.startswith(".") and _matches_platform_relative_path(
+        adapter, candidate.relative_to(directory.parent)
+    )
+
+
+def _matches_platform_relative_path(adapter: PlatformAdapter, candidate: Path) -> bool:
+    if matches_file(adapter, candidate):
+        return True
+    return any(
+        pattern.startswith("**/") and candidate.match(pattern.removeprefix("**/"))
+        for pattern in adapter.path_patterns()
+    )
 
 
 def _discover_platform_paths(directory: Path, adapter: PlatformAdapter) -> list[Path]:

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -410,8 +410,21 @@ def _semantic_platform_target(candidate: Path, semantic_targets: list[Path], ada
     )
 
 
+def _is_manifest_declared_target(target: Path, directory: Path) -> bool:
+    for plugin_root in target.parents:
+        if plugin_root != directory and not plugin_root.is_relative_to(directory):
+            break
+        if not (plugin_root / ".claude-plugin" / "plugin.json").is_file():
+            continue
+        manifest = _parse_plugin_manifest(plugin_root)
+        return manifest.is_manifest_driven and target in _discover_plugin_paths(manifest)
+    return False
+
+
 def _matches_semantic_target(adapter: PlatformAdapter, target: Path, directory: Path) -> bool:
     if any((target / ".claude-plugin" / name).is_file() for name in ("plugin.json", "marketplace.json")):
+        return True
+    if _is_manifest_declared_target(target, directory):
         return True
     foreign_provider_roots = (KNOWN_PROVIDER_DIRS | {".agents"}) - {".claude"}
     if target.is_dir():

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -370,7 +370,7 @@ def _platform_matching_paths(paths: list[Path], directory: Path, adapter: Platfo
             )
         )
     ]
-    return sorted({_semantic_platform_target(path, semantic_targets) for path in matched})
+    return sorted({_semantic_platform_target(path, semantic_targets, adapter) for path in matched})
 
 
 def _matches_platform_path(adapter: PlatformAdapter, candidate: Path, directory: Path) -> bool:
@@ -393,7 +393,9 @@ def _matches_platform_relative_path(adapter: PlatformAdapter, candidate: Path) -
     )
 
 
-def _semantic_platform_target(candidate: Path, semantic_targets: list[Path]) -> Path:
+def _semantic_platform_target(candidate: Path, semantic_targets: list[Path], adapter: PlatformAdapter) -> Path:
+    if adapter.id() == "codex" and candidate.name == "AGENTS.md":
+        return candidate
     if candidate.suffix != ".md":
         return candidate
     return next(
@@ -421,7 +423,11 @@ def _matches_semantic_target(adapter: PlatformAdapter, target: Path, directory: 
         )
     relative_target = target.relative_to(directory)
     return _matches_platform_path(adapter, target, directory) or (
-        target.suffix == ".md" and relative_target.parts[0] in {"agents", "commands"}
+        target.suffix == ".md"
+        and (
+            relative_target.parts[0] in {"agents", "commands"}
+            or (target.name == "CLAUDE.md" and target.parent == directory)
+        )
     )
 
 
@@ -437,7 +443,7 @@ def _discover_platform_paths(directory: Path, adapter: PlatformAdapter) -> list[
     for candidate in _glob_excluding(directory, "**/*"):
         if not candidate.is_file() or not _matches_platform_path(adapter, candidate, directory):
             continue
-        discovered.add(_semantic_platform_target(candidate, semantic_targets))
+        discovered.add(_semantic_platform_target(candidate, semantic_targets, adapter))
     return sorted(discovered)
 
 

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -375,8 +375,10 @@ def _matches_platform_path(adapter: PlatformAdapter, candidate: Path, directory:
     relative_candidate = candidate.relative_to(directory)
     if _matches_platform_relative_path(adapter, relative_candidate):
         return True
-    return directory.name.startswith(".") and _matches_platform_relative_path(
-        adapter, candidate.relative_to(directory.parent)
+    return any(
+        ancestor.name.startswith(".")
+        and _matches_platform_relative_path(adapter, candidate.relative_to(ancestor.parent))
+        for ancestor in (directory, *directory.parents)
     )
 
 

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -404,7 +404,8 @@ def _semantic_platform_target(candidate: Path, semantic_targets: list[Path], ada
             (
                 semantic_target
                 for semantic_target in semantic_targets
-                if _is_claude_marketplace_root(semantic_target) and candidate.is_relative_to(semantic_target)
+                if _is_claude_marketplace_root(semantic_target)
+                and candidate == semantic_target / ".claude-plugin" / "marketplace.json"
             ),
             None,
         )

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -457,7 +457,7 @@ def _manifest_filter_type_paths(
         target = directory / declared_path
         if _is_foreign_provider_target(target, directory):
             continue
-        if filter_type == "skills" and not target.exists():
+        if filter_type == "skills" and not _is_skill_folder(target):
             target = directory / ".claude-plugin" / "plugin.json"
         targets.append(target)
     return targets

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -378,8 +378,7 @@ def _matches_platform_path(adapter: PlatformAdapter, candidate: Path, directory:
     if _matches_platform_relative_path(adapter, relative_candidate):
         return True
     return any(
-        ancestor.name.startswith(".")
-        and _matches_platform_relative_path(adapter, candidate.relative_to(ancestor.parent))
+        _matches_platform_relative_path(adapter, candidate.relative_to(ancestor.parent))
         for ancestor in (directory, *directory.parents)
     )
 
@@ -394,6 +393,8 @@ def _matches_platform_relative_path(adapter: PlatformAdapter, candidate: Path) -
 
 
 def _semantic_platform_target(candidate: Path, semantic_targets: list[Path], adapter: PlatformAdapter) -> Path:
+    if adapter.id() not in {"claude_code", "codex", "cursor"}:
+        return candidate
     if adapter.id() == "codex" and candidate.name == "AGENTS.md":
         return candidate
     if candidate.suffix != ".md":
@@ -412,10 +413,10 @@ def _semantic_platform_target(candidate: Path, semantic_targets: list[Path], ada
 def _matches_semantic_target(adapter: PlatformAdapter, target: Path, directory: Path) -> bool:
     if any((target / ".claude-plugin" / name).is_file() for name in ("plugin.json", "marketplace.json")):
         return True
+    foreign_provider_roots = (KNOWN_PROVIDER_DIRS | {".agents"}) - {".claude"}
     if target.is_dir():
         if not _is_skill_folder(target):
             return False
-        foreign_provider_roots = (KNOWN_PROVIDER_DIRS | {".agents"}) - {".claude"}
         return all(
             ancestor.name not in foreign_provider_roots
             for ancestor in (target, *target.parents)
@@ -424,10 +425,8 @@ def _matches_semantic_target(adapter: PlatformAdapter, target: Path, directory: 
     relative_target = target.relative_to(directory)
     return _matches_platform_path(adapter, target, directory) or (
         target.suffix == ".md"
-        and (
-            relative_target.parts[0] in {"agents", "commands"}
-            or (target.name == "CLAUDE.md" and target.parent == directory)
-        )
+        and (target.name == "CLAUDE.md" or any(part in {"agents", "commands"} for part in relative_target.parts))
+        and not any(part in foreign_provider_roots for part in relative_target.parts)
     )
 
 

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -352,9 +352,30 @@ def _discover_validatable_paths(directory: Path) -> list[Path]:
 
 
 def _platform_matching_paths(paths: list[Path], directory: Path, adapter: PlatformAdapter | None) -> list[Path]:
-    if adapter is None or adapter.id() == "claude_code":
+    if adapter is None:
         return paths
-    return [path for path in paths if path.is_file() and matches_file(adapter, path.relative_to(directory))]
+    semantic_files = {
+        target for target in _discover_validatable_paths(directory) if target.is_file() or _is_skill_folder(target)
+    }
+    return [
+        path
+        for path in paths
+        if path.is_file()
+        and (
+            _matches_platform_path(adapter, path, directory)
+            or (
+                adapter.id() == "claude_code"
+                and any(path == target or path.is_relative_to(target) for target in semantic_files)
+            )
+        )
+    ]
+
+
+def _matches_platform_path(adapter: PlatformAdapter, candidate: Path, directory: Path) -> bool:
+    relative_candidate = candidate.relative_to(directory)
+    if matches_file(adapter, relative_candidate):
+        return True
+    return directory.name.startswith(".") and matches_file(adapter, candidate.relative_to(directory.parent))
 
 
 def _discover_platform_paths(directory: Path, adapter: PlatformAdapter) -> list[Path]:
@@ -363,7 +384,7 @@ def _discover_platform_paths(directory: Path, adapter: PlatformAdapter) -> list[
     semantic_targets = sorted(_discover_validatable_paths(directory), key=lambda path: len(path.parts), reverse=True)
     discovered: set[Path] = set()
     for candidate in _glob_excluding(directory, "**/*"):
-        if not candidate.is_file() or not matches_file(adapter, candidate):
+        if not candidate.is_file() or not _matches_platform_path(adapter, candidate, directory):
             continue
         target = next(
             (

--- a/packages/skilllint/scan_runtime.py
+++ b/packages/skilllint/scan_runtime.py
@@ -352,20 +352,19 @@ def _discover_validatable_paths(directory: Path) -> list[Path]:
 
 
 def _platform_matching_paths(paths: list[Path], directory: Path, adapter: PlatformAdapter | None) -> list[Path]:
-    if adapter is None:
+    if adapter is None or adapter.id() == "claude_code":
         return paths
     return [path for path in paths if path.is_file() and matches_file(adapter, path.relative_to(directory))]
 
 
 def _discover_platform_paths(directory: Path, adapter: PlatformAdapter) -> list[Path]:
-    discovered = {
+    if adapter.id() == "claude_code":
+        return _discover_validatable_paths(directory)
+    return sorted(
         candidate
         for candidate in _glob_excluding(directory, "**/*")
         if candidate.is_file() and matches_file(adapter, candidate.relative_to(directory))
-    }
-    if adapter.id() == "claude_code":
-        discovered.update(path for path in _discover_validatable_paths(directory) if _is_skill_folder(path))
-    return sorted(discovered)
+    )
 
 
 def _validate_filter_options(filter_glob: str | None, filter_type: str | None) -> None:
@@ -412,7 +411,7 @@ def _resolve_filter_and_expand_paths(
         else:
             resolved_glob = filter_glob
         if resolved_glob is not None and path.is_dir():
-            matched = sorted(path.glob(resolved_glob))
+            matched = _glob_excluding(path, resolved_glob)
             matched = _platform_matching_paths(matched, path, platform_adapter)
             if filter_type == "skills":
                 matched = [match.parent for match in matched]

--- a/packages/skilllint/tests/test_cli.py
+++ b/packages/skilllint/tests/test_cli.py
@@ -592,6 +592,30 @@ class TestPathArguments:
         assert result.exit_code == 1, result.stdout
         assert "Total files: 1" in result.stdout
 
+    def test_platform_filtered_missing_manifest_skill_reports_plugin_validation(
+        self, cli_runner: CliRunner, tmp_path: Path, no_color_env: None, mocker: MockerFixture
+    ) -> None:
+        plugin_dir = tmp_path / "plugin"
+        manifest = plugin_dir / ".claude-plugin" / "plugin.json"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text('{"skills": ["custom/missing-skill"]}')
+        mocker.patch("shutil.which", return_value="/usr/local/bin/claude")
+        mocker.patch("skilllint.plugin_validator._should_skip_claude_validate", return_value=False)
+        mocker.patch(
+            "skilllint.plugin_validator._run_claude_plugin_validate",
+            return_value=subprocess.CompletedProcess(
+                args=["claude", "plugin", "validate"], returncode=1, stdout="referenced file does not exist", stderr=""
+            ),
+        )
+
+        result = cli_runner.invoke(
+            plugin_validator.app,
+            ["check", "--no-color", "--platform", "claude-code", "--filter-type", "skills", str(plugin_dir)],
+        )
+
+        assert result.exit_code == 1, result.stdout
+        assert "PL005" in result.stdout
+
 
 class TestErrorMessages:
     """Test error message clarity and actionability."""

--- a/packages/skilllint/tests/test_cli.py
+++ b/packages/skilllint/tests/test_cli.py
@@ -168,6 +168,35 @@ description: Test skill with invalid name format
         assert result.exit_code == 2
         assert "Cannot use both" in result.stdout or "Cannot use both" in result.stderr
 
+    def test_exit_2_on_fix_with_platform_without_modifying_file(
+        self, cli_runner: CliRunner, tmp_path: Path, no_color_env: None
+    ) -> None:
+        """--fix with --platform is rejected before it can modify its target."""
+        skill_dir = tmp_path / "platform-fix-skill"
+        skill_dir.mkdir()
+        skill_file = skill_dir / "SKILL.md"
+        original_content = (
+            "---\n"
+            "name: platform-fix-skill\n"
+            "description: Use when testing the platform fix conflict.\n"
+            "tools:\n"
+            "  - Read\n"
+            "  - Write\n"
+            "---\n\n"
+            "# Skill\n"
+        )
+        skill_file.write_text(original_content, encoding="utf-8")
+
+        result = cli_runner.invoke(
+            plugin_validator.app, ["check", "--fix", "--platform", "claude-code", str(skill_file)]
+        )
+
+        assert result.exit_code == 2
+        assert (
+            "Cannot use --fix with --platform" in result.stdout or "Cannot use --fix with --platform" in result.stderr
+        )
+        assert skill_file.read_text(encoding="utf-8") == original_content
+
 
 class TestPluginRegistrationRoutes:
     @pytest.mark.parametrize("route", ["root", "manifest", "parent"])

--- a/packages/skilllint/tests/test_provider_validation.py
+++ b/packages/skilllint/tests/test_provider_validation.py
@@ -339,7 +339,15 @@ class TestCLIProviderIntegration:
     def test_cli_platform_codex_exits_success(self) -> None:
         """skilllint check --platform codex on valid fixtures exits 0."""
         result = subprocess.run(
-            [sys.executable, "-m", "skilllint.plugin_validator", "check", "--platform", "codex", str(CODEX_FIXTURES)],
+            [
+                sys.executable,
+                "-m",
+                "skilllint.plugin_validator",
+                "check",
+                "--platform",
+                "codex",
+                str(CODEX_FIXTURES / "valid"),
+            ],
             capture_output=True,
             text=True,
             check=False,

--- a/packages/skilllint/tests/test_provider_validation.py
+++ b/packages/skilllint/tests/test_provider_validation.py
@@ -326,7 +326,15 @@ class TestCLIProviderIntegration:
     def test_cli_platform_cursor_exits_success(self) -> None:
         """skilllint check --platform cursor on valid fixtures exits 0."""
         result = subprocess.run(
-            [sys.executable, "-m", "skilllint.plugin_validator", "check", "--platform", "cursor", str(CURSOR_FIXTURES)],
+            [
+                sys.executable,
+                "-m",
+                "skilllint.plugin_validator",
+                "check",
+                "--platform",
+                "cursor",
+                str(CURSOR_FIXTURES / "valid_rule.mdc"),
+            ],
             capture_output=True,
             text=True,
             check=False,

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -601,6 +601,75 @@ class TestResolveFilterAndExpandPaths:
 
         assert paths == [claude_file]
 
+    def test_claude_platform_preserves_nested_owned_targets_without_foreign_provider_files(
+        self, tmp_path: Path
+    ) -> None:
+        nested = tmp_path / "nested"
+        agent = nested / "agents" / "agent.md"
+        command = nested / "commands" / "command.md"
+        claude_file = nested / "CLAUDE.md"
+        foreign_agent = tmp_path / ".agents" / "agents" / "foreign.md"
+        for path in (agent, command, claude_file, foreign_agent):
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("# Target\n")
+
+        paths, _ = _resolve_filter_and_expand_paths([tmp_path], None, None, platform_adapter=ClaudeCodeAdapter())
+
+        assert paths == sorted([agent, claude_file, command])
+
+    def test_platform_recovers_non_hidden_provider_prefix_for_direct_subtree_scan(self, tmp_path: Path) -> None:
+        class VendorAdapter:
+            def id(self) -> str:
+                return "vendor"
+
+            def path_patterns(self) -> list[str]:
+                return ["vendor/**/*.md"]
+
+            def applicable_rules(self) -> set[str]:
+                return set()
+
+            def constraint_scopes(self) -> set[str]:
+                return set()
+
+            def validate(self, path: Path) -> list[dict]:
+                return []
+
+        vendor_file = tmp_path / "vendor" / "rules" / "rule.md"
+        vendor_file.parent.mkdir(parents=True)
+        vendor_file.write_text("# Vendor rule\n")
+
+        paths, _ = _resolve_filter_and_expand_paths([tmp_path / "vendor"], None, None, platform_adapter=VendorAdapter())
+
+        assert paths == [vendor_file]
+
+    def test_custom_adapter_preserves_markdown_inside_skill(self, tmp_path: Path) -> None:
+        class MarkdownAdapter:
+            def id(self) -> str:
+                return "markdown"
+
+            def path_patterns(self) -> list[str]:
+                return ["**/*.md"]
+
+            def applicable_rules(self) -> set[str]:
+                return set()
+
+            def constraint_scopes(self) -> set[str]:
+                return set()
+
+            def validate(self, path: Path) -> list[dict]:
+                return []
+
+        skill_dir = tmp_path / "skills" / "skill"
+        skill_dir.mkdir(parents=True)
+        skill_file = skill_dir / "SKILL.md"
+        note = skill_dir / "notes.md"
+        skill_file.write_text("---\ndescription: Skill\n---\n# Skill\n")
+        note.write_text("# Adapter target\n")
+
+        paths, _ = _resolve_filter_and_expand_paths([tmp_path], "**/*.md", None, platform_adapter=MarkdownAdapter())
+
+        assert paths == [skill_file, note]
+
     def test_claude_plugin_custom_filter_excludes_documentation(self, tmp_path: Path) -> None:
         plugin_root = tmp_path / "plugin"
         (plugin_root / ".claude-plugin").mkdir(parents=True)

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -18,6 +18,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from skilllint.adapters.codex import CodexAdapter
+from skilllint.adapters.cursor import CursorAdapter
 from skilllint.scan_runtime import (
     DEFAULT_SCAN_PATTERNS,
     FILTER_TYPE_MAP,
@@ -356,6 +358,55 @@ class TestResolveFilterAndExpandPaths:
 
         assert expanded == [skill_file], f"Expected [{skill_file}], got {expanded}"
         assert is_batch is False, "Expected is_batch=False for single file"
+
+    def test_platform_directory_discovers_only_matching_files_recursively(self, tmp_path: Path) -> None:
+        nested = tmp_path / "nested"
+        nested.mkdir()
+        agents = nested / "AGENTS.md"
+        rules = nested / "tool.rules"
+        mdc = nested / "rule.mdc"
+        ignored = nested / "notes.txt"
+        for path in (agents, rules, mdc, ignored):
+            path.write_text("")
+
+        codex_paths, _ = _resolve_filter_and_expand_paths([tmp_path], None, None, platform_adapter=CodexAdapter())
+        cursor_paths, _ = _resolve_filter_and_expand_paths([tmp_path], None, None, platform_adapter=CursorAdapter())
+        filtered_paths, _ = _resolve_filter_and_expand_paths(
+            [tmp_path], "**/*.rules", None, platform_adapter=CodexAdapter()
+        )
+
+        assert codex_paths == [agents, rules]
+        assert cursor_paths == [mdc]
+        assert filtered_paths == [rules]
+
+    def test_platform_directory_uses_custom_adapter_matcher_and_deduplicates_roots(self, tmp_path: Path) -> None:
+        class CustomAdapter:
+            def id(self) -> str:
+                return "custom"
+
+            def path_patterns(self) -> list[str]:
+                return ["**/*.custom"]
+
+            def applicable_rules(self) -> set[str]:
+                return set()
+
+            def constraint_scopes(self) -> set[str]:
+                return set()
+
+            def validate(self, path: Path) -> list[dict]:
+                return []
+
+        nested = tmp_path / "nested"
+        nested.mkdir()
+        custom_file = nested / "rule.custom"
+        custom_file.write_text("")
+
+        paths, is_batch = _resolve_filter_and_expand_paths(
+            [tmp_path, nested], None, None, platform_adapter=CustomAdapter()
+        )
+
+        assert paths == [custom_file]
+        assert is_batch is True
 
     def test_filter_type_resolves_to_glob(self, tmp_path: Path) -> None:
         """_resolve_filter_and_expand_paths resolves --filter-type to glob pattern.

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -429,6 +429,46 @@ class TestResolveFilterAndExpandPaths:
 
         assert paths == [skill_dir]
 
+    def test_claude_platform_preserves_plugin_context_targets(self, tmp_path: Path) -> None:
+        plugin_dir = tmp_path / "plugin"
+        (plugin_dir / ".claude-plugin").mkdir(parents=True)
+        (plugin_dir / ".claude-plugin" / "plugin.json").write_text('{"name": "plugin"}')
+        skill_dir = plugin_dir / "skills" / "nested-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: Nested skill\n---\n# Nested\n")
+        agent = plugin_dir / "agents" / "agent.md"
+        agent.parent.mkdir()
+        agent.write_text("# Agent\n")
+        command = plugin_dir / "commands" / "command.md"
+        command.parent.mkdir()
+        command.write_text("# Command\n")
+
+        paths, _ = _resolve_filter_and_expand_paths([plugin_dir], None, None, platform_adapter=ClaudeCodeAdapter())
+
+        assert paths == [plugin_dir, agent, command, skill_dir]
+
+    @pytest.mark.parametrize(
+        ("filter_type", "expected_name"),
+        [("skills", "nested-skill"), ("agents", "agent.md"), ("commands", "command.md")],
+    )
+    def test_claude_platform_filter_type_preserves_semantic_target(
+        self, tmp_path: Path, filter_type: str, expected_name: str
+    ) -> None:
+        root = tmp_path / "root"
+        skill_dir = root / "skills" / "nested-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: Nested skill\n---\n# Nested\n")
+        agent = root / "agents" / "agent.md"
+        agent.parent.mkdir()
+        agent.write_text("# Agent\n")
+        command = root / "commands" / "command.md"
+        command.parent.mkdir()
+        command.write_text("# Command\n")
+
+        paths, _ = _resolve_filter_and_expand_paths([root], None, filter_type, platform_adapter=ClaudeCodeAdapter())
+
+        assert paths == [next(path for path in (skill_dir, agent, command) if path.name == expected_name)]
+
     def test_filter_type_resolves_to_glob(self, tmp_path: Path) -> None:
         """_resolve_filter_and_expand_paths resolves --filter-type to glob pattern.
 

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -672,6 +672,18 @@ class TestResolveFilterAndExpandPaths:
 
         assert paths == [tmp_path]
 
+    def test_claude_filtered_scan_preserves_agent_beside_marketplace_manifest(self, tmp_path: Path) -> None:
+        marketplace = tmp_path / ".claude-plugin" / "marketplace.json"
+        agent = tmp_path / "agents" / "agent.md"
+        marketplace.parent.mkdir()
+        marketplace.write_text('{"name": "marketplace"}')
+        agent.parent.mkdir()
+        agent.write_text("# Agent\n")
+
+        paths, _ = _resolve_filter_and_expand_paths([tmp_path], "**/*.md", None, platform_adapter=ClaudeCodeAdapter())
+
+        assert paths == [agent]
+
     def test_claude_platform_preserves_root_claude_file(self, tmp_path: Path) -> None:
         claude_file = tmp_path / "CLAUDE.md"
         claude_file.write_text("# Claude\n")

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -482,16 +482,16 @@ class TestResolveFilterAndExpandPaths:
 
         assert paths == [skill_dir]
 
-    def test_platform_cursor_keeps_unprefixed_mdc_outside_provider_subtree(self, tmp_path: Path) -> None:
-        valid_rule = tmp_path / ".cursor" / "valid.mdc"
-        valid_rule.parent.mkdir()
-        valid_rule.write_text("---\ndescription: Valid\n---\n")
-        unrelated_rule = tmp_path / "notes.mdc"
-        unrelated_rule.write_text("---\ntype: rule\n---\n")
+    @pytest.mark.parametrize(("adapter", "filename"), [(CursorAdapter(), "rule.mdc"), (CodexAdapter(), "rule.rules")])
+    def test_platform_includes_root_provider_file(
+        self, tmp_path: Path, adapter: PlatformAdapter, filename: str
+    ) -> None:
+        provider_file = tmp_path / filename
+        provider_file.write_text("# Provider file\n")
 
-        paths, _ = _resolve_filter_and_expand_paths([tmp_path], None, None, platform_adapter=CursorAdapter())
+        paths, _ = _resolve_filter_and_expand_paths([tmp_path], None, None, platform_adapter=adapter)
 
-        assert paths == [valid_rule]
+        assert paths == [provider_file]
 
     def test_claude_custom_filter_excludes_non_adapter_markdown(self, tmp_path: Path) -> None:
         agent = tmp_path / "agents" / "agent.md"

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -494,6 +494,19 @@ class TestResolveFilterAndExpandPaths:
 
         assert paths == [skill_dir]
 
+    @pytest.mark.parametrize(("adapter", "provider"), [(CodexAdapter(), ".agents"), (CursorAdapter(), ".cursor")])
+    def test_platform_skill_target_excludes_supporting_markdown(
+        self, tmp_path: Path, adapter: PlatformAdapter, provider: str
+    ) -> None:
+        skill_dir = tmp_path / provider / "skills" / "skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: Skill\n---\n# Skill\n")
+        (skill_dir / "notes.md").write_text("# Supporting notes\n")
+
+        paths, _ = _resolve_filter_and_expand_paths([tmp_path / provider], None, None, platform_adapter=adapter)
+
+        assert paths == [skill_dir]
+
     @pytest.mark.parametrize(("adapter", "filename"), [(CursorAdapter(), "rule.mdc"), (CodexAdapter(), "rule.rules")])
     def test_platform_includes_root_provider_file(
         self, tmp_path: Path, adapter: PlatformAdapter, filename: str

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -507,6 +507,19 @@ class TestResolveFilterAndExpandPaths:
 
         assert paths == [skill_dir]
 
+    @pytest.mark.parametrize(("adapter", "provider"), [(CodexAdapter(), ".agents"), (CursorAdapter(), ".cursor")])
+    def test_platform_custom_filter_collapses_supporting_markdown_to_skill_target(
+        self, tmp_path: Path, adapter: PlatformAdapter, provider: str
+    ) -> None:
+        skill_dir = tmp_path / provider / "skills" / "skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: Skill\n---\n# Skill\n")
+        (skill_dir / "notes.md").write_text("# Supporting notes\n")
+
+        paths, _ = _resolve_filter_and_expand_paths([tmp_path / provider], "**/*.md", None, platform_adapter=adapter)
+
+        assert paths == [skill_dir]
+
     @pytest.mark.parametrize(("adapter", "filename"), [(CursorAdapter(), "rule.mdc"), (CodexAdapter(), "rule.rules")])
     def test_platform_includes_root_provider_file(
         self, tmp_path: Path, adapter: PlatformAdapter, filename: str

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -475,6 +475,39 @@ class TestResolveFilterAndExpandPaths:
         assert paths == [plugin_dir, reviewer]
 
     @pytest.mark.parametrize(
+        ("filter_glob", "filter_type", "expected_names"),
+        [
+            ("**/*.md", None, {"reviewer.md", "run.md", "custom-skill"}),
+            (None, "agents", {"reviewer.md"}),
+            (None, "commands", {"run.md"}),
+            (None, "skills", {"custom-skill"}),
+        ],
+    )
+    def test_claude_filtered_scan_preserves_manifest_declared_custom_paths(
+        self, tmp_path: Path, filter_glob: str | None, filter_type: str | None, expected_names: set[str]
+    ) -> None:
+        plugin_dir = tmp_path / "plugin"
+        manifest = plugin_dir / ".claude-plugin" / "plugin.json"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text(
+            '{"agents": ["custom/reviewer.md"], "commands": ["custom/run.md"], "skills": ["custom/custom-skill"]}'
+        )
+        reviewer = plugin_dir / "custom" / "reviewer.md"
+        command = plugin_dir / "custom" / "run.md"
+        skill_dir = plugin_dir / "custom" / "custom-skill"
+        for path in (reviewer, command):
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("# Target\n")
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: Skill\n---\n# Skill\n")
+
+        paths, _ = _resolve_filter_and_expand_paths(
+            [plugin_dir], filter_glob, filter_type, platform_adapter=ClaudeCodeAdapter()
+        )
+
+        assert {path.name for path in paths} == expected_names
+
+    @pytest.mark.parametrize(
         ("filter_type", "expected_name"),
         [("skills", "nested-skill"), ("agents", "agent.md"), ("commands", "command.md")],
     )

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -573,6 +573,15 @@ class TestResolveFilterAndExpandPaths:
 
         assert paths == [claude_skill]
 
+    def test_claude_scan_preserves_marketplace_only_root(self, tmp_path: Path) -> None:
+        marketplace = tmp_path / ".claude-plugin" / "marketplace.json"
+        marketplace.parent.mkdir()
+        marketplace.write_text('{"name": "marketplace"}')
+
+        paths, _ = _resolve_filter_and_expand_paths([tmp_path], None, None, platform_adapter=ClaudeCodeAdapter())
+
+        assert paths == [tmp_path]
+
     def test_claude_plugin_custom_filter_excludes_documentation(self, tmp_path: Path) -> None:
         plugin_root = tmp_path / "plugin"
         (plugin_root / ".claude-plugin").mkdir(parents=True)

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -507,6 +507,29 @@ class TestResolveFilterAndExpandPaths:
 
         assert {path.name for path in paths} == expected_names
 
+    def test_claude_filtered_manifest_scan_excludes_foreign_agent(self, tmp_path: Path) -> None:
+        plugin_dir = tmp_path / "plugin"
+        manifest = plugin_dir / ".claude-plugin" / "plugin.json"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text('{"agents": [".agents/agents/team/foreign.md"]}')
+        foreign_agent = plugin_dir / ".agents" / "agents" / "team" / "foreign.md"
+        foreign_agent.parent.mkdir(parents=True)
+        foreign_agent.write_text("# Foreign\n")
+
+        paths, _ = _resolve_filter_and_expand_paths([plugin_dir], None, "agents", platform_adapter=ClaudeCodeAdapter())
+
+        assert paths == []
+
+    def test_claude_filtered_manifest_scan_routes_missing_skill_to_plugin_manifest(self, tmp_path: Path) -> None:
+        plugin_dir = tmp_path / "plugin"
+        manifest = plugin_dir / ".claude-plugin" / "plugin.json"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text('{"skills": ["custom/missing-skill"]}')
+
+        paths, _ = _resolve_filter_and_expand_paths([plugin_dir], None, "skills", platform_adapter=ClaudeCodeAdapter())
+
+        assert paths == [manifest]
+
     @pytest.mark.parametrize(
         ("filter_type", "expected_name"),
         [("skills", "nested-skill"), ("agents", "agent.md"), ("commands", "command.md")],

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -461,6 +461,19 @@ class TestResolveFilterAndExpandPaths:
 
         assert paths == [plugin_dir, reviewer]
 
+    def test_claude_platform_preserves_nested_manifest_declared_custom_agent_path(self, tmp_path: Path) -> None:
+        plugin_dir = tmp_path / "parent" / "plugin"
+        manifest = plugin_dir / ".claude-plugin" / "plugin.json"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text('{"agents": ["custom/reviewer.md"]}')
+        reviewer = plugin_dir / "custom" / "reviewer.md"
+        reviewer.parent.mkdir()
+        reviewer.write_text("# Reviewer\n")
+
+        paths, _ = _resolve_filter_and_expand_paths([tmp_path], None, None, platform_adapter=ClaudeCodeAdapter())
+
+        assert paths == [plugin_dir, reviewer]
+
     @pytest.mark.parametrize(
         ("filter_type", "expected_name"),
         [("skills", "nested-skill"), ("agents", "agent.md"), ("commands", "command.md")],
@@ -621,7 +634,7 @@ class TestResolveFilterAndExpandPaths:
         agent = nested / "agents" / "agent.md"
         command = nested / "commands" / "command.md"
         claude_file = nested / "CLAUDE.md"
-        foreign_agent = tmp_path / ".agents" / "agents" / "foreign.md"
+        foreign_agent = tmp_path / ".agents" / "agents" / "team" / "foreign.md"
         for path in (agent, command, claude_file, foreign_agent):
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text("# Target\n")
@@ -629,6 +642,18 @@ class TestResolveFilterAndExpandPaths:
         paths, _ = _resolve_filter_and_expand_paths([tmp_path], None, None, platform_adapter=ClaudeCodeAdapter())
 
         assert paths == sorted([agent, claude_file, command])
+
+    def test_claude_platform_excludes_nested_agent_inside_direct_foreign_provider_scan(self, tmp_path: Path) -> None:
+        foreign_provider = tmp_path / ".codex"
+        foreign_agent = foreign_provider / "agents" / "team" / "foreign.md"
+        foreign_agent.parent.mkdir(parents=True)
+        foreign_agent.write_text("# Foreign\n")
+
+        paths, _ = _resolve_filter_and_expand_paths(
+            [foreign_provider], None, None, platform_adapter=ClaudeCodeAdapter()
+        )
+
+        assert paths == []
 
     def test_platform_recovers_non_hidden_provider_prefix_for_direct_subtree_scan(self, tmp_path: Path) -> None:
         class VendorAdapter:

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -537,6 +537,17 @@ class TestResolveFilterAndExpandPaths:
 
         assert paths == [skill_dir, native_rule]
 
+    def test_codex_platform_preserves_agents_file_inside_skill(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / ".agents" / "skills" / "skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: Skill\n---\n# Skill\n")
+        agents_file = skill_dir / "AGENTS.md"
+        agents_file.write_text("")
+
+        paths, _ = _resolve_filter_and_expand_paths([tmp_path / ".agents"], None, None, platform_adapter=CodexAdapter())
+
+        assert paths == [skill_dir, agents_file]
+
     @pytest.mark.parametrize(("adapter", "provider"), [(CodexAdapter(), ".agents"), (CursorAdapter(), ".cursor")])
     def test_platform_filter_type_skills_does_not_double_normalize_skill_target(
         self, tmp_path: Path, adapter: PlatformAdapter, provider: str
@@ -581,6 +592,14 @@ class TestResolveFilterAndExpandPaths:
         paths, _ = _resolve_filter_and_expand_paths([tmp_path], None, None, platform_adapter=ClaudeCodeAdapter())
 
         assert paths == [tmp_path]
+
+    def test_claude_platform_preserves_root_claude_file(self, tmp_path: Path) -> None:
+        claude_file = tmp_path / "CLAUDE.md"
+        claude_file.write_text("# Claude\n")
+
+        paths, _ = _resolve_filter_and_expand_paths([tmp_path], None, None, platform_adapter=ClaudeCodeAdapter())
+
+        assert paths == [claude_file]
 
     def test_claude_plugin_custom_filter_excludes_documentation(self, tmp_path: Path) -> None:
         plugin_root = tmp_path / "plugin"

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -482,6 +482,29 @@ class TestResolveFilterAndExpandPaths:
 
         assert paths == [skill_dir]
 
+    def test_platform_cursor_keeps_unprefixed_mdc_outside_provider_subtree(self, tmp_path: Path) -> None:
+        valid_rule = tmp_path / ".cursor" / "valid.mdc"
+        valid_rule.parent.mkdir()
+        valid_rule.write_text("---\ndescription: Valid\n---\n")
+        unrelated_rule = tmp_path / "notes.mdc"
+        unrelated_rule.write_text("---\ntype: rule\n---\n")
+
+        paths, _ = _resolve_filter_and_expand_paths([tmp_path], None, None, platform_adapter=CursorAdapter())
+
+        assert paths == [valid_rule]
+
+    def test_claude_custom_filter_excludes_non_adapter_markdown(self, tmp_path: Path) -> None:
+        agent = tmp_path / "agents" / "agent.md"
+        agent.parent.mkdir()
+        agent.write_text("# Agent\n")
+        note = tmp_path / "docs" / "note.md"
+        note.parent.mkdir()
+        note.write_text("# Note\n")
+
+        paths, _ = _resolve_filter_and_expand_paths([tmp_path], "**/*.md", None, platform_adapter=ClaudeCodeAdapter())
+
+        assert paths == [agent]
+
     def test_filter_type_resolves_to_glob(self, tmp_path: Path) -> None:
         """_resolve_filter_and_expand_paths resolves --filter-type to glob pattern.
 

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from skilllint.adapters.claude_code import ClaudeCodeAdapter
 from skilllint.adapters.codex import CodexAdapter
 from skilllint.adapters.cursor import CursorAdapter
 from skilllint.scan_runtime import (
@@ -407,6 +408,26 @@ class TestResolveFilterAndExpandPaths:
 
         assert paths == [custom_file]
         assert is_batch is True
+
+    def test_claude_platform_preserves_direct_skill_folder(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "direct-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("---\ndescription: Direct skill\n---\n# Direct\n")
+
+        paths, _ = _resolve_filter_and_expand_paths([skill_dir], None, None, platform_adapter=ClaudeCodeAdapter())
+
+        assert paths == [skill_dir]
+
+    def test_claude_platform_preserves_skills_from_parent_directory(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "plugins" / "example" / "skills" / "nested-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: Nested skill\n---\n# Nested\n")
+
+        paths, _ = _resolve_filter_and_expand_paths(
+            [tmp_path / "plugins"], None, None, platform_adapter=ClaudeCodeAdapter()
+        )
+
+        assert paths == [skill_dir]
 
     def test_filter_type_resolves_to_glob(self, tmp_path: Path) -> None:
         """_resolve_filter_and_expand_paths resolves --filter-type to glob pattern.

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -520,6 +520,30 @@ class TestResolveFilterAndExpandPaths:
 
         assert paths == [skill_dir]
 
+    @pytest.mark.parametrize(("adapter", "provider"), [(CodexAdapter(), ".agents"), (CursorAdapter(), ".cursor")])
+    def test_platform_filter_type_skills_does_not_double_normalize_skill_target(
+        self, tmp_path: Path, adapter: PlatformAdapter, provider: str
+    ) -> None:
+        skill_dir = tmp_path / provider / "skills" / "skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: Skill\n---\n# Skill\n")
+
+        paths, _ = _resolve_filter_and_expand_paths([tmp_path / provider], None, "skills", platform_adapter=adapter)
+
+        assert paths == [skill_dir]
+
+    def test_claude_custom_filter_collapses_supporting_markdown_to_skill_target(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / ".claude" / "skills" / "skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: Skill\n---\n# Skill\n")
+        (skill_dir / "notes.md").write_text("# Supporting notes\n")
+
+        paths, _ = _resolve_filter_and_expand_paths(
+            [tmp_path / ".claude"], "**/*.md", None, platform_adapter=ClaudeCodeAdapter()
+        )
+
+        assert paths == [skill_dir]
+
     @pytest.mark.parametrize(("adapter", "filename"), [(CursorAdapter(), "rule.mdc"), (CodexAdapter(), "rule.rules")])
     def test_platform_includes_root_provider_file(
         self, tmp_path: Path, adapter: PlatformAdapter, filename: str

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -619,6 +619,26 @@ class TestResolveFilterAndExpandPaths:
 
         assert paths == [tmp_path]
 
+    def test_claude_filtered_scan_excludes_foreign_provider_agent(self, tmp_path: Path) -> None:
+        foreign_agent = tmp_path / ".agents" / "agents" / "team" / "foreign.md"
+        foreign_agent.parent.mkdir(parents=True)
+        foreign_agent.write_text("# Foreign\n")
+
+        paths, _ = _resolve_filter_and_expand_paths([tmp_path], "**/*.md", None, platform_adapter=ClaudeCodeAdapter())
+
+        assert paths == []
+
+    def test_claude_filtered_scan_preserves_marketplace_only_root(self, tmp_path: Path) -> None:
+        marketplace = tmp_path / ".claude-plugin" / "marketplace.json"
+        marketplace.parent.mkdir()
+        marketplace.write_text('{"name": "marketplace"}')
+
+        paths, _ = _resolve_filter_and_expand_paths(
+            [tmp_path], "**/marketplace.json", None, platform_adapter=ClaudeCodeAdapter()
+        )
+
+        assert paths == [tmp_path]
+
     def test_claude_platform_preserves_root_claude_file(self, tmp_path: Path) -> None:
         claude_file = tmp_path / "CLAUDE.md"
         claude_file.write_text("# Claude\n")

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -448,6 +448,19 @@ class TestResolveFilterAndExpandPaths:
 
         assert paths == [plugin_dir, agent, command, skill_dir]
 
+    def test_claude_platform_preserves_manifest_declared_custom_agent_path(self, tmp_path: Path) -> None:
+        plugin_dir = tmp_path / "plugin"
+        manifest = plugin_dir / ".claude-plugin" / "plugin.json"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text('{"agents": ["custom/reviewer.md"]}')
+        reviewer = plugin_dir / "custom" / "reviewer.md"
+        reviewer.parent.mkdir()
+        reviewer.write_text("# Reviewer\n")
+
+        paths, _ = _resolve_filter_and_expand_paths([plugin_dir], None, None, platform_adapter=ClaudeCodeAdapter())
+
+        assert paths == [plugin_dir, reviewer]
+
     @pytest.mark.parametrize(
         ("filter_type", "expected_name"),
         [("skills", "nested-skill"), ("agents", "agent.md"), ("commands", "command.md")],

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -482,6 +482,18 @@ class TestResolveFilterAndExpandPaths:
 
         assert paths == [skill_dir]
 
+    @pytest.mark.parametrize(("adapter", "provider"), [(CodexAdapter(), ".agents"), (CursorAdapter(), ".cursor")])
+    def test_platform_preserves_provider_prefix_for_direct_skill_folder(
+        self, tmp_path: Path, adapter: PlatformAdapter, provider: str
+    ) -> None:
+        skill_dir = tmp_path / provider / "skills" / "direct-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: Direct skill\n---\n# Direct\n")
+
+        paths, _ = _resolve_filter_and_expand_paths([skill_dir], None, None, platform_adapter=adapter)
+
+        assert paths == [skill_dir]
+
     @pytest.mark.parametrize(("adapter", "filename"), [(CursorAdapter(), "rule.mdc"), (CodexAdapter(), "rule.rules")])
     def test_platform_includes_root_provider_file(
         self, tmp_path: Path, adapter: PlatformAdapter, filename: str

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -520,6 +520,23 @@ class TestResolveFilterAndExpandPaths:
 
         assert paths == [skill_dir]
 
+    @pytest.mark.parametrize(
+        ("adapter", "provider", "native_filename"),
+        [(CodexAdapter(), ".agents", "rule.rules"), (CursorAdapter(), ".cursor", "rule.mdc")],
+    )
+    def test_platform_preserves_native_rule_files_inside_skills(
+        self, tmp_path: Path, adapter: PlatformAdapter, provider: str, native_filename: str
+    ) -> None:
+        skill_dir = tmp_path / provider / "skills" / "skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: Skill\n---\n# Skill\n")
+        native_rule = skill_dir / native_filename
+        native_rule.write_text("# Native rule\n")
+
+        paths, _ = _resolve_filter_and_expand_paths([tmp_path / provider], None, None, platform_adapter=adapter)
+
+        assert paths == [skill_dir, native_rule]
+
     @pytest.mark.parametrize(("adapter", "provider"), [(CodexAdapter(), ".agents"), (CursorAdapter(), ".cursor")])
     def test_platform_filter_type_skills_does_not_double_normalize_skill_target(
         self, tmp_path: Path, adapter: PlatformAdapter, provider: str
@@ -540,6 +557,35 @@ class TestResolveFilterAndExpandPaths:
 
         paths, _ = _resolve_filter_and_expand_paths(
             [tmp_path / ".claude"], "**/*.md", None, platform_adapter=ClaudeCodeAdapter()
+        )
+
+        assert paths == [skill_dir]
+
+    def test_claude_bare_scan_excludes_other_provider_skills(self, tmp_path: Path) -> None:
+        claude_skill = tmp_path / ".claude" / "skills" / "claude-skill"
+        codex_skill = tmp_path / ".agents" / "skills" / "codex-skill"
+        cursor_skill = tmp_path / ".cursor" / "skills" / "cursor-skill"
+        for skill_dir in (claude_skill, codex_skill, cursor_skill):
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text("---\ndescription: Skill\n---\n# Skill\n")
+
+        paths, _ = _resolve_filter_and_expand_paths([tmp_path], None, None, platform_adapter=ClaudeCodeAdapter())
+
+        assert paths == [claude_skill]
+
+    def test_claude_plugin_custom_filter_excludes_documentation(self, tmp_path: Path) -> None:
+        plugin_root = tmp_path / "plugin"
+        (plugin_root / ".claude-plugin").mkdir(parents=True)
+        (plugin_root / ".claude-plugin" / "plugin.json").write_text('{"name": "plugin"}')
+        skill_dir = plugin_root / "skills" / "skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: Skill\n---\n# Skill\n")
+        docs_note = plugin_root / "docs" / "note.md"
+        docs_note.parent.mkdir()
+        docs_note.write_text("# Documentation\n")
+
+        paths, _ = _resolve_filter_and_expand_paths(
+            [plugin_root], "**/*.md", None, platform_adapter=ClaudeCodeAdapter()
         )
 
         assert paths == [skill_dir]

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -525,6 +525,7 @@ class TestResolveFilterAndExpandPaths:
         manifest = plugin_dir / ".claude-plugin" / "plugin.json"
         manifest.parent.mkdir(parents=True)
         manifest.write_text('{"skills": ["custom/missing-skill"]}')
+        (plugin_dir / "custom" / "missing-skill").mkdir(parents=True)
 
         paths, _ = _resolve_filter_and_expand_paths([plugin_dir], None, "skills", platform_adapter=ClaudeCodeAdapter())
 

--- a/packages/skilllint/tests/test_scan_runtime.py
+++ b/packages/skilllint/tests/test_scan_runtime.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from skilllint.adapters import PlatformAdapter
 from skilllint.adapters.claude_code import ClaudeCodeAdapter
 from skilllint.adapters.codex import CodexAdapter
 from skilllint.adapters.cursor import CursorAdapter
@@ -468,6 +469,18 @@ class TestResolveFilterAndExpandPaths:
         paths, _ = _resolve_filter_and_expand_paths([root], None, filter_type, platform_adapter=ClaudeCodeAdapter())
 
         assert paths == [next(path for path in (skill_dir, agent, command) if path.name == expected_name)]
+
+    @pytest.mark.parametrize(("adapter", "provider"), [(CodexAdapter(), ".agents"), (CursorAdapter(), ".cursor")])
+    def test_platform_preserves_provider_prefix_for_nested_skill_folder(
+        self, tmp_path: Path, adapter: PlatformAdapter, provider: str
+    ) -> None:
+        skill_dir = tmp_path / provider / "skills" / "nested-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\ndescription: Nested skill\n---\n# Nested\n")
+
+        paths, _ = _resolve_filter_and_expand_paths([tmp_path / provider], None, None, platform_adapter=adapter)
+
+        assert paths == [skill_dir]
 
     def test_filter_type_resolves_to_glob(self, tmp_path: Path) -> None:
         """_resolve_filter_and_expand_paths resolves --filter-type to glob pattern.

--- a/scripts/assert_action_contract.py
+++ b/scripts/assert_action_contract.py
@@ -23,6 +23,9 @@ def main() -> int:
     missing_findings = [finding for finding in expected_findings if finding not in action_findings]
     if missing_findings:
         failures.append(f"findings: missing {missing_findings!r}, got {os.environ['ACTION_FINDINGS']!r}")
+    unexpected_findings = sorted(action_findings - set(expected_findings))
+    if unexpected_findings:
+        failures.append(f"findings: unexpected {unexpected_findings!r}, got {os.environ['ACTION_FINDINGS']!r}")
     expected_python = f"Python {os.environ['EXPECTED_PYTHON_VERSION']}"
     if not os.environ["ACTION_TOOL_PYTHON"].startswith(expected_python):
         failures.append(f"tool Python: expected {expected_python!r}, got {os.environ['ACTION_TOOL_PYTHON']!r}")

--- a/scripts/assert_action_contract.py
+++ b/scripts/assert_action_contract.py
@@ -18,9 +18,11 @@ def main() -> int:
         for name, actual, expected in checks
         if os.environ[actual] != os.environ[expected]
     ]
-    expected_finding = os.environ["EXPECTED_FINDING"]
-    if expected_finding and expected_finding not in os.environ["ACTION_FINDINGS"].split():
-        failures.append(f"finding: expected {expected_finding!r}, got {os.environ['ACTION_FINDINGS']!r}")
+    expected_findings = os.environ["EXPECTED_FINDING"].split()
+    action_findings = set(os.environ["ACTION_FINDINGS"].split())
+    missing_findings = [finding for finding in expected_findings if finding not in action_findings]
+    if missing_findings:
+        failures.append(f"findings: missing {missing_findings!r}, got {os.environ['ACTION_FINDINGS']!r}")
     expected_python = f"Python {os.environ['EXPECTED_PYTHON_VERSION']}"
     if not os.environ["ACTION_TOOL_PYTHON"].startswith(expected_python):
         failures.append(f"tool Python: expected {expected_python!r}, got {os.environ['ACTION_TOOL_PYTHON']!r}")

--- a/scripts/assert_action_contract.py
+++ b/scripts/assert_action_contract.py
@@ -1,0 +1,37 @@
+"""Assert the composite Action's outputs and installed tool runtime."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> int:
+    """Return zero only when the Action environment matches its expected contract."""
+    checks = (
+        ("result", "ACTION_RESULT", "EXPECTED_RESULT"),
+        ("exit code", "ACTION_EXIT_CODE", "EXPECTED_EXIT_CODE"),
+        ("inspected count", "ACTION_INSPECTED_COUNT", "EXPECTED_INSPECTED_COUNT"),
+    )
+    failures = [
+        f"{name}: expected {os.environ[expected]!r}, got {os.environ[actual]!r}"
+        for name, actual, expected in checks
+        if os.environ[actual] != os.environ[expected]
+    ]
+    expected_finding = os.environ["EXPECTED_FINDING"]
+    if expected_finding and expected_finding not in os.environ["ACTION_FINDINGS"].split():
+        failures.append(f"finding: expected {expected_finding!r}, got {os.environ['ACTION_FINDINGS']!r}")
+    expected_python = f"Python {os.environ['EXPECTED_PYTHON_VERSION']}"
+    if not os.environ["ACTION_TOOL_PYTHON"].startswith(expected_python):
+        failures.append(f"tool Python: expected {expected_python!r}, got {os.environ['ACTION_TOOL_PYTHON']!r}")
+    expected_version = os.environ["EXPECTED_PACKAGE_VERSION"]
+    if not os.environ["ACTION_TOOL_VERSION"].endswith(expected_version):
+        failures.append(f"tool version: expected {expected_version!r}, got {os.environ['ACTION_TOOL_VERSION']!r}")
+    if failures:
+        print("\n".join(failures), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/assert_action_contract.py
+++ b/scripts/assert_action_contract.py
@@ -30,6 +30,7 @@ def main() -> int:
     if failures:
         print("\n".join(failures), file=sys.stderr)
         return 1
+    print(f"case={os.environ['CASE']} result={os.environ['ACTION_RESULT']} exit-code={os.environ['ACTION_EXIT_CODE']}")
     return 0
 
 

--- a/scripts/assert_action_contract.py
+++ b/scripts/assert_action_contract.py
@@ -29,8 +29,8 @@ def main() -> int:
     expected_python = f"Python {os.environ['EXPECTED_PYTHON_VERSION']}"
     if not os.environ["ACTION_TOOL_PYTHON"].startswith(expected_python):
         failures.append(f"tool Python: expected {expected_python!r}, got {os.environ['ACTION_TOOL_PYTHON']!r}")
-    expected_version = os.environ["EXPECTED_PACKAGE_VERSION"]
-    if not os.environ["ACTION_TOOL_VERSION"].endswith(expected_version):
+    expected_version = f"skilllint {os.environ['EXPECTED_PACKAGE_VERSION']}"
+    if os.environ["ACTION_TOOL_VERSION"] != expected_version:
         failures.append(f"tool version: expected {expected_version!r}, got {os.environ['ACTION_TOOL_VERSION']!r}")
     if failures:
         print("\n".join(failures), file=sys.stderr)

--- a/tests/fixtures/action/agents/warning-agent.md
+++ b/tests/fixtures/action/agents/warning-agent.md
@@ -1,0 +1,7 @@
+---
+name: warning-agent
+description: Use this agent when testing Action warning outcomes
+skills: 7
+---
+
+Follow the supplied task.

--- a/tests/fixtures/action/skills/fixable-skill/SKILL.md
+++ b/tests/fixtures/action/skills/fixable-skill/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: fixable-skill
+description: |
+  Exercise grouped Action fix findings.
+tools: [Read]
+---
+Follow the supplied task.

--- a/tests/test_action_metadata.py
+++ b/tests/test_action_metadata.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ACTION_FILE = Path(__file__).parents[1] / "action.yml"
+
+
+def test_action_reports_tool_python_from_uv_tool_environment() -> None:
+    action = ACTION_FILE.read_text(encoding="utf-8")
+
+    assert "uv tool list --show-python" in action
+    assert "command -v skilllint" not in action
+
+
+def test_empty_platform_description_names_matching_adapters() -> None:
+    action = ACTION_FILE.read_text(encoding="utf-8")
+
+    assert "When omitted, validates each selected file with every matching platform adapter." in action

--- a/tests/test_action_metadata.py
+++ b/tests/test_action_metadata.py
@@ -12,6 +12,13 @@ def test_action_reports_tool_python_from_uv_tool_environment() -> None:
     assert "command -v skilllint" not in action
 
 
+def test_action_reports_non_cpython_tool_runtime() -> None:
+    action = ACTION_FILE.read_text(encoding="utf-8")
+
+    assert "s/^CPython /Python /" in action
+    assert "[CPython " not in action
+
+
 def test_empty_platform_description_names_matching_adapters() -> None:
     action = ACTION_FILE.read_text(encoding="utf-8")
 

--- a/tests/test_action_metadata.py
+++ b/tests/test_action_metadata.py
@@ -22,3 +22,9 @@ def test_action_normalizes_crlf_before_reading_inspected_count() -> None:
     action = ACTION_FILE.read_text(encoding="utf-8")
 
     assert "tr -d '\\r'" in action
+
+
+def test_action_normalizes_crlf_before_counting_tokens_only_output() -> None:
+    action = ACTION_FILE.read_text(encoding="utf-8")
+
+    assert "grep -cE '^[0-9]+($|[[:blank:]])' <<< \"${NORMALIZED_OUTPUT}\"" in action

--- a/tests/test_action_metadata.py
+++ b/tests/test_action_metadata.py
@@ -16,3 +16,9 @@ def test_empty_platform_description_names_matching_adapters() -> None:
     action = ACTION_FILE.read_text(encoding="utf-8")
 
     assert "When omitted, validates each selected file with every matching platform adapter." in action
+
+
+def test_action_normalizes_crlf_before_reading_inspected_count() -> None:
+    action = ACTION_FILE.read_text(encoding="utf-8")
+
+    assert "tr -d '\\r'" in action

--- a/tests/test_assert_action_contract.py
+++ b/tests/test_assert_action_contract.py
@@ -52,3 +52,25 @@ def test_assert_action_contract_rejects_missing_expected_finding() -> None:
 
     assert result.returncode == 1
     assert "FM010" in result.stderr
+
+
+def test_assert_action_contract_accepts_all_expected_grouped_fix_codes() -> None:
+    environment = os.environ | {
+        "CASE": "warning",
+        "ACTION_RESULT": "passed",
+        "ACTION_EXIT_CODE": "0",
+        "ACTION_INSPECTED_COUNT": "1",
+        "ACTION_FINDINGS": "FM004 FM007",
+        "ACTION_TOOL_PYTHON": "Python 3.11.9",
+        "ACTION_TOOL_VERSION": "1.19.2",
+        "EXPECTED_RESULT": "passed",
+        "EXPECTED_EXIT_CODE": "0",
+        "EXPECTED_INSPECTED_COUNT": "1",
+        "EXPECTED_FINDING": "FM004 FM007",
+        "EXPECTED_PYTHON_VERSION": "3.11",
+        "EXPECTED_PACKAGE_VERSION": "1.19.2",
+    }
+
+    result = subprocess.run([sys.executable, SCRIPT], env=environment, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0, result.stderr

--- a/tests/test_assert_action_contract.py
+++ b/tests/test_assert_action_contract.py
@@ -54,6 +54,29 @@ def test_assert_action_contract_rejects_missing_expected_finding() -> None:
     assert "FM010" in result.stderr
 
 
+def test_assert_action_contract_rejects_unexpected_finding() -> None:
+    environment = os.environ | {
+        "CASE": "validation-error",
+        "ACTION_RESULT": "failed",
+        "ACTION_EXIT_CODE": "1",
+        "ACTION_INSPECTED_COUNT": "1",
+        "ACTION_FINDINGS": "FM010 ZZ999",
+        "ACTION_TOOL_PYTHON": "Python 3.11.9",
+        "ACTION_TOOL_VERSION": "1.19.2",
+        "EXPECTED_RESULT": "failed",
+        "EXPECTED_EXIT_CODE": "1",
+        "EXPECTED_INSPECTED_COUNT": "1",
+        "EXPECTED_FINDING": "FM010",
+        "EXPECTED_PYTHON_VERSION": "3.11",
+        "EXPECTED_PACKAGE_VERSION": "1.19.2",
+    }
+
+    result = subprocess.run([sys.executable, SCRIPT], env=environment, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 1
+    assert "unexpected" in result.stderr
+
+
 def test_assert_action_contract_accepts_all_expected_grouped_fix_codes() -> None:
     environment = os.environ | {
         "CASE": "warning",

--- a/tests/test_assert_action_contract.py
+++ b/tests/test_assert_action_contract.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "assert_action_contract.py"
+
+
+def test_assert_action_contract_accepts_matching_outcome() -> None:
+    environment = os.environ | {
+        "ACTION_RESULT": "passed",
+        "ACTION_EXIT_CODE": "0",
+        "ACTION_INSPECTED_COUNT": "1",
+        "ACTION_FINDINGS": "",
+        "ACTION_TOOL_PYTHON": "Python 3.11.9",
+        "ACTION_TOOL_VERSION": "1.19.2",
+        "EXPECTED_RESULT": "passed",
+        "EXPECTED_EXIT_CODE": "0",
+        "EXPECTED_INSPECTED_COUNT": "1",
+        "EXPECTED_FINDING": "",
+        "EXPECTED_PYTHON_VERSION": "3.11",
+        "EXPECTED_PACKAGE_VERSION": "1.19.2",
+    }
+
+    result = subprocess.run([sys.executable, SCRIPT], env=environment, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_assert_action_contract_rejects_missing_expected_finding() -> None:
+    environment = os.environ | {
+        "ACTION_RESULT": "failed",
+        "ACTION_EXIT_CODE": "1",
+        "ACTION_INSPECTED_COUNT": "1",
+        "ACTION_FINDINGS": "SK005",
+        "ACTION_TOOL_PYTHON": "Python 3.11.9",
+        "ACTION_TOOL_VERSION": "1.19.2",
+        "EXPECTED_RESULT": "failed",
+        "EXPECTED_EXIT_CODE": "1",
+        "EXPECTED_INSPECTED_COUNT": "1",
+        "EXPECTED_FINDING": "FM010",
+        "EXPECTED_PYTHON_VERSION": "3.11",
+        "EXPECTED_PACKAGE_VERSION": "1.19.2",
+    }
+
+    result = subprocess.run([sys.executable, SCRIPT], env=environment, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 1
+    assert "FM010" in result.stderr

--- a/tests/test_assert_action_contract.py
+++ b/tests/test_assert_action_contract.py
@@ -10,6 +10,7 @@ SCRIPT = Path(__file__).parents[1] / "scripts" / "assert_action_contract.py"
 
 def test_assert_action_contract_accepts_matching_outcome() -> None:
     environment = os.environ | {
+        "CASE": "clean",
         "ACTION_RESULT": "passed",
         "ACTION_EXIT_CODE": "0",
         "ACTION_INSPECTED_COUNT": "1",
@@ -27,10 +28,12 @@ def test_assert_action_contract_accepts_matching_outcome() -> None:
     result = subprocess.run([sys.executable, SCRIPT], env=environment, capture_output=True, text=True, check=False)
 
     assert result.returncode == 0, result.stderr
+    assert result.stdout == "case=clean result=passed exit-code=0\n"
 
 
 def test_assert_action_contract_rejects_missing_expected_finding() -> None:
     environment = os.environ | {
+        "CASE": "validation-error",
         "ACTION_RESULT": "failed",
         "ACTION_EXIT_CODE": "1",
         "ACTION_INSPECTED_COUNT": "1",

--- a/tests/test_assert_action_contract.py
+++ b/tests/test_assert_action_contract.py
@@ -16,7 +16,7 @@ def test_assert_action_contract_accepts_matching_outcome() -> None:
         "ACTION_INSPECTED_COUNT": "1",
         "ACTION_FINDINGS": "",
         "ACTION_TOOL_PYTHON": "Python 3.11.9",
-        "ACTION_TOOL_VERSION": "1.19.2",
+        "ACTION_TOOL_VERSION": "skilllint 1.19.2",
         "EXPECTED_RESULT": "passed",
         "EXPECTED_EXIT_CODE": "0",
         "EXPECTED_INSPECTED_COUNT": "1",
@@ -39,7 +39,7 @@ def test_assert_action_contract_rejects_missing_expected_finding() -> None:
         "ACTION_INSPECTED_COUNT": "1",
         "ACTION_FINDINGS": "SK005",
         "ACTION_TOOL_PYTHON": "Python 3.11.9",
-        "ACTION_TOOL_VERSION": "1.19.2",
+        "ACTION_TOOL_VERSION": "skilllint 1.19.2",
         "EXPECTED_RESULT": "failed",
         "EXPECTED_EXIT_CODE": "1",
         "EXPECTED_INSPECTED_COUNT": "1",
@@ -77,6 +77,29 @@ def test_assert_action_contract_rejects_unexpected_finding() -> None:
     assert "unexpected" in result.stderr
 
 
+def test_assert_action_contract_rejects_version_suffix_match() -> None:
+    environment = os.environ | {
+        "CASE": "clean",
+        "ACTION_RESULT": "passed",
+        "ACTION_EXIT_CODE": "0",
+        "ACTION_INSPECTED_COUNT": "1",
+        "ACTION_FINDINGS": "",
+        "ACTION_TOOL_PYTHON": "Python 3.11.9",
+        "ACTION_TOOL_VERSION": "skilllint 11.19.2",
+        "EXPECTED_RESULT": "passed",
+        "EXPECTED_EXIT_CODE": "0",
+        "EXPECTED_INSPECTED_COUNT": "1",
+        "EXPECTED_FINDING": "",
+        "EXPECTED_PYTHON_VERSION": "3.11",
+        "EXPECTED_PACKAGE_VERSION": "1.19.2",
+    }
+
+    result = subprocess.run([sys.executable, SCRIPT], env=environment, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 1
+    assert "tool version" in result.stderr
+
+
 def test_assert_action_contract_accepts_all_expected_grouped_fix_codes() -> None:
     environment = os.environ | {
         "CASE": "warning",
@@ -85,7 +108,7 @@ def test_assert_action_contract_accepts_all_expected_grouped_fix_codes() -> None
         "ACTION_INSPECTED_COUNT": "1",
         "ACTION_FINDINGS": "FM004 FM007",
         "ACTION_TOOL_PYTHON": "Python 3.11.9",
-        "ACTION_TOOL_VERSION": "1.19.2",
+        "ACTION_TOOL_VERSION": "skilllint 1.19.2",
         "EXPECTED_RESULT": "passed",
         "EXPECTED_EXIT_CODE": "0",
         "EXPECTED_INSPECTED_COUNT": "1",

--- a/tests/test_readme_action_examples.py
+++ b/tests/test_readme_action_examples.py
@@ -28,3 +28,10 @@ def test_action_examples_pin_package_version_separately_from_action_ref() -> Non
             if input_line.startswith("version: ")
         ]
         assert any(len(version) == 3 and all(part.isdigit() for part in version) for version in versions), lines[index]
+
+
+def test_action_outputs_table_documents_every_public_output() -> None:
+    readme = README.read_text(encoding="utf-8")
+
+    for output in ("result", "exit-code", "inspected-count", "findings", "tool-python", "tool-version"):
+        assert f"| `{output}` |" in readme

--- a/tests/test_readme_action_examples.py
+++ b/tests/test_readme_action_examples.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+README = Path(__file__).parents[1] / "README.md"
+ACTION_USE = "uses: bitflight-devops/skilllint@"
+
+
+def test_action_examples_pin_package_version_separately_from_action_ref() -> None:
+    lines = README.read_text(encoding="utf-8").splitlines()
+    action_lines = [index for index, line in enumerate(lines) if ACTION_USE in line]
+
+    assert action_lines
+    for index in action_lines:
+        with_index = index + 1
+        with_indent = len(lines[with_index]) - len(lines[with_index].lstrip())
+        assert lines[with_index].strip() == "with:"
+
+        input_lines = []
+        for line in lines[with_index + 1 :]:
+            if line and len(line) - len(line.lstrip()) <= with_indent:
+                break
+            input_lines.append(line.strip())
+
+        versions = [
+            input_line.removeprefix("version: ").strip('"').split(".")
+            for input_line in input_lines
+            if input_line.startswith("version: ")
+        ]
+        assert any(len(version) == 3 and all(part.isdigit() for part in version) for version in versions), lines[index]


### PR DESCRIPTION
Part of #242.

Binds `uv tool install` to the requested Python and adds real composite-Action outcome coverage for clean, warning-only, zero-selected, validation, and usage-error paths.