### PR TITLE
docs(architecture): align maintainer and provenance contracts

### DIFF
--- a/docs/TYPING_POLICY.md
+++ b/docs/TYPING_POLICY.md
@@ -1,7 +1,7 @@
 # AI Engineering Policy: Strict Typing and Typed Boundaries in Python
 
 Version: 1.0
-Applies to: Python 3.11+
+Applies to: Python 3.11+ (3.11 is the repository baseline)
 Required libraries: [Pydantic](https://docs.pydantic.dev/), [Hypothesis](https://hypothesis.readthedocs.io/)
 
 ## 1. Purpose
@@ -111,7 +111,7 @@ Everywhere else:
 
 ### skilllint repository
 
-CI (`.github/workflows/test.yml`) and `.pre-commit-config.yaml` run Astral **`ty check`** on `packages/` (configuration: `pyproject.toml` → `[tool.ty.environment]` / `[tool.ty.src]`). Use `uv run ty check packages/` locally. **`[tool.mypy]`** (effectively excluded) and **`[tool.basedpyright]`** (`typeCheckingMode = "off"`) stay that way on purpose: **ty** is the single type gate; mypy and Pyright/basedpyright overlap it and would create conflicting diagnostics and repeated configuration work if left active.
+CI and the pre-commit configuration run Astral **`ty check`** on `packages/` (configured in `pyproject.toml`). Use `uv run ty check packages/` locally. This is the package-only type scope; repository gates are broader and include formatting, lint, shell, Markdown, workflow, and pytest checks. **`[tool.mypy]`** (effectively excluded) and **`[tool.basedpyright]`** (`typeCheckingMode = "off"`) stay that way on purpose: **ty** is the single type gate.
 
 ## 8. Pydantic Addendum
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,9 +16,10 @@ CLI (plugin_validator.main)
   -> reporting.ConsoleReporter or CIReporter
 ```
 
-`scan_runtime.detect_scan_context` classifies a directory as manifest, auto,
-structure, or bare. `_discover_validatable_paths` dispatches that classification
-to `_discover_plugin_paths` and the other discovery implementations. Omitting
+`scan_runtime.detect_scan_context` classifies a directory as `PLUGIN`, `PROVIDER`,
+or `BARE`. `_discover_validatable_paths` dispatches that classification to
+`_discover_plugin_paths` and the other discovery implementations, whose
+downstream logic selects manifest, auto, or structure discovery modes. Omitting
 `--platform` preserves the default compatibility route.
 An explicit platform selects a registered `PlatformAdapter`; explicit-platform
 validation is validation-only and does not apply fixes. Discovery selects

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,90 @@
+# Current architecture
+
+`skilllint` is a command-line validation pipeline. The public seam is the
+`skilllint check` command; the implementation is split into discovery,
+validation, rule registration, fixing, and reporting modules.
+
+## Runtime flow
+
+```text
+CLI (plugin_validator.main)
+  -> scan_runtime._resolve_filter_and_expand_paths
+  -> scan_runtime._discover_validatable_paths
+  -> plugin_validator.validate_file / validate_single_path
+  -> schema validators and registered rules
+  -> optional fixer, then revalidation
+  -> reporting.ConsoleReporter or CIReporter
+```
+
+`scan_runtime.detect_scan_context` classifies a directory as manifest, auto,
+structure, or bare. `_discover_validatable_paths` dispatches that classification
+to `_discover_plugin_paths` and the other discovery implementations. Omitting
+`--platform` preserves the default compatibility route.
+An explicit platform selects a registered `PlatformAdapter`; explicit-platform
+validation is validation-only and does not apply fixes. Discovery selects
+paths; an adapter does not replace the core validators.
+
+## Adapters and the extension seam
+
+`PlatformAdapter` in `packages/skilllint/adapters/protocol.py` is a structural
+interface with `id`, `path_patterns`, `applicable_rules`, `constraint_scopes`,
+and `validate`. `adapters.registry.load_adapters()` loads entry points from
+the `skilllint.adapters` group and instantiates them. A third-party adapter is
+therefore an adapter at this seam, not a change to the core validator.
+
+Adapters provide platform metadata and platform-specific fallback validation.
+For third-party adapters, non-`SKILL.md` files use the adapter's
+`validate(path)` route directly and do not run core validators; the bundled
+Claude adapter is the limited exception that enters the existing core pipeline
+for recognized paths. Adapters assign severity on finding dictionaries; the
+core interprets it into `ValidationResult`, applies fixer authorization, and
+owns reporter output. Adapter metadata or registration does not prove that a
+rule emits a finding: public fixture/CLI evidence is emitter proof.
+
+## Rules, ownership, severity, and provenance
+
+The `@skilllint_rule` decorator in `rule_registry.py` registers documentation,
+category, platform, severity, fixability, and optional authority metadata.
+`ValidatorOwnership` in `plugin_validator.py` records whether a validator is
+schema-backed or lint-owned. These are separate dimensions: ownership does
+not wire severity, and registry membership does not create an emitter.
+
+`skilllint rules` renders the active registry. `skilllint rule CODE` renders a
+single registered rule. PR001, PR002, and PR005 are active public-route rules:
+PR001 warns only for unregistered agents/commands (not additive skills), PR002
+reports an error for missing registered component targets using accepted file,
+directory, root, and `./` shapes, and PR005 is an informational recommendation
+for a command path that is also a skill directory. PR003, PR004, and SK009 are
+retired and must not appear in the active catalog/help.
+
+The maintained provenance chain is rule claim -> authority -> recorded
+extraction/locator -> comparison. The refresher currently has two claims: the
+fetched source changed, and the extracted claim matches the maintained value.
+A future LLM/general provenance pipeline is proposed only; it is not shipped.
+
+## Fixing and reporting
+
+`scan_runtime.run_validation_loop` orchestrates file iteration and sends
+resulting `FileResults` to the selected reporter. The
+`plugin_validator.validate_single_path` function owns per-path validation,
+fixer authorization, revalidation, and
+the distinction between a fixer and its reporting rule. Exit status is derived
+from resulting errors and usage/validation contracts, not adapter registration.
+
+## Maintainer map
+
+| Concern | Maintained seam | Proof |
+| --- | --- | --- |
+| path selection | `scan_runtime.py` | scan runtime tests |
+| platform metadata | `adapters/protocol.py`, `adapters/registry.py` | adapter protocol tests |
+| schema constraints | `schemas/`, schema validators | schema/frontmatter tests |
+| lint rules | `rules/`, `rule_registry.py` | rule fixture and CLI tests |
+| fix authorization | `plugin_validator.py` trigger map | fixer/revalidation tests |
+| output | `reporting.py` | reporter/CLI tests |
+
+The versioned Claude runtime contract remains evidence for the version named
+by its filename; it is not rewritten by this guide. Historical issue states are
+recorded as follows: #112 closes only at its accepted PR #187 boundary, #124
+remains the registration/emitter boundary until both proofs land, and #146
+supplies the schema locator and refresh outcomes. None implies a general
+enrollment system.

--- a/docs/design-markdown-link-conventions.md
+++ b/docs/design-markdown-link-conventions.md
@@ -1,5 +1,8 @@
 # Design: Markdown Link Conventions — Closing the Link-Validation Gap
 
+> Status: proposed design. Existing link helpers and implemented checks are
+> current; deferred rules and discovery changes below are not active contracts.
+
 Status: revised (post-adversarial-review)
 Author: python-cli-design-spec (architecture pass)
 Depends on: `packages/skilllint/rules/lk_series.py`, `packages/skilllint/plugin_validator.py`,

--- a/docs/design-rule-provenance-registry.md
+++ b/docs/design-rule-provenance-registry.md
@@ -1,5 +1,9 @@
 # Design: Rule Provenance Registry
 
+> Status: proposed design, with the implemented registry/locator subset
+> explicitly identified below. The multi-stage LLM pipeline in this document
+> is not shipped runtime behavior.
+
 ## 1. Problem Statement
 
 skilllint's rule catalogue is not fixed to the FM, HK, AS, and PA families -- run `skilllint rules` for the current set. Many rules assert constraints derived from upstream vendor documentation -- event type enumerations, hook type sets, field constraints, and naming rules. These constraints are hardcoded as Python literals disconnected from their upstream sources.

--- a/docs/maintainer-extension-guide.md
+++ b/docs/maintainer-extension-guide.md
@@ -1,437 +1,111 @@
-# Maintainer Extension Guide
+# Maintainer extension guide
 
-This guide explains how to extend skilllint with new schemas, provider adapters, lint rules, and provenance metadata. Use this when adding support for a new AI coding platform or enhancing validation capabilities.
+This guide describes the current extension seams. Read the interface and its
+tests before adding an adapter, schema claim, or rule.
 
-## Where Does This Belong?
+## Choose the seam
 
-Before implementing, determine which extension path applies:
+| Need | Add | Owner |
+| --- | --- | --- |
+| provider metadata or fallback validation | `adapters/<provider>/` plus an entry point | `PlatformAdapter` |
+| schema-backed shape/type constraint | versioned provider schema | schema validators |
+| cross-platform quality rule | `rules/<series>_series.py` and decorator | rule registry + rule emitter |
+| traceability for a checkable claim | authority metadata or provenance registry entry | claim locator |
 
-| Your Goal | Extension Path | Key Files |
-|-----------|---------------|-----------|
-| **Schema-backed shape/type validation** | Schema JSON + `ValidatorOwnership.SCHEMA` | `packages/skilllint/schemas/<provider>/vN.json` |
-| **Provider-specific behavior** | Adapter in `adapters/<provider>/` + registry | `packages/skilllint/adapters/<provider>/` |
-| **Cross-platform quality/style rule** | Rule in `rules/` + `ValidatorOwnership.LINT` | `packages/skilllint/rules/` |
-| **Traceability metadata** | `authority` dict in schema or rule | Schema top-level key, rule decorator |
+Do not add an adapter for a rule that belongs to the core validator. Do not
+declare a rule complete because a decorator, catalog row, or entry point exists;
+the public fixture/CLI path must emit the finding.
 
----
+## Add an adapter
 
-## Section 1: Adding a Schema Update
-
-Schema updates add or modify constraints that are backed by an official specification. These produce `ValidatorOwnership.SCHEMA` violations (hard errors that fail the build).
-
-### Where Schema Files Live
-
-Versioned schema files are stored in:
-
-```
-packages/skilllint/schemas/<provider>/vN.json
-```
-
-For example, `packages/skilllint/schemas/claude_code/v1.json` defines the Claude Code platform schema.
-
-### Schema Structure
-
-Each schema file has a top-level structure:
-
-```json
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "skilllint/schemas/claude_code/v1.json",
-  "title": "Claude Code Platform Schema v1",
-  "version": "1.0.0",
-  "platform": "claude_code",
-  "provenance": {
-    "authority_url": "https://docs.anthropic.com/claude-code",
-    "last_verified": "2026-03-14",
-    "provider_id": "claude_code"
-  },
-  "file_types": {
-    "skill": { "fields": { ... } },
-    "agent": { "fields": { ... } },
-    "command": { "fields": { ... } },
-    "plugin": { "fields": { ... } }
-  }
-}
-```
-
-### Adding a New Field Constraint
-
-To add a new field or constraint:
-
-1. **Locate the target `file_types` section** (e.g., `skill`, `agent`, `command`, `plugin`).
-
-2. **Add or modify the field** with required metadata:
-
-```json
-"fields": {
-  "new_field": {
-    "required": false,
-    "constraint_scope": "shared",
-    "x-audited": {
-      "date": "2026-03-15",
-      "source": "docs/new-provider/spec.md"
-    }
-  }
-}
-```
-
-3. **Set `constraint_scope` appropriately**:
-   - `"shared"` — Applies to all platforms
-   - `"provider_specific"` — Only applies when this provider's adapter is active
-
-### Schema Validators Produce Hard Errors
-
-The ownership mapping is defined in `packages/skilllint/plugin_validator.py`:
+Implement the five-method structural interface in
+`packages/skilllint/adapters/protocol.py`:
 
 ```python
