### PR TITLE
docs(usage): consolidate verified user and integration contracts

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -89,8 +89,7 @@ Ignore keys are path prefixes relative to their config root. An empty prefix
 matches every file below it; `skills/legacy` does not match a sibling such as
 `skills/legacy-old`. Invalid `thresholds` and `severity` values are diagnosed
 and the documented defaults are used; fix the config rather than relying on a
-fallback. See [`ignore-config.md`](ignore-config.md) for the complete ignore
-reference.
+fallback.
 
 ## GitHub Action
 
@@ -137,7 +136,7 @@ repos:
 
 `skilllint` checks without mutating files; `skilllint-fix` applies supported
 fixes and is idempotent. Use the hook's `exclude` for generated or vendored
-trees.
+trees. The broad by-file-type hook is intentionally omitted from this guide.
 
 ## Maintainer checks
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -89,7 +89,8 @@ Ignore keys are path prefixes relative to their config root. An empty prefix
 matches every file below it; `skills/legacy` does not match a sibling such as
 `skills/legacy-old`. Invalid `thresholds` and `severity` values are diagnosed
 and the documented defaults are used; fix the config rather than relying on a
-fallback. The configuration examples above are the complete supported shape.
+fallback. See [`ignore-config.md`](ignore-config.md) for the complete ignore
+reference.
 
 ## GitHub Action
 


### PR DESCRIPTION
## Summary
- add canonical install, CLI, policy, Action, and pre-commit usage guide
- add source-coupled executable CLI/config examples
- correct plugin activation and concrete platform check example

Todo 20 / SL-DOC. This is an issue-exempt documentation PR; it does not use `Part of`.

## Verification
- `uv run prek run --all-files` passed
- focused usage tests: 3 passed
- full pytest: 1596 passed, 33 skipped; benchmark extraction hit host `Errno 28` (no space left on device), recorded in task evidence

No merge requested.