### PR TITLE
fix(cache): preserve same-minute refresh history

### DIFF
--- a/packages/skilllint/tests/test_vendor_cache.py
+++ b/packages/skilllint/tests/test_vendor_cache.py
@@ -540,6 +540,32 @@ class TestFetchOrCachedStale:
         assert result.path.name == "history-gap-2026-09-10-0036-3.md"
         assert find_latest("history-gap", sources_dir=tmp_path) == result.path
 
+    def test_fetch_or_cached_allocates_after_suffix_when_same_minute_base_is_missing(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        mocker.patch("skilllint.vendor_cache.SOURCES_DIR", tmp_path)
+        fixed_time = datetime(2026, 9, 10, 0, 36, tzinfo=UTC)
+        mock_datetime = mocker.patch("skilllint.vendor_cache.datetime")
+        mock_datetime.now.return_value = fixed_time
+        mock_datetime.fromisoformat.side_effect = datetime.fromisoformat
+        url = "https://example.com/docs/history-gap-missing-base.md"
+        old_path = _write_md(tmp_path, "history-gap-missing-base-2026-09-10-0036-2.md", "older suffix two")
+        _write_sidecar(
+            old_path,
+            url=url,
+            sha256=hashlib.sha256(b"older suffix two").hexdigest(),
+            byte_count=len(b"older suffix two"),
+            fetched_at="2026-01-01T00:00:00+00:00",
+        )
+        mocker.patch("skilllint.vendor_cache.fetch_url_text", return_value="new refresh")
+
+        result = fetch_or_cached(url)
+
+        assert result.status == CacheStatus.REFRESHED
+        assert result.path.name == "history-gap-missing-base-2026-09-10-0036-3.md"
+        assert result.path.read_text(encoding="utf-8") == "new refresh"
+        assert find_latest("history-gap-missing-base", sources_dir=tmp_path) == result.path
+
     def test_fetch_or_cached_returns_unchanged_when_content_identical(
         self, tmp_path: Path, mocker: MockerFixture
     ) -> None:

--- a/packages/skilllint/tests/test_vendor_cache.py
+++ b/packages/skilllint/tests/test_vendor_cache.py
@@ -494,7 +494,7 @@ class TestFetchOrCachedStale:
             url=url,
             sha256=hashlib.sha256(old_content.encode()).hexdigest(),
             byte_count=len(old_content.encode()),
-            fetched_at=_stale_fetched_at(),
+            fetched_at="2026-01-01T00:00:00+00:00",
         )
         mocker.patch("skilllint.vendor_cache.fetch_url_text", side_effect=[first_content, second_content])
 
@@ -510,6 +510,35 @@ class TestFetchOrCachedStale:
         assert first.path.read_text(encoding="utf-8") == first_content
         assert second.path.read_text(encoding="utf-8") == second_content
         assert find_latest("history", sources_dir=tmp_path) == second.path