-VALIDATOR_OWNERSHIP: dict[str, ValidatorOwnership] = {
-    # Schema-backed validators (hard failures)
-    "FrontmatterValidator": ValidatorOwnership.SCHEMA,
-    "PluginStructureValidator": ValidatorOwnership.SCHEMA,
-    "PluginRegistrationValidator": ValidatorOwnership.SCHEMA,
-    "HookValidator": ValidatorOwnership.SCHEMA,
-    "SymlinkTargetValidator": ValidatorOwnership.SCHEMA,
-    # Lint validators (warnings/findings)
-    "NameFormatValidator": ValidatorOwnership.LINT,
-    "DescriptionValidator": ValidatorOwnership.LINT,
-    # ...
-}
-```
+from pathlib import Path
 
-### Testing Schema Changes
 
-Run the frontmatter-related tests:
-
-```bash
-uv run pytest packages/skilllint/tests/ -k frontmatter -v
-```
-
----
-
-## Section 2: Adding a Provider Overlay (New Adapter)
-
-Provider adapters encapsulate platform-specific behavior: file patterns, constraint scopes, and validation logic.
-
-### The PlatformAdapter Protocol
-
-All adapters must satisfy the `PlatformAdapter` protocol defined in `packages/skilllint/adapters/protocol.py`:
-
-```python
-@runtime_checkable
-class PlatformAdapter(Protocol):
+class ExampleAdapter:
     def id(self) -> str:
