### PR TITLE
docs(cache): consolidate verified cache lifecycle and roots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,18 @@ Stale cache is served when the network is unavailable (`STALE` status, warning t
 
 ### Agent instructions
 
-Run `docs fetch` (above), then Read the file path it prints — never WebFetch or an MCP URL-reading tool. For large files, narrow with `docs sections` and `docs section` first.
+Before capturing a URL, inspect `.claude/vendor/{provider}/` for an equivalent
+authoritative Markdown or RST source from the maintained vendor clone. Read the
+matching path and section directly when it exists; this source-first check must
+not invoke URL capture. Record the path and section used. If no equivalent
+local source exists, run `uv run skilllint docs fetch URL` (or the standalone
+script above), then read the cache path printed on stdout. A rendered page may
+remain authoritative when Markdown/RST cannot represent the authority; capture
+that URL in that case. `fetch-authorities` is an on-demand URL operation and is
+used only after the same local-source check. Never use WebFetch or an MCP
+URL-reading tool to pull vendor documentation into context.
+
+For large cached files, narrow with `docs sections` and `docs section` first.
 
 ### Relationship to `fetch_platform_docs.py`
 

--- a/docs/vendor-cache.md
+++ b/docs/vendor-cache.md
@@ -37,7 +37,8 @@ CACHE_PATH="$(uv run skilllint docs fetch "https://example.com/guide.md")"
 # Existing file within the TTL: FRESH (no request)
 uv run skilllint docs fetch "https://example.com/guide.md"
 
-# Force a request. Identical text is UNCHANGED; changed text is REFRESHED.
+# Force a request. The current implementation reports NEW and writes the
+# fetched result; UNCHANGED/REFRESHED are stale (non-force) outcomes.
 uv run skilllint docs fetch "https://example.com/guide.md" --force
 
 # TTL is in hours. TTL 0 means attempt refresh on every call; successful text
@@ -55,7 +56,7 @@ Available` and prints no path.
 ## Query and verify
 
 ```bash
-LATEST_PATH="$(uv run skilllint docs latest "$(python -c 'from skilllint.vendor_io import derive_page_name; print(derive_page_name("https://example.com/guide.md"))')")"
+LATEST_PATH="$(uv run skilllint docs latest "$(python -c 'from skilllint.vendor_cache import derive_page_name; print(derive_page_name("https://example.com/guide.md"))')")"
 uv run skilllint docs sections "$LATEST_PATH"
 uv run skilllint docs section "$LATEST_PATH" "Usage"
 uv run skilllint docs verify "$LATEST_PATH"
@@ -65,23 +66,31 @@ uv run skilllint docs verify "$LATEST_PATH"
 code. `section` accepts heading text or its lowercase Markdown slug. `verify`
 returns `INTACT` (exit 0) when the file matches its sidecar; modified,
 missing, malformed, or incomplete metadata returns `MODIFIED` or
-`UNVERIFIABLE` (exit 1). An empty successful HTTP response is an unsuccessful
-fetch: with a cache it follows stale fallback, and without one it is a bounded
-failure rather than a false successful path.
+`UNVERIFIABLE` (exit 1). An empty successful HTTP response currently raises the
+cache fetcher's `ValueError`; it is not a successful path or stale fallback.
+Normal transport/HTTP failures with an existing cache return `STALE`;
+empty-response normalization is a separate implementation follow-up.
 
-To fetch every normalized rule authority URL after performing the source-first
-check for each provider:
+To fetch every normalized rule authority URL after independently performing the
+source-first check for each provider:
 
 ```bash
 uv run skilllint docs fetch-authorities
 ```
 
+`fetch-authorities` itself is an on-demand URL loop and cannot exclude a URL
+because a clone contains an equivalent file. Use the per-URL `fetch` recipe
+when the local-source sentinel must prove zero URL calls; this limitation is a
+separate product follow-up.
+
 ## Roots and retained history
 
 Source checkouts and linked worktrees share the project vendor root; tracked
-schema outputs remain worktree-local. Installed wheel and `uvx` invocations
-resolve their runtime cache owner from the invocation project/root contract,
-while a non-Git working directory falls back to that working directory. The
+schema outputs remain worktree-local. Because the runtime derives
+`PROJECT_ROOT` from the imported module, an installed wheel or `uvx` invocation
+currently places its cache under the installation environment, not the
+invocation project. A non-Git working directory uses the imported runtime's
+derived root as well. This installed-root behavior is a product follow-up; the
 standalone script is source-coupled to this checkout and uses the same cache
 implementation:
 

--- a/docs/vendor-cache.md
+++ b/docs/vendor-cache.md
@@ -1,0 +1,98 @@
+# Vendor documentation cache
+
+`skilllint docs` stores on-demand vendor pages under the project vendor cache
+and prints the selected path. The cache stores decoded response text encoded as
+UTF-8, with a JSON sidecar containing provenance, SHA-256, and byte count. The
+Markdown file and sidecar are separate writes; missing or partial pairs are
+detectable with `verify`, not atomic transactions.
+
+## Choose the source first
+
+Before capturing a URL, inspect `.claude/vendor/{provider}/` for an equivalent
+authoritative Markdown or RST file from the maintained vendor clone. Record the
+path and heading/section read. This local-source branch makes no URL request.
+When no equivalent source exists, capture the page and read the path printed by
+the existing command:
+
+```bash
+CACHE_PATH="$(uv run skilllint docs fetch "https://example.com/guide.md")"
+uv run skilllint docs sections "$CACHE_PATH"
+```
+
+The rendered page remains authoritative when its content cannot be represented
+by the clone's Markdown/RST. In that case URL capture is allowed. The
+`fetch-authorities` command is likewise an on-demand URL operation, after the
+same local-source check; it does not select clone content automatically.
+
+## Lifecycle recipe
+
+The following commands use a shell-captured path, so they do not depend on a
+timestamp or home directory. Status is written to stderr; the path and query
+content are written to stdout.
+
+```bash
+# First successful capture: NEW
+CACHE_PATH="$(uv run skilllint docs fetch "https://example.com/guide.md")"
+
+# Existing file within the TTL: FRESH (no request)
+uv run skilllint docs fetch "https://example.com/guide.md"
+
+# Force a request. Identical text is UNCHANGED; changed text is REFRESHED.
+uv run skilllint docs fetch "https://example.com/guide.md" --force
+
+# TTL is in hours. TTL 0 means attempt refresh on every call; successful text
+# is still cached. A failed refresh with a cache returns STALE.
+uv run skilllint docs fetch "https://example.com/guide.md" --ttl 0
+```
+
+`NEW` means no previous cache existed. `FRESH` serves the existing pair without
+network access. `UNCHANGED` keeps the existing path and repairs/touches its
+sidecar when fetched text is identical. `REFRESHED` writes a new cached version
+when text differs and retains the old version. `STALE` serves an existing pair
+when refresh fails. With no pair, a failed request exits 1 with `No Cache
+Available` and prints no path.
+
+## Query and verify
+
+```bash
+LATEST_PATH="$(uv run skilllint docs latest "$(python -c 'from skilllint.vendor_io import derive_page_name; print(derive_page_name("https://example.com/guide.md"))')")"
+uv run skilllint docs sections "$LATEST_PATH"
+uv run skilllint docs section "$LATEST_PATH" "Usage"
+uv run skilllint docs verify "$LATEST_PATH"
+```
+
+`sections` reports real Markdown headings and ignores headings inside fenced
+code. `section` accepts heading text or its lowercase Markdown slug. `verify`
+returns `INTACT` (exit 0) when the file matches its sidecar; modified,
+missing, malformed, or incomplete metadata returns `MODIFIED` or
+`UNVERIFIABLE` (exit 1). An empty successful HTTP response is an unsuccessful
+fetch: with a cache it follows stale fallback, and without one it is a bounded
+failure rather than a false successful path.
+
+To fetch every normalized rule authority URL after performing the source-first
+check for each provider:
+
+```bash
+uv run skilllint docs fetch-authorities
+```
+
+## Roots and retained history
+
+Source checkouts and linked worktrees share the project vendor root; tracked
+schema outputs remain worktree-local. Installed wheel and `uvx` invocations
+resolve their runtime cache owner from the invocation project/root contract,
+while a non-Git working directory falls back to that working directory. The
+standalone script is source-coupled to this checkout and uses the same cache
+implementation:
+
+```bash
+uv run --script scripts/fetch_doc_source.py fetch "https://example.com/guide.md"
+uv run --script scripts/fetch_doc_source.py latest "example--guide"
+uv run --script scripts/fetch_doc_source.py sections "$LATEST_PATH"
+uv run --script scripts/fetch_doc_source.py section "$LATEST_PATH" "Usage"
+uv run --script scripts/fetch_doc_source.py verify "$LATEST_PATH"
+```
+
+Do not infer source selection from a cache status: `FRESH` and `STALE` describe
+the cache response only, not whether a local clone was consulted. Keep older
+cache guides during this migration; they are retired in Todo 23.

--- a/docs/vendor-cache.md
+++ b/docs/vendor-cache.md
@@ -97,8 +97,8 @@ standalone script is source-coupled to this checkout and uses the same cache
 implementation:
 
 ```bash
-uv run --script scripts/fetch_doc_source.py fetch "https://example.com/guide.md"
-uv run --script scripts/fetch_doc_source.py latest "guide"
+FETCHED_PATH="$(uv run --script scripts/fetch_doc_source.py fetch "https://example.com/guide.md")"
+LATEST_PATH="$(uv run --script scripts/fetch_doc_source.py latest "guide")"
 uv run --script scripts/fetch_doc_source.py sections "$LATEST_PATH"
 uv run --script scripts/fetch_doc_source.py section "$LATEST_PATH" "Usage"
 uv run --script scripts/fetch_doc_source.py verify "$LATEST_PATH"

--- a/docs/vendor-cache.md
+++ b/docs/vendor-cache.md
@@ -65,9 +65,11 @@ uv run skilllint docs verify "$LATEST_PATH"
 `sections` reports real Markdown headings and ignores headings inside fenced
 code. `section` accepts heading text or its lowercase Markdown slug. `verify`
 returns `INTACT` (exit 0) when the file matches its sidecar; modified,
-missing, malformed, or incomplete metadata returns `MODIFIED` or
-`UNVERIFIABLE` (exit 1). An empty successful HTTP response currently raises the
-cache fetcher's `ValueError`; it is not a successful path or stale fallback.
+missing metadata returns `MODIFIED` or `UNVERIFIABLE` (exit 1). Wrong-shaped
+JSON sidecars are not a bounded status contract and may raise during cache
+ingest; use a valid object sidecar or remove it before retrying. An empty
+successful HTTP response currently raises the cache fetcher's `ValueError`; it
+is not a successful path or stale fallback.
 Normal transport/HTTP failures with an existing cache return `STALE`;
 empty-response normalization is a separate implementation follow-up.
 
@@ -96,7 +98,7 @@ implementation:
 
 ```bash
 uv run --script scripts/fetch_doc_source.py fetch "https://example.com/guide.md"
-uv run --script scripts/fetch_doc_source.py latest "example--guide"
+uv run --script scripts/fetch_doc_source.py latest "guide"
 uv run --script scripts/fetch_doc_source.py sections "$LATEST_PATH"
 uv run --script scripts/fetch_doc_source.py section "$LATEST_PATH" "Usage"
 uv run --script scripts/fetch_doc_source.py verify "$LATEST_PATH"

--- a/packages/skilllint/tests/test_vendor_cache_docs.py
+++ b/packages/skilllint/tests/test_vendor_cache_docs.py
@@ -50,10 +50,10 @@ def test_adversarial_cache_outcomes_are_documented() -> None:
     text = _guide()
     for phrase in (
         "missing or partial pairs",
-        "malformed, or incomplete metadata",
+        "Wrong-shaped\nJSON",
         "fenced",
         "No Cache\nAvailable",
-        "empty successful HTTP response",
+        "empty\nsuccessful HTTP response",
         "decoded response text encoded as\nUTF-8",
     ):
         assert phrase in text

--- a/packages/skilllint/tests/test_vendor_cache_docs.py
+++ b/packages/skilllint/tests/test_vendor_cache_docs.py
@@ -18,6 +18,9 @@ def test_canonical_guide_and_commands_are_present() -> None:
     assert "scripts/fetch_doc_source.py" in text
     assert "--force" in text
     assert "--ttl 0" in text
+    assert "current implementation reports NEW" in text
+    assert "ValueError" in text
+    assert "cannot exclude a URL" in text
 
 
 def test_recipes_are_source_coupled_to_public_implementation() -> None:
@@ -32,6 +35,7 @@ def test_recipes_are_source_coupled_to_public_implementation() -> None:
         assert symbol in cli
         assert symbol in script
     assert re.search(r"uv run --script scripts/fetch_doc_source\.py fetch", text)
+    assert "from skilllint.vendor_cache import derive_page_name" in text
 
 
 def test_source_first_policy_has_network_sentinel_contract() -> None:

--- a/packages/skilllint/tests/test_vendor_cache_docs.py
+++ b/packages/skilllint/tests/test_vendor_cache_docs.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+GUIDE = Path(__file__).parents[3] / "docs" / "vendor-cache.md"
+
+
+def _guide() -> str:
+    return GUIDE.read_text(encoding="utf-8")
+
+
+def test_canonical_guide_and_commands_are_present() -> None:
+    text = _guide()
+    assert text.startswith("# Vendor documentation cache\n")
+    for command in ("fetch", "fetch-authorities", "latest", "sections", "section", "verify"):
+        assert f"skilllint docs {command}" in text
+    assert "scripts/fetch_doc_source.py" in text
+    assert "--force" in text
+    assert "--ttl 0" in text
+
+
+def test_recipes_are_source_coupled_to_public_implementation() -> None:
+    text = _guide()
+    source = (Path(__file__).parents[1] / "vendor_cache.py").read_text(encoding="utf-8")
+    cli = (Path(__file__).parents[1] / "cli_docs.py").read_text(encoding="utf-8")
+    script = (GUIDE.parents[1] / "scripts" / "fetch_doc_source.py").read_text(encoding="utf-8")
+    for status in ("NEW", "FRESH", "UNCHANGED", "REFRESHED", "STALE"):
+        assert status in text
+        assert status in source
+    for symbol in ("fetch_or_cached", "find_latest", "format_section_index", "read_section", "verify_integrity"):
+        assert symbol in cli
+        assert symbol in script
+    assert re.search(r"uv run --script scripts/fetch_doc_source\.py fetch", text)
+
+
+def test_source_first_policy_has_network_sentinel_contract() -> None:
+    text = _guide()
+    assert ".claude/vendor/{provider}/" in text
+    assert "no URL request" in text
+    assert "does not select clone content automatically" in text
+    assert "fetch-authorities` command is likewise an on-demand URL operation" in text
+
+
+def test_adversarial_cache_outcomes_are_documented() -> None:
+    text = _guide()
+    for phrase in (
+        "missing or partial pairs",
+        "malformed, or incomplete metadata",
+        "fenced",
+        "No Cache\nAvailable",
+        "empty successful HTTP response",
+        "decoded response text encoded as\nUTF-8",
+    ):
+        assert phrase in text


### PR DESCRIPTION
## Summary
- add canonical vendor-cache lifecycle and query guide
- document clone-first source selection and on-demand URL fallback
- add source-coupled guide contracts

## Scope
Documentation and documentation tests only. Existing cache guides remain for Todo 23; cache implementation and bulk sync are unchanged.

## Verification
- focused guide tests: 4 passed
- `uv run prek run --all-files`: passed
- full `uv run pytest`: 1598 passed, 33 skipped; one unrelated flaky Hypothesis deadline failure in `packages/skilllint/tests/test_hooks_json_ingest.py::test_arbitrary_hooks_mapping_round_trips` (deadline exceeded on one run)
- manual CLI/standalone help, sections, missing lookup, and malformed verify smoke passed

Resolves #265.