+
+    def test_fetch_or_cached_allocates_after_existing_same_minute_suffix_gap(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        # Given
+        mocker.patch("skilllint.vendor_cache.SOURCES_DIR", tmp_path)
+        fixed_time = datetime(2026, 9, 10, 0, 36, tzinfo=UTC)
+        mock_datetime = mocker.patch("skilllint.vendor_cache.datetime")
+        mock_datetime.now.return_value = fixed_time
+        mock_datetime.fromisoformat.side_effect = datetime.fromisoformat
+        url = "https://example.com/docs/history-gap.md"
+        _write_md(tmp_path, "history-gap-2026-09-10-0036.md", "base")
+        old_path = _write_md(tmp_path, "history-gap-2026-09-10-0036-2.md", "older suffix two")
+        _write_sidecar(
+            old_path,
+            url=url,
+            sha256=hashlib.sha256(b"older suffix two").hexdigest(),
+            byte_count=len(b"older suffix two"),
+            fetched_at=_stale_fetched_at(),
+        )
+        mocker.patch("skilllint.vendor_cache.fetch_url_text", return_value="new refresh")
+
+        # When
+        result = fetch_or_cached(url)
+
+        # Then
+        assert result.status == CacheStatus.REFRESHED
+        assert result.path.name == "history-gap-2026-09-10-0036-3.md"
+        assert find_latest("history-gap", sources_dir=tmp_path) == result.path
 
     def test_fetch_or_cached_returns_unchanged_when_content_identical(
         self, tmp_path: Path, mocker: MockerFixture

--- a/packages/skilllint/tests/test_vendor_cache.py
+++ b/packages/skilllint/tests/test_vendor_cache.py
@@ -366,6 +366,67 @@ class TestFetchOrCachedFresh:
         assert result.path == md_path
         assert result.url == url
 
+    @pytest.mark.parametrize(
+        "invalid_fetched_at", ["not-a-timestamp", 1, "2026-01-01T00:00:00"], ids=["malformed", "wrong-type", "naive"]
+    )
+    def test_fetch_or_cached_refreshes_invalid_sidecar_timestamp(
+        self, tmp_path: Path, mocker: MockerFixture, invalid_fetched_at: str | int
+    ) -> None:
+        # Given
+        mocker.patch("skilllint.vendor_cache.SOURCES_DIR", tmp_path)
+        url = "https://example.com/docs/invalid-timestamp.md"
+        content = "# Cached\nSome content."
+        md_path = _write_md(tmp_path, "invalid-timestamp-2026-03-23-1000.md", content)
+        sidecar_path = _write_sidecar(
+            md_path,
+            url=url,
+            sha256=hashlib.sha256(content.encode()).hexdigest(),
+            byte_count=len(content.encode()),
+            fetched_at=_fresh_fetched_at(),
+        )
+        sidecar = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        sidecar["fetched_at"] = invalid_fetched_at
+        sidecar_path.write_text(json.dumps(sidecar), encoding="utf-8")
+        mock_fetch = mocker.patch("skilllint.vendor_cache.fetch_url_text", return_value=content)
+
+        # When
+        result = fetch_or_cached(url, ttl_hours=4.0)
+
+        # Then
+        mock_fetch.assert_called_once_with(url)
+        assert result.status == CacheStatus.UNCHANGED
+        assert result.path == md_path
+        assert (
+            datetime.fromisoformat(json.loads(sidecar_path.read_text(encoding="utf-8"))["fetched_at"]).tzinfo
+            is not None
+        )
+
+    def test_fetch_or_cached_refreshes_missing_sidecar_timestamp(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        # Given
+        mocker.patch("skilllint.vendor_cache.SOURCES_DIR", tmp_path)
+        url = "https://example.com/docs/missing-timestamp.md"
+        content = "# Cached\nSome content."
+        md_path = _write_md(tmp_path, "missing-timestamp-2026-03-23-1000.md", content)
+        sidecar_path = _write_sidecar(
+            md_path,
+            url=url,
+            sha256=hashlib.sha256(content.encode()).hexdigest(),
+            byte_count=len(content.encode()),
+            fetched_at=_fresh_fetched_at(),
+        )
+        sidecar = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        del sidecar["fetched_at"]
+        sidecar_path.write_text(json.dumps(sidecar), encoding="utf-8")
+        mock_fetch = mocker.patch("skilllint.vendor_cache.fetch_url_text", return_value=content)
+
+        # When
+        result = fetch_or_cached(url, ttl_hours=4.0)
+
+        # Then
+        mock_fetch.assert_called_once_with(url)
+        assert result.status == CacheStatus.UNCHANGED
+        assert result.path == md_path
+
 
 class TestFetchOrCachedStale:
     """Tests for fetch_or_cached — stale cache scenarios."""

--- a/packages/skilllint/tests/test_vendor_cache.py
+++ b/packages/skilllint/tests/test_vendor_cache.py
@@ -275,6 +275,17 @@ class TestFindLatest:
         assert result is not None
         assert result.name == "mypage-2026-01-01-1200.md"
 
+    def test_find_latest_prefers_collision_suffix_over_legacy_minute_name(self, tmp_path: Path) -> None:
+        # Given
+        _write_md(tmp_path, "mypage-2026-01-01-1200.md", "legacy")
+        collision = _write_md(tmp_path, "mypage-2026-01-01-1200-1.md", "newer")
+
+        # When
+        result = find_latest("mypage", sources_dir=tmp_path)
+
+        # Then
+        assert result == collision
+
     def test_find_latest_ignores_meta_json_files(self, tmp_path: Path) -> None:
         """find_latest ignores .meta.json sidecar files when scanning.
 
@@ -465,6 +476,40 @@ class TestFetchOrCachedStale:
         assert result.status == CacheStatus.REFRESHED
         assert result.path != md_path  # new timestamped file was written
         assert result.path.read_text(encoding="utf-8") == new_content
+
+    def test_fetch_or_cached_retains_changed_same_minute_refreshes(self, tmp_path: Path, mocker: MockerFixture) -> None:
+        # Given
+        mocker.patch("skilllint.vendor_cache.SOURCES_DIR", tmp_path)
+        fixed_time = datetime(2026, 9, 9, 12, 34, tzinfo=UTC)
+        mock_datetime = mocker.patch("skilllint.vendor_cache.datetime")
+        mock_datetime.now.return_value = fixed_time
+        mock_datetime.fromisoformat.side_effect = datetime.fromisoformat
+        url = "https://example.com/docs/history.md"
+        old_content = "# Old\n"
+        first_content = "# First\n"
+        second_content = "# Second\n"
+        old_path = _write_md(tmp_path, "history-2026-01-01-0000.md", old_content)
+        _write_sidecar(
+            old_path,
+            url=url,
+            sha256=hashlib.sha256(old_content.encode()).hexdigest(),
+            byte_count=len(old_content.encode()),
+            fetched_at=_stale_fetched_at(),
+        )
+        mocker.patch("skilllint.vendor_cache.fetch_url_text", side_effect=[first_content, second_content])
+
+        # When
+        first = fetch_or_cached(url)
+        second = fetch_or_cached(url, force=True)
+
+        # Then
+        assert first.status == CacheStatus.REFRESHED
+        assert second.status == CacheStatus.REFRESHED
+        assert first.path.name == "history-2026-09-09-1234.md"
+        assert second.path.name == "history-2026-09-09-1234-1.md"
+        assert first.path.read_text(encoding="utf-8") == first_content
+        assert second.path.read_text(encoding="utf-8") == second_content
+        assert find_latest("history", sources_dir=tmp_path) == second.path
 
     def test_fetch_or_cached_returns_unchanged_when_content_identical(
         self, tmp_path: Path, mocker: MockerFixture

--- a/packages/skilllint/tests/test_vendor_cache.py
+++ b/packages/skilllint/tests/test_vendor_cache.py
@@ -528,7 +528,7 @@ class TestFetchOrCachedStale:
             url=url,
             sha256=hashlib.sha256(b"older suffix two").hexdigest(),
             byte_count=len(b"older suffix two"),
-            fetched_at=_stale_fetched_at(),
+            fetched_at="2026-01-01T00:00:00+00:00",
         )
         mocker.patch("skilllint.vendor_cache.fetch_url_text", return_value="new refresh")
 

--- a/packages/skilllint/vendor_cache.py
+++ b/packages/skilllint/vendor_cache.py
@@ -227,6 +227,19 @@ def _age_hours(fetched_at_iso: str | None) -> float:
     return delta.total_seconds() / 3600.0
 
 
+def _collision_safe_path(page_name: str, directory: Path, timestamp: str) -> Path:
+    timestamped_path = directory / f"{page_name}-{timestamp}.md"
+    if not timestamped_path.exists():
+        return timestamped_path
+
+    collision = 1
+    while True:
+        candidate = directory / f"{page_name}-{timestamp}-{collision}.md"
+        if not candidate.exists():
+            return candidate
+        collision += 1
+
+
 # ---------------------------------------------------------------------------
 # Cache operations
 # ---------------------------------------------------------------------------
@@ -291,9 +304,9 @@ def find_latest(page_name: str, *, sources_dir: Path | None = None) -> Path | No
 
     Scans *sources_dir* (defaults to :data:`~skilllint.vendor_io.SOURCES_DIR`)
     for files matching ``{page_name}-*.md`` (excluding ``*.meta.json`` files).
-    Returns the path whose filename sorts lexicographically last (timestamps
-    in ``YYYY-MM-DD-HHMM`` format sort correctly by lexicographic order), or
-    ``None`` if no matches exist.
+    Returns the path with the newest minute timestamp and, for paths allocated
+    within the same minute, the highest collision suffix. Legacy minute-only
+    names remain readable. Returns ``None`` if no matches exist.
 
     Args:
         page_name: Filesystem-safe page name, as returned by
@@ -308,7 +321,14 @@ def find_latest(page_name: str, *, sources_dir: Path | None = None) -> Path | No
     candidates = [p for p in directory.glob(f"{page_name}-*.md") if not p.name.endswith(".meta.json")]
     if not candidates:
         return None
-    return max(candidates, key=lambda p: p.name)
+
+    def _sort_key(path: Path) -> tuple[str, int]:
+        stem = path.stem.removeprefix(f"{page_name}-")
+        timestamp = stem[:16]
+        suffix = stem[16:].removeprefix("-")
+        return timestamp, int(suffix) if suffix.isdecimal() else 0
+
+    return max(candidates, key=_sort_key)
 
 
 def fetch_or_cached(url: str, *, ttl_hours: float = 4.0, force: bool = False) -> CacheResult:
@@ -341,7 +361,8 @@ def fetch_or_cached(url: str, *, ttl_hours: float = 4.0, force: bool = False) ->
           - Network failure → raise :exc:`NoCacheError`.
 
     File naming convention: ``{page_name}-{YYYY-MM-DD-HHMM}.md`` inside
-    :data:`~skilllint.vendor_io.SOURCES_DIR`.
+    :data:`~skilllint.vendor_io.SOURCES_DIR`; same-minute collisions append a
+    numeric suffix.
 
     Args:
         url: URL of the documentation page to fetch.
@@ -365,7 +386,7 @@ def fetch_or_cached(url: str, *, ttl_hours: float = 4.0, force: bool = False) ->
         return datetime.now(UTC).strftime("%Y-%m-%d-%H%M")
 
     def _new_path() -> Path:
-        return SOURCES_DIR / f"{page_name}-{_timestamp()}.md"
+        return _collision_safe_path(page_name, SOURCES_DIR, _timestamp())
 
     if cached_path is not None:
         sidecar = load_sidecar(cached_path)

--- a/packages/skilllint/vendor_cache.py
+++ b/packages/skilllint/vendor_cache.py
@@ -229,21 +229,16 @@ def _age_hours(fetched_at_iso: str | None) -> float:
 
 def _collision_safe_path(page_name: str, directory: Path, timestamp: str) -> Path:
     timestamped_path = directory / f"{page_name}-{timestamp}.md"
-    if not timestamped_path.exists():
+    suffix_prefix = f"{page_name}-{timestamp}-"
+    suffixes = [
+        int(path.stem.removeprefix(suffix_prefix))
+        for path in directory.glob(f"{suffix_prefix}*.md")
+        if path.stem.removeprefix(suffix_prefix).isdecimal()
+    ]
+    if not timestamped_path.exists() and not suffixes:
         return timestamped_path
 
-    suffix_prefix = f"{page_name}-{timestamp}-"
-    collision = (
-        max(
-            (
-                int(path.stem.removeprefix(suffix_prefix))
-                for path in directory.glob(f"{suffix_prefix}*.md")
-                if path.stem.removeprefix(suffix_prefix).isdecimal()
-            ),
-            default=0,
-        )
-        + 1
-    )
+    collision = max(suffixes, default=0) + 1
     while True:
         candidate = directory / f"{page_name}-{timestamp}-{collision}.md"
         if not candidate.exists():

--- a/packages/skilllint/vendor_cache.py
+++ b/packages/skilllint/vendor_cache.py
@@ -232,7 +232,18 @@ def _collision_safe_path(page_name: str, directory: Path, timestamp: str) -> Pat
     if not timestamped_path.exists():
         return timestamped_path
 
-    collision = 1
+    suffix_prefix = f"{page_name}-{timestamp}-"
+    collision = (
+        max(
+            (
+                int(path.stem.removeprefix(suffix_prefix))
+                for path in directory.glob(f"{suffix_prefix}*.md")
+                if path.stem.removeprefix(suffix_prefix).isdecimal()
+            ),
+            default=0,
+        )
+        + 1
+    )
     while True:
         candidate = directory / f"{page_name}-{timestamp}-{collision}.md"
         if not candidate.exists():

--- a/packages/skilllint/vendor_cache.py
+++ b/packages/skilllint/vendor_cache.py
@@ -211,12 +211,16 @@ def _is_network_error(exc: Exception) -> bool:
     return isinstance(exc, (httpx.ConnectError, httpx.TimeoutException, httpx.HTTPError))
 
 
-def _age_hours(fetched_at_iso: str) -> float:
+def _age_hours(fetched_at_iso: str | None) -> float:
     """Return age in hours between *fetched_at_iso* and now (UTC)."""
+    if not isinstance(fetched_at_iso, str):
+        return float("inf")
     try:
         fetched_at = datetime.fromisoformat(fetched_at_iso)
     except (ValueError, TypeError):
         # Treat unparseable timestamps as maximally stale.
+        return float("inf")
+    if fetched_at.tzinfo is None or fetched_at.utcoffset() is None:
         return float("inf")
     now = datetime.now(UTC)
     delta = now - fetched_at
@@ -365,8 +369,10 @@ def fetch_or_cached(url: str, *, ttl_hours: float = 4.0, force: bool = False) ->
 
     if cached_path is not None:
         sidecar = load_sidecar(cached_path)
-        fetched_at = sidecar.get("fetched_at", "") if not force and sidecar else ""
-        if not force and _age_hours(fetched_at) < ttl_hours:
+        fetched_at = sidecar.get("fetched_at") if sidecar else None
+        age = _age_hours(fetched_at)
+
+        if not force and age < ttl_hours:
             return CacheResult(path=cached_path, status=CacheStatus.FRESH, page_name=page_name, url=url)
 
         # Stale — attempt refresh.


### PR DESCRIPTION
Part of #237.

Preserves changed same-minute cache history with collision suffixes while retaining legacy minute-name discovery and latest selection.