-        """Return the unique platform identifier (e.g. 'claude_code', 'cursor')."""
-        ...
+        return "example"
 
     def path_patterns(self) -> list[str]:
-        """Return glob patterns matching files this adapter handles."""
-        ...
+        return ["*.json"]
 
     def applicable_rules(self) -> set[str]:
-        """Return the set of rule-series codes this adapter applies (e.g. {'AS', 'CC'})."""
-        ...
+        return {"EX"}
 
     def constraint_scopes(self) -> set[str]:
-        """Return constraint_scope values from the provider schema."""
-        ...
-
-    def validate(self, path: pathlib.Path) -> list[dict]:
-        """Validate the given file path and return violation dicts."""
-        ...
-```
-
-### Creating a New Adapter
-
-1. **Create the adapter directory**:
-
-```bash
-mkdir -p packages/skilllint/adapters/<new_provider>/
-```
-
-2. **Implement the adapter class** (see `packages/skilllint/adapters/claude_code/adapter.py` as a template):
-
-```python
-# packages/skilllint/adapters/new_provider/adapter.py
-from pathlib import Path, PurePath
-
-
-class NewProviderAdapter:
-    def id(self) -> str:
-        return "new_provider"
-
-    def path_patterns(self) -> list[str]:
-        return ["**/.new_provider/**/*.md", "**/new-provider.yaml"]
-
-    def applicable_rules(self) -> set[str]:
-        return {"AS"}  # AS-series rules apply
-
-    def constraint_scopes(self) -> set[str]:
-        # Load from schema or return static set
-        return {"shared", "provider_specific"}
+        return {"shared"}
 
     def validate(self, path: Path) -> list[dict]:
-        # Platform-specific validation logic
-        return []
+        return (
+            [{"code": "EX001", "severity": "error", "message": "example failure"}] if path.name == "fail.json" else []
+        )
 ```
 
-3. **Register via entry points** in `pyproject.toml`:
+Register the class in the package that owns it:
 
 ```toml
 [project.entry-points."skilllint.adapters"]
-claude_code = "skilllint.adapters.claude_code:ClaudeCodeAdapter"
-new_provider = "skilllint.adapters.new_provider:NewProviderAdapter"
+example = "example_skilllint.adapter:ExampleAdapter"
 ```
 
-### How Adapter Discovery Works
+`load_adapters()` discovers and instantiates these entry points. A tiny sample
+distribution is retained in the architecture example test so installation,
+loading, and one passing/failing CLI result remain executable. Keep third-party
+validation output to dictionaries with `code`, `severity`, and `message`; the
+core converts them to `ValidationIssue` objects. The core still owns severity
+semantics, fixing, revalidation, and reporting.
 
-The `load_adapters()` function in `packages/skilllint/adapters/registry.py` discovers adapters:
+## Add a rule
 
-```python
-def load_adapters() -> list[PlatformAdapter]:
-    eps = importlib.metadata.entry_points(group="skilllint.adapters")
-    adapters: list[PlatformAdapter] = []
-    for ep in eps:
-        adapter_cls = ep.load()
-        adapters.append(adapter_cls())
-    return adapters
-```
+Use `@skilllint_rule` with an explicit code, category, platform, severity, and
+authority when an external source supports the claim. The decorator registers
+metadata for `skilllint rules` and `skilllint rule CODE`; the check function is
+the emitter. Keep registration, emission, severity, validator ownership, and
+provenance as separate facts.
 
-Third-party packages can register their own adapters by adding an entry point in their `pyproject.toml` — no modification to skilllint core required.
+Current registration rules include PR001, PR002, and PR005. PR001 is a warning
+for replacing unregistered agents/commands, not for additive skills. PR002 is
+skilllint's error for a registered component whose accepted file/directory/root
+target is absent. PR005 is a valid configuration with an optional informational
+recommendation when a command path is a skill directory. PR003, PR004, and
+SK009 are retired and must not be restored to help, catalog, or examples.
 
-### Structure-Based Discovery for Provider Directories
+## Schema and provenance
 
-When a provider directory lacks a `plugin.json` manifest, skilllint uses structure-based discovery. The `ScanDiscoveryMode` enum in `packages/skilllint/scan_runtime.py` defines three modes:
+Version schema changes under `packages/skilllint/schemas/<provider>/vN.json`.
+Preserve `constraint_scope`: `shared` means the core can apply it across
+providers; `provider_specific` requires the matching adapter. The old
+`docs/registry-schema-examples.md` remains a companion reference and is not
+deleted or treated as a second catalog.
 
-```python
-class ScanDiscoveryMode(StrEnum):
-    MANIFEST = "manifest"  # plugin.json explicitly enumerates components
-    AUTO = "auto"  # plugin.json exists but omits component arrays
-    STRUCTURE = "structure"  # provider directories without manifest
-```
+A provenance claim must identify its rule, authority file/URL and heading (when
+applicable), extraction shape, assertion locator, expected value, and audit
+date. The current locator test proves the supported Python-constant locators;
+schema JSON field/enum locators have separate schema validation coverage and
+must not be inferred from that test alone. The current refresher has two claims:
+the source changed, and the extracted claim matches the maintained value. #146
+is the schema-locator and refresh-outcome boundary. Future LLM or generalized
+provenance stages are proposed design, not shipped behavior.
 
-To add a new provider directory name for structure-based discovery, update `PROVIDER_DIR_NAMES` in `scan_runtime.py`:
+## Verification checklist
 
-```python
-PROVIDER_DIR_NAMES: frozenset[str] = frozenset({
-    ".claude",
-    ".agent",
-    ".agents",
-    ".gemini",
-    ".cursor",
-    ".new_provider",  # Add your provider here
-})
-```
+1. Add a source-coupled test for every documented symbol, heading, and code
+   block. Missing source or heading must fail.
+2. Install/load any retained adapter sample and run both its passing and
+   failing public CLI probes with `PYTHONPATH` cleared.
+3. Run `skilllint rules` and `skilllint rule CODE`; use Todo 15 emitter evidence
+   for the eight retained stub-backed claims and Todo 14 public-route evidence
+   for PR001, PR002, and PR005.
+4. Run `uv run prek run --all-files` and `uv run pytest`.
 
----
+## Typing boundary
 
-## Section 3: Adding a New Lint Rule
-
-Lint rules enforce cross-platform quality standards. They produce `ValidatorOwnership.LINT` violations (warnings that don't fail the build, unless configured otherwise).
-
-### Rule File Location
-
-All lint rules live in `packages/skilllint/rules/`. The file `packages/skilllint/rules/as_series.py` serves as the canonical template.
-
-### Using the @skilllint_rule Decorator
-
-The `@skilllint_rule` decorator registers a function in the global rule registry. From `packages/skilllint/rule_registry.py`:
-
-```python
-@skilllint_rule(
-    "FM010",
-    severity="error",
-    category="frontmatter",
-    platforms=["agentskills"],
-    # No `reference`: FM010 serves skills, agents and commands, whose frontmatter
-    # is defined by different vendor pages, so no single URL is correct for every
-    # finding. See the note below on rule-level versus claim-level authority.
-    authority={"origin": "anthropic.com"},
-)
-def check_fm010(frontmatter: dict, path: Path, file_type: str) -> list[ValidationIssue]:
-    """## FM010 — Name field does not match directory name or violates naming pattern"""
-    # Validation logic...
-```
-
-### Adding to the Ownership Registry
-
-After creating a new lint validator, register it in `packages/skilllint/plugin_validator.py`:
-
-```python
-VALIDATOR_OWNERSHIP: dict[str, ValidatorOwnership] = {
-    # ... existing entries ...
-    "MyNewValidator": ValidatorOwnership.LINT
-}
-```
-
-### Adding to the Constraint Scopes Registry
-
-Also register applicable constraint scopes:
-
-```python
-VALIDATOR_CONSTRAINT_SCOPES: dict[str, set[str]] = {
-    # ... existing entries ...
-    "MyNewValidator": {"shared", "provider_specific"}
-}
-```
-
-### Choosing Severity
-
-Reference the S04 severity classification:
-
-| Severity | When to Use | Exit Code Impact |
-|----------|-------------|-------------------|
-| `error` | Genuine schema violations, correctness issues | Exit 1 |
-| `warning` | Style preferences, best practices, runtime-accepted patterns | Exit 0 |
-| `info` | Recommendations, optional improvements | Exit 0 |
-
-### Testing Lint Rules
-
-Run tests filtered by rule code:
-
-```bash
-uv run pytest packages/skilllint/tests/ -k <rule_code> -v
-```
-
----
-
-## Section 4: Adding Provenance Metadata
-
-Provenance metadata (`authority` dicts) enables traceability from any violation back to its authoritative source. See "Why It Matters" below for what this satisfies.
-
-### Authority Dict Structure
-
-The `authority` dict has a standard shape:
-
-```python
-authority = {
-    "origin": "agentskills.io",  # Required: the authoritative source
-    "reference": "/specification#skill-naming",  # Optional: path/anchor within source
-}
-```
-
-### In Schema Files
-
-Add a top-level `provenance` key (see Section 1's schema structure) or a per-field `x-audited` block, as shown here for the `name` field:
-
-```json
-{
-  "file_types": {
-    "skill": {
-      "fields": {
-        "name": {
-          "required": true,
-          "constraint_scope": "shared",
-          "x-audited": {
-            "date": "2026-03-10",
-            "source": ".claude/vendor/claude_code/plugins/plugin-dev/skills/plugin-structure/SKILL.md"
-          }
-        }
-      }
-    }
-  }
-}
-```
-
-### In Rule Definitions
-
-Pass the `authority` kwarg to `@skilllint_rule`, as shown in the FM010 example in Section 3.
-
-The `authority` kwarg is **rule-level**, and the runtime lookup keys on the rule
-code, so every finding a rule emits inherits the same origin and reference. That
-is coarser than reality in two ways.
-
-First, a rule that serves several file types cannot name one correct page. FM010
-validates skills, agents and commands; `skills.md` and `sub-agents.md` define
-their frontmatter separately. Naming either one would attach it to findings on
-the other, so FM010 and FM001 declare `origin` alone and cite their per-context
-sources in the rule docstring that `skilllint rule <CODE>` renders.
-
-Second, a rule can carry a mix of sourced and unsourced claims.
-
-FM010 is exactly such a rule. Its 64-character limit is schema-backed and is
-registered as the claim `FM010.max_name_length` in
-`packages/skilllint/schemas/provenance-registry.json`. Its regex and
-consecutive-hyphen checks have no schema source and are recorded as the opinion
-`FM010.name_pattern` in `packages/skilllint/schemas/opinion-catalog.json`.
-
-Do not read a rule-level `authority` as a claim-level one. When you add a rule
-whose claims differ in provenance, split them across those two catalogs and cite
-the claim key, not the rule code, in anything that reports provenance.
-
-The decorator converts this to a `RuleAuthority` dataclass (defined in `packages/skilllint/rule_registry.py`):
-
-```python
-@dataclass
-class RuleAuthority:
-    origin: str  # e.g., "agent-skills.io", "anthropic.com"
-    reference: str | None = None  # URL or doc path
-```
-
-### Client Load Behavior
-
-`RuleEntry.client_load_behavior` is a separate, optional field recording what a
-real Claude Code / agent-skill client actually *does* at load time for a
-rule's finding — `"warn-and-load"` (the client logs a warning and loads the
-skill anyway) or `"skip-skill"` (the client refuses to load the skill). It is
-distinct from `authority`: `authority` says where a constraint comes from,
-`client_load_behavior` says what happens when a client encounters a
-violation of it.
-
-Set it only when the client-implementation guide
-(`https://agentskills.io/client-implementation/adding-skills-support#lenient-validation`)
-is explicit about client behavior for that exact check. Pass it as a keyword
-argument to `@skilllint_rule`, the same way as `authority`:
-
-```python
-@skilllint_rule(
-    "FM010",
-    severity="error",
-    category="frontmatter",
-    client_load_behavior="warn-and-load",
-)
-```
-
-It defaults to `None` — "the guide does not say" — matching how `authority`
-defaults to `None` for "no external reference." There is no third literal
-member for "unknown"; `None` already covers it. Most rules will leave this
-unset: only classify a rule when the guide states the client's behavior for
-the specific branch the rule checks, and note any branch-granularity gap
-(a rule checking more than the guide classifies) in the rule's docstring.
-
-### In Violation Dicts
-
-Rules can include authority directly in violation outputs:
-
-```python
-def _make_violation(code: str, severity: str, message: str, fix: str | None = None) -> dict:
-    return {
-        "code": code,
-        "severity": severity,
-        "message": message,
-        "authority": _get_rule_authority(code),  # Looked up from registry
-    }
-```
-
-### Why It Matters
-
-Provenance metadata enables:
-
-1. **Auditability:** Every violation can be traced to its source specification
-2. **Freshness detection:** `last_verified` dates indicate when schema constraints were last checked against the upstream spec
-3. **Debugging:** Users can click through to the authoritative documentation
-4. **Compliance:** Satisfies D002 (traceability to specs) and D005 (machine-readable provenance)
-
----
-
-## Quick Reference
-
-| What | Where | Key Pattern |
-|------|------|--------------|
-| Schema JSON | `packages/skilllint/schemas/<provider>/vN.json` | `file_types.<type>.fields.<field>` |
-| Adapter Protocol | `packages/skilllint/adapters/protocol.py` | `PlatformAdapter` Protocol |
-| Adapter Registry | `packages/skilllint/adapters/registry.py` | `load_adapters()` via entry_points |
-| Rule Registry | `packages/skilllint/rule_registry.py` | `@skilllint_rule` decorator |
-| Ownership Mapping | `packages/skilllint/plugin_validator.py` | `VALIDATOR_OWNERSHIP` dict |
-| Constraint Scopes | `packages/skilllint/plugin_validator.py` | `VALIDATOR_CONSTRAINT_SCOPES` dict |
-| Discovery Modes | `packages/skilllint/scan_runtime.py` | `ScanDiscoveryMode` enum |
-| Provider Directories | `packages/skilllint/scan_runtime.py` | `PROVIDER_DIR_NAMES` frozenset |
+Python 3.11 is the supported baseline. The repository's single enforced type
+checker is `ty`; its scope is `packages/` (`uv run ty check packages/`). The
+repository gates are broader: `uv run prek run --all-files` also runs formatting,
+lint, shell, Markdown, and workflow checks, while `uv run pytest` runs tests.
+Keep untrusted adapter/file payloads at explicit boundary modules and validate
+them before passing concrete values inward; see [TYPING_POLICY.md](TYPING_POLICY.md).

--- a/docs/maintainer-extension-guide.md
+++ b/docs/maintainer-extension-guide.md
@@ -96,9 +96,13 @@ provenance stages are proposed design, not shipped behavior.
    block. Missing source or heading must fail.
 2. Install/load any retained adapter sample and run both its passing and
    failing public CLI probes with `PYTHONPATH` cleared.
-3. Run `skilllint rules` and `skilllint rule CODE`; use Todo 15 emitter evidence
-   for the eight retained stub-backed claims and Todo 14 public-route evidence
-   for PR001, PR002, and PR005.
+3. Run `uv run skilllint rules` and `uv run skilllint rule CODE`. The eight
+   retained stub-backed emitter claims are exercised by
+   `packages/skilllint/tests/test_public_rule_emitters.py` (run it with
+   `uv run pytest packages/skilllint/tests/test_public_rule_emitters.py`), and
+   the PR001/PR002/PR005 public-route cases are in
+   `packages/skilllint/tests/test_plugin_registration_validator.py` (run it
+   with `uv run pytest packages/skilllint/tests/test_plugin_registration_validator.py`).
 4. Run `uv run prek run --all-files` and `uv run pytest`.
 
 ## Typing boundary

--- a/packages/skilllint/tests/test_architecture_examples.py
+++ b/packages/skilllint/tests/test_architecture_examples.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from skilllint.adapters import PlatformAdapter, load_adapters
+from skilllint.plugin_validator import app, validate_single_path
+from skilllint.rule_registry import get_rule, list_rules
+
+ROOT = Path(__file__).parents[3]
+
+
+def _read(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def test_architecture_names_current_runtime_seams() -> None:
+    text = _read("docs/architecture.md")
+    for symbol in (
+        "plugin_validator.main",
+        "_resolve_filter_and_expand_paths",
+        "_discover_validatable_paths",
+        "_discover_plugin_paths",
+        "detect_scan_context",
+        "run_validation_loop",
+        "validate_single_path",
+        "PlatformAdapter",
+        "load_adapters",
+        "skilllint rules",
+        "skilllint rule CODE",
+    ):
+        assert symbol in text
+
+
+def test_maintainer_example_is_complete_and_protocol_compatible() -> None:
+    text = _read("docs/maintainer-extension-guide.md")
+    assert '[project.entry-points."skilllint.adapters"]' in text
+    assert all(
+        f"def {name}(" in text for name in ("id", "path_patterns", "applicable_rules", "constraint_scopes", "validate")
+    )
+    sample = re.search(r"```python\n(?P<sample>.*?class ExampleAdapter:.*?)(?:```)", text, re.DOTALL)
+    assert sample is not None
+    assert all(
+        name in sample.group("sample")
+        for name in ("id", "path_patterns", "applicable_rules", "constraint_scopes", "validate")
+    )
+    assert isinstance(load_adapters()[0], PlatformAdapter)
+    assert callable(validate_single_path)
+
+
+def test_retained_adapter_sample_installs_loads_and_emits(monkeypatch, cli_runner, tmp_path: Path) -> None:
+    package = tmp_path / "example_skilllint"
+    package.mkdir()
+    (package / "__init__.py").write_text("from .adapter import ExampleAdapter\n", encoding="utf-8")
+    sample = re.search(
+        r"```python\n(?P<sample>.*?class ExampleAdapter:.*?)(?:```)",
+        _read("docs/maintainer-extension-guide.md"),
+        re.DOTALL,
+    )
+    assert sample is not None
+    (package / "adapter.py").write_text(sample.group("sample"), encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\nname = 'example-skilllint-adapter'\nversion = '0.0.1'\n"
+        "requires-python = '>=3.11'\n[project.entry-points.'skilllint.adapters']\n"
+        "example = 'example_skilllint.adapter:ExampleAdapter'\n[build-system]\n"
+        "requires = ['hatchling']\nbuild-backend = 'hatchling.build'\n"
+        "[tool.hatch.build.targets.wheel]\npackages = ['example_skilllint']\n",
+        encoding="utf-8",
+    )
+    dist = tmp_path / "dist"
+    subprocess.run(
+        ["uv", "build", "--wheel", "--out-dir", str(dist)], check=True, capture_output=True, text=True, cwd=tmp_path
+    )
+    target = tmp_path / "target"
+    wheel = next(dist.glob("*.whl"))
+    subprocess.run(
+        ["uv", "pip", "install", "--target", str(target), str(wheel)], check=True, capture_output=True, text=True
+    )
+    probe = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from importlib.metadata import distributions; print(next(ep for d in distributions() for ep in d.entry_points if ep.group == 'skilllint.adapters' and ep.name == 'example').load()().id())",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={"PATH": ":".join((str(Path(sys.executable).parent), "/usr/bin")), "PYTHONPATH": str(target)},
+    )
+    assert probe.stdout.strip() == "example"
+    from importlib.metadata import distributions
+
+    import skilllint.plugin_validator as validator
+
+    monkeypatch.syspath_prepend(str(target))
+    adapter_entry_point = next(
+        ep
+        for distribution in distributions(path=[str(target)])
+        for ep in distribution.entry_points
+        if ep.group == "skilllint.adapters" and ep.name == "example"
+    )
+    assert adapter_entry_point.value == "example_skilllint.adapter:ExampleAdapter"
+    adapter_cls = adapter_entry_point.load()
+    monkeypatch.setitem(validator.ADAPTERS, "example", adapter_cls())
+
+    passing = tmp_path / "pass.json"
+    failing = tmp_path / "fail.json"
+    passing.write_text("{}", encoding="utf-8")
+    failing.write_text("{}", encoding="utf-8")
+    assert cli_runner.invoke(app, ["check", str(passing), "--platform", "example"]).exit_code == 0
+    assert cli_runner.invoke(app, ["check", str(failing), "--platform", "example"]).exit_code == 1
+
+
+def test_active_catalog_keeps_retired_rules_out_and_public_registration_rules_in() -> None:
+    active = {entry.id for entry in list_rules()}
+    assert {"PR001", "PR002", "PR005"} <= active
+    assert not {"PR003", "PR004", "SK009"} & active
+    assert get_rule("PR001") is not None
+    assert get_rule("PR002") is not None
+    assert get_rule("PR005") is not None
+
+
+def test_design_documents_label_proposed_boundaries() -> None:
+    for path in ("docs/design-rule-provenance-registry.md", "docs/design-markdown-link-conventions.md"):
+        assert "Status: proposed design" in _read(path)
+
+
+def test_typing_policy_states_baseline_and_gate_scope() -> None:
+    text = _read("docs/TYPING_POLICY.md")
+    assert "Python 3.11" in text
+    assert "ty check" in text
+    assert "packages/" in text
+    assert "pytest" in text


### PR DESCRIPTION
## Summary
- add current architecture and extension-flow guide
- align maintainer adapter, rule, provenance, and typing guidance
- add source-coupled executable adapter and CLI contracts

Todo 21 / SL-DOC. No issue-linked closure.

## Verification
- `uv run prek run --all-files`
- `uv run pytest`
- focused architecture tests (7 passed)